### PR TITLE
Correction d'un test de notification

### DIFF
--- a/back/dora/notifications/tasks/tests/tests_users.py
+++ b/back/dora/notifications/tasks/tests/tests_users.py
@@ -337,9 +337,9 @@ def test_simpler_manager_structure_moderation_task_should_trigger(
         )
         n.save()
 
-    assert not manager_structure_moderation_task.should_trigger(
-        n
-    ), "Il n'y pas de structure à modérer : pas de déclenchement attendu"
+        assert not manager_structure_moderation_task.should_trigger(
+            n
+        ), "Il n'y pas de structure à modérer : pas de déclenchement attendu"
 
     # création d'une structure à modérer
     make_structure(department="37", moderation_status=moderation_status)


### PR DESCRIPTION
À cause d'une erreur d'indentation, le test `test_simpler_manager_structure_moderation_task_should_trigger()` échoue le mercredi.

`should_trigger()` utilise la date du jour, il faut donc qu'il soit appelé dans le contexte `freeze_time("2024-10-14")`.