### PR TITLE
Page recherche: sélection par défaut du filtre de lieu d'accueil « En présentiel »

### DIFF
--- a/front/src/routes/recherche/+page.svelte
+++ b/front/src/routes/recherche/+page.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+  import { onMount } from "svelte";
+
   import { page } from "$app/stores";
 
   import Breadcrumb from "$lib/components/display/breadcrumb.svelte";
@@ -40,6 +42,17 @@
     }),
     {} as Filters
   );
+
+  onMount(() => {
+    // Vérifie si aucun filtre n'est sélectionné
+    const noFilterSelected = Object.values(filters).every(
+      (filter) => filter.length === 0
+    );
+    // Si aucun filtre n'est sélectionné, on présélectionne le filtre de lieu d'accueil « En présentiel »
+    if (noFilterSelected) {
+      filters.locationKinds.push("en-presentiel");
+    }
+  });
 
   function resetFilters() {
     filters = { kinds: [], fundedBy: [], feeConditions: [], locationKinds: [] };


### PR DESCRIPTION
ℹ️ PR créée à partir de la PR originale https://github.com/gip-inclusion/dora-front/pull/464 suite à la création du [monorepo](https://github.com/gip-inclusion/dora/pull/8).

**Problème :** les utilisateurs ont tendance à ne pas être intéressé par les services à distance en général

**Solution :** on présélectionne le filtre de lieu d'accueil « En présentiel »

**Effet de bord non voulu :** si un utilisateur désélectionne le filtre de lieu d'accueil « En présentiel » (et qu'aucun autre filtre n'est sélectionné), et recharge la page ou transmet l'URL à une autre personne, le filtre de lieu d'accueil « En présentiel » sera resélectionné.

![image](https://github.com/user-attachments/assets/97c2d228-873a-409d-bb30-e0968713ac21)
