### PR TITLE
bugfix: ne pas afficher l'adresse quand elle n'est pas renseignée

### DIFF
--- a/front/src/routes/recherche/search-result.svelte
+++ b/front/src/routes/recherche/search-result.svelte
@@ -67,7 +67,9 @@
       <div class="flex flex-wrap items-baseline gap-s6">
         {#if onSite}
           <div class="text-f16 text-france-blue">
-            {result.address1}{#if result.address2}, {result.address2}{/if},
+            {#if result.address1}
+              {result.address1}{#if result.address2}, {result.address2}{/if},
+            {/if}
             {result.postalCode}&nbsp;{result.city}
           </div>
           <!-- On n'affiche pas la distance lorsqu'elle n'est pas fournie ou


### PR DESCRIPTION
### 🍣 Contexte / problème 

Si un service ne possède pas d'adresse, on affiche "null".

![bug_screen](https://github.com/user-attachments/assets/4766b454-9edf-4d41-a3b9-5f4c2e8467e8)

> 💡 D'après l'équipe data·inclusion, cela concerne 6% des données provenant de Soliguide.

### 🦄 Solution / action

Côté front, ne pas afficher l'adresse principale si elle n'est pas renseignée (de même qu'on gérait déjà si le champ `address2` n'existe pas).

<img width="780" alt="image" src="https://github.com/user-attachments/assets/b99a0809-4dd2-45d4-a045-3e1040e2f3eb">

La question de cacher tout bonnement les services n'ayant pas des données clean a été posée (@ikarius ).

La piste retenue est de se dire qu'il vaut mieux les afficher, car au pire, il y a les infos de contact.

### 🛠️ Reproduire / tester

Il faut faire une recherche sur Lille pour des services alimentaires : 

```
http://localhost:3000/recherche?cats=equipement-et-alimentation&city=59350&cl=Lille+%2859%29&l=Lille+%2859%29
```
