### PR TITLE
⚠️ Learning ⚠️ (NE SURTOUT PAS MERGER) pourquoi les tests back sont longs

### DIFF
--- a/back/dora/conftest.py
+++ b/back/dora/conftest.py
@@ -14,7 +14,7 @@ def patch_di_client():
         yield
 
 
-@pytest.fixture(autouse=True)
+@pytest.fixture(autouse=False)
 def _use_db(db):
     # Active automatiquement la gestion de la db
     # (ce qui n'est pas fait par défaut avec pytest).


### PR DESCRIPTION
Ceci n'est pas une PR ayant vocation à être mergée. Elle sert à tester des choses pour améliorer notre outillage de test et vérifier le comportement en CI / CD.

### Hypothèse n°1 : le fait de charger la DB pour tous les tests les ralentit ✅

Dans back/conftest.py, on active la DB pour tous les tests. Le coût incompressible devient alors de 14s, que l'on exécute 1, 10 ou 100 tests, qu'il concerne un Modele / la BDD ou pas.

Hypothèse validée. 

Questions à creuser : 
- est-ce à cause de la quantité et contenu des migrations SQL ?
- est-ce à cause de jeu(x) de données par défaut ?

Si tout ça se confirme, quelles sont les pistes à envisager ?