### PR TITLE
chore: add script to automatically push a new release into production

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+.DS_Store
+*.log
+*.tmp
+*.temp
+.history
+.vscode
+.idea
+.env

--- a/release.sh
+++ b/release.sh
@@ -3,51 +3,60 @@
 set -e
 set -o pipefail
 
+# Variables globales
 CURRENT_DIR=$(pwd)
 MERGE_COMMIT_MESSAGE="MEP $(date +'%d.%m.%Y') : Merge branch 'main' into release"
 GIT_BACK_END_URL=git@github.com:gip-inclusion/dora-back.git
 GIT_FRONT_END_URL=git@github.com:gip-inclusion/dora-front.git
 
+# Fonction pour gérer le processus de déploiement
+deploy_repo() {
+  local repo_url=$1
+  local repo_name=$2
+  
+  echo "Clonage du dépôt $repo_name..."
+  git clone "$repo_url"
+
+  cd "$repo_name"
+
+  echo "Récupération des branches distantes pour $repo_name..."
+  git fetch --all
+
+  echo "Changement de branche vers release..."
+  git switch release
+
+  # Vérifier s'il y a des commits d'écart entre 'main' et 'release'
+  COMMITS_DIFF=$(git rev-list --count release..main)
+
+  if [ "$COMMITS_DIFF" -gt 0 ]; then
+    echo "Il y a $COMMITS_DIFF commit(s) d'écart entre 'main' et 'release' pour $repo_name. Lancement du merge..."
+    
+    echo "Merge de la branche main dans release pour $repo_name..."
+    if ! git merge --no-ff main -m "$MERGE_COMMIT_MESSAGE"; then
+      echo "Conflit lors du merge de la branche main dans release pour $repo_name. Veuillez résoudre manuellement."
+      exit 1
+    fi
+
+    echo "Poussée des changements vers le dépôt distant pour $repo_name..."
+    git push
+  else
+    echo "Pas de commits à merger entre 'main' et 'release' pour $repo_name. Aucun merge effectué."
+  fi
+
+  # Revenir au répertoire temporaire
+  cd ..
+}
+
+# Création d'un répertoire temporaire
 TEMP_DIR=$(mktemp -d)
 echo "Création d'un répertoire temporaire pour le travail : $TEMP_DIR"
 cd "$TEMP_DIR"
 
-echo "Clonage du dépôt dora-back..."
-git clone $GIT_BACK_END_URL
+# Déploiement des dépôts
+deploy_repo "$GIT_BACK_END_URL" "dora-back"
+deploy_repo "$GIT_FRONT_END_URL" "dora-front"
 
-cd dora-back
-
-echo "Récupération des branches distantes pour dora-back..."
-git fetch --all
-
-echo "Changement de branche vers release..."
-git switch release
-
-echo "Merge de la branche main dans release pour dora-back..."
-git merge --no-ff main -m "$MERGE_COMMIT_MESSAGE"
-
-echo "Poussée des changements vers le dépôt distant pour dora-back..."
-git push
-
-cd ..
-
-echo "Clonage du dépôt dora-front..."
-git clone $GIT_FRONT_END_URL
-
-cd dora-front
-
-echo "Récupération des branches distantes pour dora-front..."
-git fetch --all
-
-echo "Changement de branche vers release..."
-git switch release
-
-echo "Merge de la branche main dans release pour dora-front..."
-git merge --no-ff main -m "$MERGE_COMMIT_MESSAGE"
-
-echo "Poussée des changements vers le dépôt distant pour dora-front..."
-git push
-
+# Nettoyage
 echo "Nettoyage : retour au répertoire initial et suppression du répertoire temporaire."
 cd "$CURRENT_DIR"
 rm -rf "$TEMP_DIR"

--- a/release.sh
+++ b/release.sh
@@ -10,7 +10,7 @@ GIT_FRONT_END_URL=git@github.com:gip-inclusion/dora-front.git
 
 TEMP_DIR=$(mktemp -d)
 echo "Création d'un répertoire temporaire pour le travail : $TEMP_DIR"
-cd $TEMP_DIR
+cd "$TEMP_DIR"
 
 echo "Clonage du dépôt dora-back..."
 git clone $GIT_BACK_END_URL
