### PR TITLE
chore(release): amélioration du script de livraison

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -5,8 +5,8 @@ set -o pipefail
 
 # Variables globales
 CURRENT_DIR=$(pwd)
-MERGE_COMMIT_MESSAGE="MEP $(date +'%d.%m.%Y') : Merge branch 'main' into release"
-DORA_REPOSITORY=git@github.com:gip-inclusion/dora.git
+DORA_REPOSITORY_URL=git@github.com:gip-inclusion/dora.git
+DORA_REPOSITORY_NAME=dora
 
 # Couleurs ANSI
 RED='\033[0;31m'
@@ -16,65 +16,183 @@ BLUE='\033[0;34m'
 CYAN='\033[0;36m'
 NC='\033[0m' # No Color (reset)
 
-# Fonction pour gérer le processus de déploiement
-deploy_repo() {
-  local repo_url=$1
-  local repo_name=$2
-  
-  echo -e "${CYAN}📦 Déploiement de l'application ${repo_name}${NC}"
+# ===
+# 1. PREPARE
+# ===
 
-  echo "Clonage du dépôt $repo_name..."
-  git clone "$repo_url"
+echo ""
+echo -e "${YELLOW}🔎 Validations avant lancement de la procédure de livraison${NC}"
+echo ""
 
-  cd "$repo_name"
+# ---
+# Check param(s)
+# ---
 
-  echo "Récupération des branches distantes pour $repo_name..."
-  git fetch --all
+echo -e "Vérification des arguments"
+if [ -z "$1" ]; then
+  echo -e "${RED}⚠️  Vous devez spécifier le type de release (major, minor, patch).${NC}"
+  exit 1
+fi
 
-  echo "Changement de branche vers release..."
-  git switch release
+RELEASE_TYPE=$1
 
-  # Vérifier s'il y a des commits d'écart entre 'main' et 'release'
-  COMMITS_DIFF=$(git rev-list --count release..main)
+echo -e "Vérification du type de livraison (parmi "major", "minor" ou "patch")"
+if [[ "$RELEASE_TYPE" != "major" && "$RELEASE_TYPE" != "minor" && "$RELEASE_TYPE" != "patch" ]]; then
+  echo -e "${RED}⚠️  Type de release invalide : '$RELEASE_TYPE'. Utilisez uniquement 'major', 'minor' ou 'patch'.${NC}"
+  exit 1
+fi
 
-  if [ "$COMMITS_DIFF" -gt 0 ]; then
-    echo "Il y a $COMMITS_DIFF commit(s) d'écart entre 'main' et 'release' pour $repo_name. Lancement du merge..."
-    
-    echo "Merge de la branche main dans release pour $repo_name..."
-    if ! git merge --no-ff main -m "$MERGE_COMMIT_MESSAGE"; then
-      echo "⚠️ Conflit lors du merge de la branche main dans release pour $repo_name. Veuillez résoudre manuellement."
-      exit 1
-    fi
+# ---
+# Check environment variables
+# ---
 
-    echo "Poussée des changements vers le dépôt distant pour $repo_name..."
-    git push
-
-    echo "✅ La branche 'release' du repository $repo_name a été mise à jour"
-  else
-    echo "🙅 Pas de commits à merger entre 'main' et 'release' pour $repo_name. Aucun merge effectué."
+check_env_var() {
+  local var_name=$1
+  if [ -z "${!var_name}" ]; then
+    echo -e "${RED}⚠️  La variable d'environnement $var_name doit être définie.${NC}"
+    exit 1
   fi
-
-  # Revenir au répertoire temporaire
-  cd ..
-  echo ""
 }
 
-# Début
+echo -e "Vérification des variables d'environnement"
+check_env_var "SCALINGO_REGION"
+check_env_var "SCALINGO_BACK_APP"
+check_env_var "SCALINGO_FRONT_APP"
+
+# ---
+# Check Scalingo concerns
+# ---
+
+echo -e "Vérification du CLI Scalingo"
+if ! command -v scalingo &> /dev/null; then
+  echo -e "${RED}⚠️  Le CLI Scalingo n'est pas installé. Veuillez l'installer avant d'exécuter ce script.${NC}"
+  exit 1
+fi
+
+echo -e "Vérification des accès aux applications Scalingo"
+APPS_LIST=$(scalingo apps --region "$SCALINGO_REGION")
+
+check_app_access() {
+  local app_name=$1
+  if echo "$APPS_LIST" | grep -E "^\|[[:space:]]*$app_name[[:space:]]*\|[[:space:]]*collaborator[[:space:]]*\|" &> /dev/null; then
+    echo -e "Accès confirmé pour l'application '$app_name'."
+  else
+    echo -e "${RED}⚠️  Vous n'avez pas accès en tant que collaborateur à l'application '$app_name' dans la région '$SCALINGO_REGION'. Veuillez vérifier vos permissions.${NC}"
+    exit 1
+  fi
+}
+
+check_app_access "$SCALINGO_BACK_APP"
+check_app_access "$SCALINGO_FRONT_APP"
+
+# ---
+# Utils
+# ---
+
+get_next_version() {
+  local version=$1
+  local release_type=$2
+
+  # Supprimer le 'v' au début et séparer en parties (major.minor.patch)
+  version="${version#v}"
+  IFS='.' read -r major minor patch <<< "$version"
+
+  case $release_type in
+    major)
+      major=$((major + 1))
+      minor=0
+      patch=0
+      ;;
+    minor)
+      minor=$((minor + 1))
+      patch=0
+      ;;
+    patch)
+      patch=$((patch + 1))
+      ;;
+    *)
+      echo -e "${RED}⚠️  Type de release non valide. Utilisez major, minor ou patch.${NC}"
+      exit 1
+      ;;
+  esac
+
+  echo "v$major.$minor.$patch"
+}
+
+# ===
+# 2. PERFORM
+# ===
+
 echo ""
