### PR TITLE
L'adresse e-mail du bénéficiaire doit être différente de celle du référent ou utiliser l'option Via le référent

### DIFF
--- a/front/src/lib/types.ts
+++ b/front/src/lib/types.ts
@@ -1,5 +1,3 @@
-import type { FundingLabel } from "../routes/recherche/result-filters.svelte";
-
 export type AdminDivisionType =
   | "country"
   | "region"

--- a/front/src/lib/types.ts
+++ b/front/src/lib/types.ts
@@ -642,7 +642,7 @@ export type Day =
 export type DayPrefix = "Mo" | "Tu" | "We" | "Th" | "Fr" | "Sa" | "Su";
 export type DayPeriod = "timeSlot1" | "timeSlot2";
 
-type ContactPreferences = "TELEPHONE" | "EMAIL" | "AUTRE";
+type ContactPreferences = "TELEPHONE" | "EMAIL" | "REFERENT" | "AUTRE";
 
 export interface Orientation {
   // Tous les champs de l'étape 1 pouvant être optionnels

--- a/front/src/routes/(modeles-services)/services/[slug]/orienter/demande/+page.svelte
+++ b/front/src/routes/(modeles-services)/services/[slug]/orienter/demande/+page.svelte
@@ -48,6 +48,13 @@
       validatedData.attachments
     ).flat();
 
+    // Remplace REFERENT par EMAIL en s'assurant que chaque élément n'apparaisse qu'une fois
+    let beneficiaryContactPreferences =
+      validatedData.beneficiaryContactPreferences.map((item) =>
+        item === "REFERENT" ? "EMAIL" : item
+      );
+    beneficiaryContactPreferences = [...new Set(beneficiaryContactPreferences)];
+
     return fetch(`${getApiURL()}/orientations/`, {
       method: "POST",
       headers: {
@@ -57,6 +64,7 @@
       },
       body: JSON.stringify({
         ...validatedData,
+        beneficiaryContactPreferences,
         serviceSlug: isDI ? null : service.slug,
         diServiceId: isDI ? service.slug : "",
         diServiceName: isDI ? service.name || "" : "",

--- a/front/src/routes/(modeles-services)/services/[slug]/orienter/demande/+page.svelte
+++ b/front/src/routes/(modeles-services)/services/[slug]/orienter/demande/+page.svelte
@@ -48,7 +48,11 @@
       validatedData.attachments
     ).flat();
 
-    // Remplace REFERENT par EMAIL en s'assurant que chaque élément n'apparaisse qu'une fois
+    // Remplace REFERENT par EMAIL en s'assurant que chaque élément n'apparaisse qu'une fois.
+    // Explication : le mode REFERENT existe uniquement côté front-end et sert à spécifier
+    // l'adresse e-mail du référent comme celle du destinataire via une case à cocher supplémentaire.
+    // Côté back-end, ce mode n'existe pas. On utilise le mode EMAIL à la place. L'adresse e-mail du
+    // référent a été spécifiée dans le champ beneficiaryEmail.
     let beneficiaryContactPreferences =
       validatedData.beneficiaryContactPreferences.map((item) =>
         item === "REFERENT" ? "EMAIL" : item

--- a/front/src/routes/(modeles-services)/services/[slug]/orienter/demande/orientation-form.svelte
+++ b/front/src/routes/(modeles-services)/services/[slug]/orienter/demande/orientation-form.svelte
@@ -12,11 +12,28 @@
   import Accordion from "$lib/components/display/accordion.svelte";
   import SelectField from "$lib/components/forms/fields/select-field.svelte";
   import { userPreferences } from "$lib/utils/preferences";
+  import type { Choice } from "$lib/types";
+  import { formErrors } from "$lib/validation/validation";
 
   export let service;
   export let credentials;
 
-  let contactPrefOptions = [];
+  let contactPrefOptions: Choice[] = [];
+  let previousUseReferentEmail = false;
+
+  function useReferentEmailForBeneficiary(useReferentEmail: boolean) {
+    if (useReferentEmail === previousUseReferentEmail) {
+      return;
+    }
+    $orientation.beneficiaryEmail = useReferentEmail
+      ? $orientation.referentEmail
+      : "";
+    previousUseReferentEmail = useReferentEmail;
+    $formErrors.beneficiaryEmail = [];
+  }
+  $: useReferentEmail =
+    $orientation.beneficiaryContactPreferences.includes("REFERENT");
+  $: useReferentEmailForBeneficiary(useReferentEmail);
 
   if ($userInfo.structures?.length === 1) {
     $orientation.prescriberStructureSlug = $userInfo.structures[0].slug;
@@ -33,6 +50,7 @@
     contactPrefOptions = [
       { value: "TELEPHONE", label: "Téléphone" },
       { value: "EMAIL", label: "E-mail" },
+      { value: "REFERENT", label: "Via le conseiller référent" },
       { value: "AUTRE", label: "Autre" },
     ];
 
@@ -213,6 +231,7 @@
           placeholder="nom@domaine.fr"
           description="Format attendu&nbsp;: nom@domaine.fr"
           bind:value={$orientation.beneficiaryEmail}
+          disabled={useReferentEmail}
           vertical
         />
       </div>

--- a/front/src/routes/(modeles-services)/services/[slug]/orienter/schema.ts
+++ b/front/src/routes/(modeles-services)/services/[slug]/orienter/schema.ts
@@ -91,8 +91,10 @@ export const orientationStep2Schema: v.Schema = {
       v.maxStrLength(254),
       (_fieldName, value, data: Orientation) => {
         return {
-          valid: value !== data.referentEmail,
-          msg: "L’adresse e-mail du bénéficiaire doit être différente de celle du prescripteur.",
+          valid:
+            data.beneficiaryContactPreferences.includes("REFERENT") ||
+            value !== data.referentEmail,
+          msg: "L’adresse e-mail du bénéficiaire doit être différente de celle du référent.",
         };
       },
     ],

--- a/front/src/routes/(modeles-services)/services/[slug]/orienter/schema.ts
+++ b/front/src/routes/(modeles-services)/services/[slug]/orienter/schema.ts
@@ -1,3 +1,4 @@
+import type { Orientation } from "$lib/types";
 import * as v from "$lib/validation/schema-utils";
 
 export const orientationStep1Schema: v.Schema = {
@@ -85,7 +86,16 @@ export const orientationStep2Schema: v.Schema = {
   beneficiaryEmail: {
     label: "E-mail",
     default: "",
-    rules: [v.isEmail(), v.maxStrLength(254)],
+    rules: [
+      v.isEmail(),
+      v.maxStrLength(254),
+      (_fieldName, value, data: Orientation) => {
+        return {
+          valid: value !== data.referentEmail,
+          msg: "L’adresse e-mail du bénéficiaire doit être différente de celle du prescripteur.",
+        };
+      },
+    ],
     post: [v.lower, v.trim],
     maxLength: 254,
     required: (data) => {


### PR DESCRIPTION
Si la même adresse e-mail est utilisée pour le référent et pour le bénéficiaire, une erreur est montrée.

Si l'option _Via le référent_ est cochée, l'adresse e-mail du bénéficiaire est forcée, sans erreur.

![image](https://github.com/user-attachments/assets/9f615a37-90a0-4380-994f-291c277c7d6c)
![image](https://github.com/user-attachments/assets/36600663-4c22-4ef8-b49c-596badc7c885)