@@ -49,5 +49,5 @@ echo "Poussée des changements vers le dépôt distant pour dora-front..."
 git push
 
 echo "Nettoyage : retour au répertoire initial et suppression du répertoire temporaire."
-cd $CURRENT_DIR
-rm -rf $TEMP_DIR
+cd "$CURRENT_DIR"
+rm -rf "$TEMP_DIR"

--- a/release.sh
+++ b/release.sh
@@ -21,7 +21,16 @@ NC='\033[0m' # No Color (reset)
 if [ "$#" -ne 1 ]; then
   echo ""
   echo -e "${RED}❌ Argument manquant${NC}"
-  echo "Usage: $0 {back|front|all}"
+  echo "Usage: $0 {back|front}"
+  echo ""
+  exit 1
+fi
+
+# Vérifier que l'argument vaut "back" ou "front"
+if [ "$1" != "back" ] && [ "$1" != "front" ]; then
+  echo ""
+  echo -e "${RED}❌ Argument invalide : $1${NC}"
+  echo "Usage: $0 {back|front}"
   echo ""
   exit 1
 fi
@@ -88,13 +97,9 @@ case "$1" in
   front)
     deploy_repo "$GIT_FRONT_END_URL" "dora-front"
     ;;
-  all)
-    deploy_repo "$GIT_BACK_END_URL" "dora-back"
-    deploy_repo "$GIT_FRONT_END_URL" "dora-front"
-    ;;
   *)
     echo "Argument invalide : $1"
-    echo "Usage: $0 {back|front|both}"
+    echo "Usage: $0 {back|front}"
     exit 1
     ;;
 esac

--- a/release.sh
+++ b/release.sh
@@ -9,11 +9,30 @@ MERGE_COMMIT_MESSAGE="MEP $(date +'%d.%m.%Y') : Merge branch 'main' into release
 GIT_BACK_END_URL=git@github.com:gip-inclusion/dora-back.git
 GIT_FRONT_END_URL=git@github.com:gip-inclusion/dora-front.git
 
+# Couleurs ANSI
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[0;33m'
+BLUE='\033[0;34m'
+CYAN='\033[0;36m'
+NC='\033[0m' # No Color (reset)
+
+# Vérifier qu'un argument est passé
+if [ "$#" -ne 1 ]; then
+  echo ""
+  echo -e "${RED}❌ Argument manquant${NC}"
+  echo "Usage: $0 {back|front|all}"
+  echo ""
+  exit 1
+fi
+
 # Fonction pour gérer le processus de déploiement
 deploy_repo() {
   local repo_url=$1
   local repo_name=$2
   
+  echo -e "${CYAN}📦 Déploiement de l'application ${repo_name}${NC}"
+
   echo "Clonage du dépôt $repo_name..."
   git clone "$repo_url"
 
@@ -33,30 +52,59 @@ deploy_repo() {
     
     echo "Merge de la branche main dans release pour $repo_name..."
     if ! git merge --no-ff main -m "$MERGE_COMMIT_MESSAGE"; then
-      echo "Conflit lors du merge de la branche main dans release pour $repo_name. Veuillez résoudre manuellement."
+      echo "⚠️ Conflit lors du merge de la branche main dans release pour $repo_name. Veuillez résoudre manuellement."
       exit 1
     fi
 
     echo "Poussée des changements vers le dépôt distant pour $repo_name..."
     git push
+
+    echo "✅ La branche 'release' du repository $repo_name a été mise à jour"
   else
-    echo "Pas de commits à merger entre 'main' et 'release' pour $repo_name. Aucun merge effectué."
+    echo "🙅 Pas de commits à merger entre 'main' et 'release' pour $repo_name. Aucun merge effectué."
   fi
 
   # Revenir au répertoire temporaire
   cd ..
+  echo ""
 }
+
+# Début
+echo ""
+echo -e "${YELLOW}🚀 Démarrage de la procédure de livraison${NC}"
+echo ""
 
 # Création d'un répertoire temporaire
 TEMP_DIR=$(mktemp -d)
-echo "Création d'un répertoire temporaire pour le travail : $TEMP_DIR"
+echo "✨ Création d'un répertoire temporaire pour le travail : $TEMP_DIR"
 cd "$TEMP_DIR"
+echo ""
 
-# Déploiement des dépôts
-deploy_repo "$GIT_BACK_END_URL" "dora-back"
-deploy_repo "$GIT_FRONT_END_URL" "dora-front"
+# Gestion des arguments
+case "$1" in
+  back)
+    deploy_repo "$GIT_BACK_END_URL" "dora-back"
+    ;;
+  front)
+    deploy_repo "$GIT_FRONT_END_URL" "dora-front"
+    ;;
+  all)
+    deploy_repo "$GIT_BACK_END_URL" "dora-back"
+    deploy_repo "$GIT_FRONT_END_URL" "dora-front"
+    ;;
+  *)
+    echo "Argument invalide : $1"
+    echo "Usage: $0 {back|front|both}"
+    exit 1
+    ;;
+esac
 
 # Nettoyage