-echo -e "${YELLOW}🚀 Démarrage de la procédure de livraison${NC}"
+echo -e "${YELLOW}🚀 Lancement de la procédure de livraison${NC}"
 echo ""
 
-# Création d'un répertoire temporaire
 TEMP_DIR=$(mktemp -d)
 echo "✨ Création d'un répertoire temporaire pour le travail : $TEMP_DIR"
 cd "$TEMP_DIR"
 echo ""
 
 # Déploiement
-deploy_repo "$DORA_REPOSITORY" "dora"
+
+echo -e "🐑 Clonage du dépôt $DORA_REPOSITORY_NAME..."
+echo ""
+git clone "$DORA_REPOSITORY_URL"
+cd "$DORA_REPOSITORY_NAME"
+
+echo ""
+echo -e "🚰 Récupération des tags existants"
+echo ""
+git fetch --all
+
+# Récupérer le dernier tag pour déterminer la version actuelle
+CURRENT_VERSION=$(git describe --tags $(git rev-list --tags --max-count=1))
+if [ -z "$CURRENT_VERSION" ]; then
+  echo -e "${RED}⚠️ Aucun tag de version trouvé. Assurez-vous qu'un tag existe dans le dépôt.${NC}"
+  exit 1
+fi
+
+# Vérifier si le tag de la version actuelle existe déjà sur le dernier commit de main
+MAIN_COMMIT_HASH=$(git rev-parse main)
+TAG_COMMIT_HASH=$(git rev-list -n 1 "$CURRENT_VERSION" 2>/dev/null || echo "")
+
+if [ "$MAIN_COMMIT_HASH" == "$TAG_COMMIT_HASH" ]; then
+  echo -e "${YELLOW}🙅 La version '$CURRENT_VERSION' est déjà déployée pour le dernier commit de main. Aucun nouveau déploiement nécessaire.${NC}"
+else
+  echo -e "💡 Il y a des modifications non déployées dans la branche 'main'. Création d'une nouvelle version..."
+  echo ""
+
+  # Incrémenter la version et définir le nouveau tag
+  NEW_VERSION=$(get_next_version "$CURRENT_VERSION" "$RELEASE_TYPE")
+  echo -e "${CYAN}📌 Création du tag $NEW_VERSION (basée sur le type $RELEASE_TYPE)${NC}"
+  echo ""
+
+  git tag "$NEW_VERSION"
+  git push origin "$NEW_VERSION"
+
+  echo ""
+  echo -e "${CYAN}🚀 Déploiement de l'archive sur Scalingo pour les applications dora-back et dora-front${NC}"
+  echo ""
+  tag_archive_url="https://github.com/gip-inclusion/dora/archive/refs/tags/$NEW_VERSION.tar.gz"
+  
+  # TODO : paralléliser les déploiements
+
+  echo -e "Déploiement de l'application back-end"
+  echo ""
+  scalingo deploy --region "$SCALINGO_REGION" --app "$SCALINGO_BACK_APP" "$tag_archive_url"
+  echo ""
+
+  echo -e "Déploiement de l'application front-end"
+  echo ""
+  scalingo deploy --region "$SCALINGO_REGION" --app "$SCALINGO_FRONT_APP" "$tag_archive_url"
+  echo ""
+fi
+
+# Revenir au répertoire temporaire
+cd ..
+echo ""
 
 # Nettoyage
