### PR TITLE
Correction du problème de dépendance qui fait planter le front

### DIFF
--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -14,7 +14,7 @@
         "@iframe-resizer/parent": "^5.3.2",
         "@nazka/map-gl-js-spiderfy": "^1.2.5",
         "@sveltejs/adapter-node": "^5.2.9",
-        "@sveltejs/kit": "^2.8.1",
+        "@sveltejs/kit": "2.8.0",
         "@sveltejs/vite-plugin-svelte": "^3.1.2",
         "@tailwindcss/typography": "^0.5.15",
         "@tiptap/core": "^2.9.1",
@@ -2306,9 +2306,9 @@
       }
     },
     "node_modules/@sveltejs/kit": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-2.8.1.tgz",
-      "integrity": "sha512-uuOfFwZ4xvnfPsiTB6a4H1ljjTUksGhWnYq5X/Y9z4x5+3uM2Md8q/YVeHL+7w+mygAwoEFdgKZ8YkUuk+VKww==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-2.8.0.tgz",
+      "integrity": "sha512-HCiWupCuKJQ3aPaC4Xc6lpPdjOOnoGzEiYjOqMqppdtfGtY2ABrx932Vw66ZwS2RGXc0BmZvFvNq5SzqlmDVLg==",
       "hasInstallScript": true,
       "dependencies": {
         "@types/cookie": "^0.6.0",

--- a/front/package.json
+++ b/front/package.json
@@ -30,7 +30,7 @@
     "@iframe-resizer/parent": "^5.3.2",
     "@nazka/map-gl-js-spiderfy": "^1.2.5",
     "@sveltejs/adapter-node": "^5.2.9",
-    "@sveltejs/kit": "^2.8.1",
+    "@sveltejs/kit": "2.8.0",
     "@sveltejs/vite-plugin-svelte": "^3.1.2",
     "@tailwindcss/typography": "^0.5.15",
     "@tiptap/core": "^2.9.1",


### PR DESCRIPTION
La version de `@sveltejs/kit` 2.8.1 fait planter le front. Je la bloque à 2.8.0 pour résoudre le problème, en attendant de trouver ce qui doit être changé pour faire fonctionner la 2.8.1.