### PR TITLE
libs: MaJ vers Django 4.2.17

### DIFF
--- a/back/requirements/base.txt
+++ b/back/requirements/base.txt
@@ -1,6 +1,6 @@
 data-inclusion-schema==0.19.0
 dj-database-url==2.3.0
-Django==4.2.16
+Django==4.2.17
 django-cors-headers==4.6.0
 django-csp==3.8
 django-filter==24.3


### PR DESCRIPTION
avant que `dependabot` y retrouve ses petits ...

voir https://www.djangoproject.com/weblog/2024/dec/04/security-releases/
