### PR TITLE
Modification de la durée de vie des sessions Django

### DIFF
--- a/back/config/settings/base.py
+++ b/back/config/settings/base.py
@@ -82,6 +82,12 @@ AUTHENTICATION_BACKENDS = [
     "sesame.backends.ModelBackend",
 ]
 
+# Sessions :
+# https://docs.djangoproject.com/fr/4.2/topics/http/sessions/
+# La durée de vie de la session est de 12 heures par défaut
+# (identique à ProConnect)
+SESSION_COOKIE_AGE = 60 * 60 * 12  # 12 heures
+
 # Permet de garder le comportement d'identification "standard" (e-mail/password)
 ACCOUNT_EMAIL_REQUIRED = True
 ACCOUNT_AUTHENTICATION_METHOD = "email"


### PR DESCRIPTION
Fixée à 12 heures en correspondance avec la durée des sessions de ProConnect.
