### PR TITLE
Détection de mots de test dans le formulaire d'orientation

### DIFF
--- a/front/src/lib/consts.ts
+++ b/front/src/lib/consts.ts
@@ -4,3 +4,5 @@ export const SIREN_FRANCE_TRAVAIL = "130005481";
 export const enum TallyFormId {
   SERVICE_CREATION_FORM_ID = "mRGdpK",
 }
+
+export const TEST_WORDS = ["test", "truc", "bidule"];

--- a/front/src/lib/utils/orientation.ts
+++ b/front/src/lib/utils/orientation.ts
@@ -1,5 +1,6 @@
 import { getApiURL } from "./api";
 import { fetchData } from "./misc";
+import { TEST_WORDS } from "$lib/consts";
 import type { Choice, Orientation, Service } from "$lib/types";
 
 export function getOrientation(queryId: string, queryHash: string) {
@@ -141,4 +142,26 @@ export function computeRequirementsChoices(service: Service): {
     requirementChoices,
     requirementRequired: requirementChoices.length > 0,
   };
+}
+
+export function orientationContainsTestWords(
+  orientation: Orientation
+): string | false {
+  const testWordsRegexp = `\\b(${TEST_WORDS.join("|")})\\b`;
+  const fieldsToTest = [
+    orientation.referentFirstName,
+    orientation.referentLastName,
+    orientation.referentEmail,
+    orientation.beneficiaryFirstName,
+    orientation.beneficiaryLastName,
+    orientation.beneficiaryEmail,
+    orientation.orientationReasons,
+  ];
+  for (const field of fieldsToTest) {
+    const testWordMatched = field.match(testWordsRegexp);
+    if (testWordMatched) {
+      return testWordMatched[0];
+    }
+  }
+  return false;
 }

--- a/front/src/routes/(modeles-services)/services/[slug]/orienter/demande/orientation-form.svelte
+++ b/front/src/routes/(modeles-services)/services/[slug]/orienter/demande/orientation-form.svelte
@@ -11,6 +11,7 @@
   import { onMount } from "svelte";
   import Accordion from "$lib/components/display/accordion.svelte";
   import SelectField from "$lib/components/forms/fields/select-field.svelte";
+  import { orientationContainsTestWords } from "$lib/utils/orientation";
   import { userPreferences } from "$lib/utils/preferences";
 
   export let service;
@@ -40,6 +41,8 @@
     $orientation.referentFirstName = $userInfo.firstName;
     $orientation.referentEmail = $userInfo.email;
   });
+
+  $: testWordDetected = orientationContainsTestWords($orientation);
 </script>
 
 <div>
@@ -294,7 +297,22 @@
     </Fieldset>
   {/if}
 
