### PR TITLE
[HOTFIX] _get_di_results(): gère le cas où le champ thematiques est nul

### DIFF
--- a/back/dora/services/search.py
+++ b/back/dora/services/search.py
@@ -184,7 +184,8 @@ def _get_di_results(
     raw_di_results = [
         result
         for result in raw_di_results
-        if not any(
+        if result["service"]["thematiques"] is None
+        or not any(
             thematique in result["service"]["thematiques"]
             for thematique in EXCLUDED_DI_SERVICES_THEMATIQUES
         )


### PR DESCRIPTION
**Problème :** DI fournit 2 services dont le champ `thematiques` a pour valeur `null`. Dans `_get_di_results()`, on considérait que c'était toujours une liste, provoquant ainsi une exception `TypeError` lors d'une recherche faisant ressortir ces services.

**Solution :** prise en compte de la nullité possible du champ `thematiques`.

**Recherches en erreur ainsi réparées :**
- https://dora.inclusion.beta.gouv.fr/recherche?city=59350&cl=Lille%20(59)&l=Lille%20(59)
- https://dora.inclusion.beta.gouv.fr/recherche?city=31555&cl=Toulouse%20(31)&l=Toulouse%20(31)