### PR TITLE
ServiceModelSerializer: ajout des champs funding_labels et funding_labels_display

### DIFF
--- a/back/dora/services/serializers.py
+++ b/back/dora/services/serializers.py
@@ -480,6 +480,15 @@ class ServiceModelSerializer(ServiceSerializer):
         max_length=140,
         required=False,
     )
+    funding_labels = serializers.SlugRelatedField(
+        slug_field="value",
+        queryset=FundingLabel.objects.all(),
+        many=True,
+        required=False,
+    )
+    funding_labels_display = serializers.SlugRelatedField(
+        source="funding_labels", slug_field="label", many=True, read_only=True
+    )
 
     class Meta:
         model = ServiceModel
@@ -510,6 +519,8 @@ class ServiceModelSerializer(ServiceSerializer):
             "fee_details",
             "forms",
             "forms_info",
+            "funding_labels",
+            "funding_labels_display",
             "full_desc",
             "is_cumulative",
             "kinds",


### PR DESCRIPTION
Ces champs étaient présents dans le sérialiseur de service, mais pas celui de modèle. Or, les deux sont utilisés de la même manière. L'oubli de ces champs cause une erreur au chargement de la page d'un modèle.

Exemple : http://localhost:3000/modeles/nenettes-co-le-resea-aide-au-permis-et-pr-htxi