-  <div class="my-s32">
+  <div class="my-s32 flex flex-col gap-s32">
+    {#if testWordDetected}
+      <Notice
+        type="error"
+        title="Le mot «&#8239;{testWordDetected}&#8239;» a été détecté dans les champs…"
+        ><p>
+          Les orientations fictives/test nécessitent une vérification manuelle,
+          augmentant la charge de travail de nos équipes. Pour découvrir le
+          fonctionnement du formulaire, consultez plutôt <a
+            href="https://aide.dora.inclusion.beta.gouv.fr/fr/category/orienter-vos-beneficiaires-c25cna/"
+            target="_blank"
+            class="underline">notre documentation</a
+          >.
+        </p></Notice
+      >
+    {/if}
     <Notice
       type="info"
       title="L’accompagnateur s’engage à informer la personne concernée de ce traitement de données."

--- a/front/src/tests/utils/orientation/orientationContainsTestWords.test.ts
+++ b/front/src/tests/utils/orientation/orientationContainsTestWords.test.ts
@@ -1,0 +1,100 @@
+import { beforeEach, describe, expect, test } from "vitest";
+import type { Orientation } from "$lib/types";
+import { TEST_WORDS } from "$lib/consts";
+import { orientationContainsTestWords } from "$lib/utils/orientation";
+
+const ORIENTATION_TEMPLATE: Orientation = {
+  firstStepDone: false,
+  contactBoxOpen: false,
+  situation: [],
+  situationOther: "",
+  requirements: [],
+  referentLastName: "",
+  referentFirstName: "",
+  referentPhone: "",
+  referentEmail: "",
+  prescriberStructureSlug: "",
+  beneficiaryLastName: "",
+  beneficiaryFirstName: "",
+  beneficiaryAvailability: "",
+  beneficiaryContactPreferences: [],
+  beneficiaryPhone: "",
+  beneficiaryEmail: "",
+  beneficiaryOtherContactMethod: "",
+  orientationReasons: "",
+  attachments: {},
+  queryId: "",
+  creationDate: "",
+  status: "OUVERTE",
+  beneficiaryAttachmentsDetails: [],
+};
+
+describe("orientationContainsTestWords", () => {
+  let orientation = structuredClone(ORIENTATION_TEMPLATE);
+
+  beforeEach(() => {
+    orientation = structuredClone(ORIENTATION_TEMPLATE);
+  });
+
+  test("détecte les mots de test dans chaque champ vérifié", () => {
+    TEST_WORDS.forEach((testWord) => {
+      [
+        "referentFirstName",
+        "referentLastName",
+        "referentEmail",
+        "beneficiaryFirstName",
+        "beneficiaryLastName",
+        "beneficiaryEmail",
+        "orientationReasons",
+      ].forEach((field) => {
+        orientation = structuredClone(ORIENTATION_TEMPLATE);
+        orientation[field] = testWord;
+        expect(orientationContainsTestWords(orientation)).toStrictEqual(
+          testWord
+        );
+      });
+    });
+  });
+
+  test("détecte les mots de test en début de chaîne", () => {
+    TEST_WORDS.forEach((testWord) => {
+      orientation.orientationReasons = `${testWord} foo bar`;
+      expect(orientationContainsTestWords(orientation)).toStrictEqual(testWord);
+    });
+  });
+
+  test("détecte les mots de test en milieu de chaîne", () => {
+    TEST_WORDS.forEach((testWord) => {
+      orientation.orientationReasons = `foo ${testWord} bar`;
+      expect(orientationContainsTestWords(orientation)).toStrictEqual(testWord);
+    });
+  });
+
+  test("détecte les mots de test en fin de chaîne", () => {
+    TEST_WORDS.forEach((testWord) => {
+      orientation.orientationReasons = `foo bar ${testWord}`;
+      expect(orientationContainsTestWords(orientation)).toStrictEqual(testWord);
+    });
+  });
+
+  test("ne détecte pas les mots de test en début de chaîne comme partie d'un autre mot", () => {
+    TEST_WORDS.forEach((testWord) => {
+      orientation.orientationReasons = `${testWord}foobar`;
+      expect(orientationContainsTestWords(orientation)).toEqual(false);
+    });
+  });
+
+  test("ne détecte pas les mots de test en milieu de chaîne comme partie d'un autre mot", () => {
+    TEST_WORDS.forEach((testWord) => {
+      orientation.orientationReasons = `foo${testWord}bar`;
+      expect(orientationContainsTestWords(orientation)).toEqual(false);
+    });
+  });
+
+  test("ne détecte pas les mots de test en fin de chaîne comme partie d'un autre mot", () => {
+    TEST_WORDS.forEach((testWord) => {
+      orientation.orientationReasons = `foobar${testWord}`;
+      expect(orientationContainsTestWords(orientation)).toEqual(false);
+    });
+  });
+});

--- a/front/tsconfig.json
+++ b/front/tsconfig.json
@@ -12,6 +12,5 @@
     "sourceMap": true,
     "strict": true,
     "target": "ES2017"
-  },
-  "exclude": ["./src/tests/**"]
+  }
 }


### PR DESCRIPTION
Si un mot parmi _test_, _truc_, _bidule_ est détecté dans les champs prénom, nom, email du référent ou du bénéficiaire, ou bien dans le champ motif, alors on affiche une notice erreur en bas du formulaire. Cette erreur ne bloque pas l'envoi du formulaire.

![image](https://github.com/user-attachments/assets/d6833c96-534e-4c44-b5cc-afad1f677f0c)

J'ai écrit des tests pour la fonction utilitaire.

J'ai modifié la configuration de TypeScript pour que l'autocomplétion fonctionne dans les fichiers de test.