-echo "Nettoyage : retour au répertoire initial et suppression du répertoire temporaire."
+echo "🧹 Nettoyage : retour au répertoire initial et suppression du répertoire temporaire."
 cd "$CURRENT_DIR"
 rm -rf "$TEMP_DIR"
+echo ""
+
+# Fin
+echo -e "${GREEN}🎉 Fin de la procédure de livraison${NC}"
+echo ""

--- a/release.sh
+++ b/release.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+
+set -e
+set -o pipefail
+
+CURRENT_DIR=$(pwd)
+MERGE_COMMIT_MESSAGE="MEP $(date +'%d.%m.%Y') : Merge branch 'main' into release"
+GIT_BACK_END_URL=git@github.com:gip-inclusion/dora-back.git
+GIT_FRONT_END_URL=git@github.com:gip-inclusion/dora-front.git
+
+TEMP_DIR=$(mktemp -d)
+echo "Création d'un répertoire temporaire pour le travail : $TEMP_DIR"
+cd $TEMP_DIR
+
+echo "Clonage du dépôt dora-back..."
+git clone $GIT_BACK_END_URL
+
+cd dora-back
+
+echo "Récupération des branches distantes pour dora-back..."
+git fetch --all
+
+echo "Changement de branche vers release..."
+git switch release
+
+echo "Merge de la branche main dans release pour dora-back..."
+git merge --no-ff main -m "$MERGE_COMMIT_MESSAGE"
+
+echo "Poussée des changements vers le dépôt distant pour dora-back..."
+git push
+
+cd ..
+
+echo "Clonage du dépôt dora-front..."
+git clone $GIT_FRONT_END_URL
+
+cd dora-front
+
+echo "Récupération des branches distantes pour dora-front..."
+git fetch --all
+
+echo "Changement de branche vers release..."
+git switch release
+
+echo "Merge de la branche main dans release pour dora-front..."
+git merge --no-ff main -m "$MERGE_COMMIT_MESSAGE"
+
+echo "Poussée des changements vers le dépôt distant pour dora-front..."
+git push
+
+echo "Nettoyage : retour au répertoire initial et suppression du répertoire temporaire."
+cd $CURRENT_DIR
+rm -rf $TEMP_DIR


### PR DESCRIPTION
### 🍣 Problème

La procédure pour déployer une nouvelle version de DORA en production est aujourd'hui effectuée manuellement.

Ça engendre : 
* de la complication
* du temps (celui de se souvenir des manipulations et de tout vérifier)
* des messages de mise en production non homogènes
* des risques d'erreurs de manipulation
* du stress

### 🦄 Solution

Automatiser la procédure de mise en production.

```shell
# Livraison du back-end puis du front-end
./release.sh back && ./release.sh front
```

Subtilité : on réalise le tout dans un répertoire temporaire.

### ℹ️ Nota bene

Ce script est un MVP, le plus basique possible, qui se contente de gérer les "cas autoroute" (normalement, 95% du temps).

Il ne demande qu'à être éprouvé et amélioré.

<img width="1512" alt="Capture d’écran 2024-09-23 à 19 24 17" src="https://github.com/user-attachments/assets/0da061fd-cc33-464d-88c3-191d7f0f8e4f">


