### PR TITLE
Ajout de 'dora.oidc` en tant qu'app Django

### DIFF
--- a/back/config/settings/base.py
+++ b/back/config/settings/base.py
@@ -53,6 +53,7 @@ INSTALLED_APPS = [
     "dora.stats",
     "dora.notifications",
     "dora.logs",
+    "dora.oidc",
     "dora.auth_links",
 ]
 

--- a/back/dora/oidc/backends.py
+++ b/back/dora/oidc/backends.py
@@ -1,0 +1,122 @@
+from logging import getLogger
+
+import requests
+from django.core.exceptions import SuspiciousOperation
+from mozilla_django_oidc.auth import (
+    OIDCAuthenticationBackend as MozillaOIDCAuthenticationBackend,
+)
+from rest_framework.authtoken.models import Token
+
+from dora.users.models import User
+
+logger = getLogger(__name__)
+
+
+class OIDCAuthenticationBackend(MozillaOIDCAuthenticationBackend):
+    def get_userinfo(self, access_token, id_token, payload):
+        # Surcharge de la récupération des informations utilisateur:
+        # le décodage JSON du contenu JWT pose problème avec ProConnect
+        # qui le retourne en format binaire (content-type: application/jwt)
+        # d'où ce petit hack.
+        # Inspiré de : https://github.com/numerique-gouv/people/src/backend/core/authentication/backends.py
+        user_response = requests.get(
+            self.OIDC_OP_USER_ENDPOINT,
+            headers={"Authorization": "Bearer {0}".format(access_token)},
+            verify=self.get_settings("OIDC_VERIFY_SSL", True),
+            timeout=self.get_settings("OIDC_TIMEOUT", None),
+            proxies=self.get_settings("OIDC_PROXY", None),
+        )
+        user_response.raise_for_status()
+
+        try:
+            # cas où le type du token JWT est `application/json`
+            return user_response.json()
+        except requests.exceptions.JSONDecodeError:
+            # sinon, on présume qu'il s'agit d'un token JWT au format `application/jwt` (+...)
+            # comme c'est le cas pour ProConnect.
+            return self.verify_token(user_response.text)
+
+    # Pas nécessaire de surcharger `get_or_create_user` puisque sur DORA,
+    # les utilisateurs ont un e-mail unique qui leur sert de `username`.
+
+    def create_user(self, claims):
+        # on peut à la rigueur se passer de certains élements contenus dans les claims,
+        # mais pas de ceux-là :
+        email, sub = claims.get("email"), claims.get("sub")
+        if not email:
+            raise SuspiciousOperation(
+                "L'adresse e-mail n'est pas incluse dans les `claims`"
+            )
+
+        if not sub:
+            raise SuspiciousOperation(
+                "Le sujet (`sub`) n'est pas inclus dans les `claims`"
+            )
+
+        # L'utilisateur est créé sans mot de passe (aucune connexion à l'admin),
+        # et comme venant de ProConnect, on considère l'e-mail vérifié.
+        new_user = self.UserModel.objects.create_user(
+            email,
+            sub_pc=sub,
+            first_name=claims.get("given_name", "N/D"),
+            last_name=claims.get("usual_name", "N/D"),
+            is_valid=True,
+        )
+
+        # recupération du code SAFIR :
+        # même pour l'instant inutilisé, on pourra par la suite le passer au frontend
+        # pour rattachement direct à une agence France Travail
+        if custom := claims.get("custom"):
+            code_safir = custom.get("structureTravail")  # noqa F481
+            # TODO: une fois le code SAFIR récupéré, voir quoi en faire (redirection vers un rattachement)
+
+        # compatibilité :
+        # durant la phase de migration vers ProConnect on ne replace *que* le fournisseur d'identité,
+        # et on ne touche pas aux mécanismes d'identification entre back et front.
+        self.get_or_create_drf_token(new_user)
+
+        return new_user
+
+    def update_user(self, user, claims):
+        # L'utilisateur peut déjà étre inscrit à IC, dans ce cas on réutilise la plupart
+        # des informations déjà connues
+        sub = claims.get("sub")
+
+        if not sub:
+            raise SuspiciousOperation(
+                "Le sujet (`sub`) n'est pas inclu dans les `claims`"
+            )
+
+        if user.sub_pc and str(user.sub_pc) != sub:
+            raise SuspiciousOperation(
+                "Le sub enregistré est différent de celui fourni par ProConnect"
+            )
+
+        if not user.sub_pc:
+            # utilisateur existant, mais non-enregistré sur ProConnect
+            user.sub_pc = sub
+            user.save()
+
+        return user
+
+    def get_user(self, user_id):
+        if user := super().get_user(user_id):
+            self.get_or_create_drf_token(user)
+            return user
+        return None
+
+    def get_or_create_drf_token(self, user_email):
+        # Pour être temporairement compatible, on crée un token d'identification DRF lié au nouvel utilisateur.
+        if not user_email:
+            raise SuspiciousOperation(
+                "Utilisateur non renseigné pour la création du token DRF"
+            )
+
+        user = User.objects.get(email=user_email)
+
+        token, created = Token.objects.get_or_create(user=user)
+
+        if created:
+            logger.info("Initialisation du token DRF pour l'utilisateur %s", user_email)
+
+        return token

