### PR TITLE
fix: correction d'une erreur de validation dans l'admin

### DIFF
--- a/back/config/settings/prod.py
+++ b/back/config/settings/prod.py
@@ -42,6 +42,11 @@ SECURE_REFERRER_POLICY = "same-origin"
 SECURE_CONTENT_TYPE_NOSNIFF = True
 SECURE_SSL_REDIRECT = True
 
+# Certains formulaires d'admin (par ex. structures)
+# peuvent contenir un grand nombre de champs associés (par ex. membres)
+# et déclencher une erreur de type : `TooManyFieldsSent` lors de la modification
+# et de la validation des enregistrements.
+DATA_UPLOAD_MAX_NUMBER_FIELDS = 2_000
 
 # Sentry :
 # uniquement sur les environnememts de production / staging


### PR DESCRIPTION
Relatif à https://trello.com/c/vvs4q4yW/260-fix-bug-labellisation-des-cd-bloquer-le-label-une-fois-corrig%C3%A9

Une erreur `TooManyFieldsSent` est levée quand le nombre de champs d'un formulaire est
trop élevé.

C'est le cas pour certaines structures dans l'admin. 
On peut augmenter (doubler présentement) le nombre de champs possibles dans un formulaire pour que tout rentre
dans l'ordre via le paramètre `DATA_UPLOAD_MAX_NUMBER_FIELDS`.

Voir :
https://docs.djangoproject.com/en/5.0/ref/settings/#data-upload-max-number-fields