-echo "🧹 Nettoyage : retour au répertoire initial et suppression du répertoire temporaire."
+echo -e "🧹 Nettoyage : retour au répertoire initial et suppression du répertoire temporaire."
 cd "$CURRENT_DIR"
 rm -rf "$TEMP_DIR"
 echo ""
@@ -82,3 +200,4 @@ echo ""
 # Fin
 echo -e "${GREEN}🎉 Fin de la procédure de livraison${NC}"
 echo ""
+trap - EXIT


### PR DESCRIPTION
### 🍣 Contexte / problème

Grâce au passage au monorepo, il est désormais possible (ou tout du moins raisonnablement aisé) de gérer les versions de l'application via des tags Git.

Aujourd'hui, la création de tags doit être effectuée manuellement, après la bonne exécution du script de `release.sh`. Le risque est de l'oublier (cf. saut de la version 0.3.0 – ProConnect)

Par ailleurs, le déclenchement du déploiement des apps sur Scalingo est laissé à la discrétion et au bon-vouloir des webhooks GitHub.

### 🦄 Solution / réalisation

L'objet de cette PR est d'améliorer la procédure automatisée de mise en production.

Pour ce faire, elle embarque les améliorations suivantes :

* création et gestion automatique d'un tag SemVer…
* … à partir du type de release en paramètre
* déploiement via Scalingo CLI (plutôt que webhook GitHub)
* ajout de vérifications pour sécuriser la livraison

### 🏄‍♂️ Usage

Pré-requis : 
1. avoir installé le CLI Scalingo
2. disposer d'un compte Scalingo ainsi que d'accès aux apps back et front de production
3. définir les variables d'environnement `SCALINGO_REGION`, `SCALINGO_BACK_APP` et `SCALINGO_FRONT_APP`

```shell
export SCALINGO_REGION=osc-secnum-fr1 SCALINGO_BACK_APP=dora-back-end SCALINGO_FRONT_APP=dora-front-end
```

Commande : 

```shell
./release.sh <major | minor | patch>
```

###  Exemples de sorties

Nouvelle version à livrer :

<img width="930" alt="Capture d’écran 2024-10-30 à 00 13 38" src="https://github.com/user-attachments/assets/f1528d85-ce96-41ad-8264-373caf76cc3b">

Pas de nouvelle version à livrer :

<img width="881" alt="Capture d’écran 2024-10-30 à 00 15 27" src="https://github.com/user-attachments/assets/88c11030-ad2e-49ac-9c04-9f6e347abd4f">

Paramètre `release_type` manquant :

<img width="468" alt="Capture d’écran 2024-10-30 à 00 14 13" src="https://github.com/user-attachments/assets/16003640-5bba-41a1-958d-a70161f05724">

Variable d'environnement `SCALINGO_FRONT_APP` non définie : 

<img width="495" alt="Capture d’écran 2024-10-30 à 00 14 43" src="https://github.com/user-attachments/assets/dd0b870b-2e14-478c-9ea0-e1798e511538">

### 🤖 Misc

Les modifications ont été élaborées et testées depuis un fork du projet, sur [jbuget/dora](https://github.com/jbuget/dora). 

Pour reproduire, il faut : 
* forker le projet
* modifier le script release.sh et remplacer la chaine `gip-inclusion` par l'organisation où a été réalisé le fork
* commenter les lignes `scalingo deploy xxx`
* constater la création et la publication du tag

Le script est découpé en 2 grandes étapes :
1. Prepare : pour effectuer toutes les vérifications
2. Perform : pour accomplir la procédure de MEP 