--- a/back/dora/oidc/tests.py
+++ b/back/dora/oidc/tests.py
@@ -5,6 +5,7 @@ import jwt
 import pytest
 from django.conf import settings
 from django.core.cache import cache
+from django.core.exceptions import SuspiciousOperation
 from django.db.utils import IntegrityError
 from requests_mock import Mocker
 
@@ -12,7 +13,6 @@ from dora.core.test_utils import make_structure, make_user
 from dora.structures.models import StructurePutativeMember
 from dora.users.models import User
 
-from . import OIDCError
 from .utils import updated_ic_user
 
 
@@ -75,7 +75,7 @@ def test_updated_user_member_of_structure(client_with_cache, settings):
     ic_user = make_user(ic_id=uuid.uuid4())
 
     # doit retourner une erreur si on essaye de modifier un utilisateur membre d'une structure
-    with pytest.raises(OIDCError):
+    with pytest.raises(SuspiciousOperation):
         _, _ = updated_ic_user(ic_user, member_user.email)
 
 

--- a/back/dora/oidc/utils.py
+++ b/back/dora/oidc/utils.py
@@ -1,9 +1,8 @@
+from django.core.exceptions import SuspiciousOperation
 from django.db import transaction
 
 from dora.structures.models import StructureMember, StructurePutativeMember
 from dora.users.models import User
-
-from . import OIDCError
 
 # utilitaires divers et corrections métiers en relation avec Inclusion-Connect / OIDC
 
@@ -19,7 +18,7 @@ def updated_ic_user(user: User, ic_token_email: str) -> tuple[User, bool]:
         # => on vérifie si l'utilisateur est membre d'une structure
         # c'est un cas marginal, on se contente de "crasher" proprement
         if StructureMember.objects.filter(user__email=ic_token_email):
-            raise OIDCError(
+            raise SuspiciousOperation(
                 f"L'utilisateur '{ic_token_email}' est membre d'une ou plusieurs structures et ne peut être supprimé"
             )
 


### PR DESCRIPTION
# `dora.oidc` comme app Django 

Au début l'idée était de faire une toute petite `management command` permettant la déconnexion des utilisateurs.
Mais en voulant faire les choses proprement, il s'est avéré qu'il est nécessaire de modifier la structure du package `dora.oidc` pour, entre autre, en faire une app Django à part entière.

Pour ce faire : 
- le module contenant le backend d'identification est maintenant `dora.oidc.backends` ,
- on supprime `OIDCError` largement inutile.

Voilà en gros ce que fait cette première PR (1).

À suivre : 
- PR 2 : une modification de modélisation, qui sera dans la nouvelle app et permettra de lier directement utilisateurs et sessions
- PR 3 : la `management command` proprement dites (déjà écrite), qui permet d'effacer les tokens DRF **ET** les sessions correspondantes (c'est à ça que sert la PR 2, faire facilement un croisement entre tokens et sessions).

Le fichier `__init__.py` est commenté sur le pourquoi / comment des difficultés rencontrées ...