### PR TITLE
Validité des e-mails des anciens utilisateurs

### DIFF
--- a/back/dora/oidc/backends.py
+++ b/back/dora/oidc/backends.py
@@ -95,6 +95,8 @@ class OIDCAuthenticationBackend(MozillaOIDCAuthenticationBackend):
         if not user.sub_pc:
             # utilisateur existant, mais non-enregistré sur ProConnect
             user.sub_pc = sub
+            # on considère que si l'utilisateur s'est connecté via ProConnect, son e-mail est valide
+            user.is_valid = True
             user.save()
 
         return user


### PR DESCRIPTION
On considère qu'un ancien utilisateur a son e-mail automatiquement
validé si il se connecte via ProConnect.

Il s'agit d'un cas à la marge où certains anciens utilisateurs pouvait ne pas avoir validé leur e-mail.
