### PR TITLE
Remplace le contenu de la bannière d'avertissement par le contenu de la variable d'environnement

### DIFF
--- a/front/.env-example
+++ b/front/.env-example
@@ -11,3 +11,5 @@ GITGUARDIAN_API_KEY=
 VITE_PUBLIC_MATOMO_CONTAINER_URL=# ex: "https://<matomo_host>/js/container_<container_id>.js"
 
 VITE_OIDC_AUTH_BACKEND=# proconnect | inclusionconnect
+
+VITE_WARNING_BANNER=

--- a/front/src/lib/env.ts
+++ b/front/src/lib/env.ts
@@ -4,7 +4,6 @@ export const INTERNAL_API_URL = import.meta.env.VITE_INTERNAL_API_URL;
 export const SENTRY_DSN = import.meta.env.VITE_SENTRY_DSN;
 export const CANONICAL_URL = import.meta.env.VITE_PUBLIC_CANONICAL_URL;
 export const METABASE_EMBED_URL = import.meta.env.VITE_METABASE_EMBED_URL;
-export const WARNING_BANNER_ENABLED =
-  import.meta.env.VITE_WARNING_BANNER_ENABLED === "true";
+export const WARNING_BANNER = import.meta.env.VITE_WARNING_BANNER;
 export const OIDC_AUTH_BACKEND =
   import.meta.env.VITE_OIDC_AUTH_BACKEND || "proconnect";

--- a/front/src/routes/_index/header.svelte
+++ b/front/src/routes/_index/header.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { browser } from "$app/environment";
-  import { ENVIRONMENT, WARNING_BANNER_ENABLED } from "$lib/env";
+  import { ENVIRONMENT, WARNING_BANNER } from "$lib/env";
   import LogoDORA from "$lib/assets/logos/logo-dora.svg";
   import LogoRepublique from "$lib/assets/logos/logo-rf.svg";
   import CenteredGrid from "$lib/components/display/centered-grid.svelte";
@@ -49,10 +49,9 @@
     <SubMenu />
   </CenteredGrid>
 
-  {#if WARNING_BANNER_ENABLED}
+  {#if WARNING_BANNER}
     <div class="bg-service-orange p-s8 text-center font-bold">
-      Nous sommes actuellement en cours de migration vers ProConnect. Pendant ce
-      temps, la création de compte n’est pas disponible.
+      {WARNING_BANNER}
     </div>
   {/if}
 </header>


### PR DESCRIPTION
Si la variable d'environnement `VITE_WARNING_BANNER` existe et que son contenu n'est pas vide, alors ce contenu est affiché sous forme de bannière d'avertissement.

![image](https://github.com/user-attachments/assets/56dd8ff3-b980-4f1d-bb45-b0274411ccec)
![image](https://github.com/user-attachments/assets/28df681b-687e-4b15-a726-2b5987da47fa)
