### PR TITLE
Dérivation du mode d'orientation par formulaire Dora pour les services DI

### DIFF
--- a/back/dora/data_inclusion/mappings.py
+++ b/back/dora/data_inclusion/mappings.py
@@ -173,8 +173,15 @@ def map_service(service_data: dict, is_authenticated: bool) -> dict:
 
     coach_orientation_modes = None
     if service_data["modes_orientation_accompagnateur"] is not None:
+        coach_orientation_mode_values = map(
+            lambda mode: "formulaire-dora"
+            if mode == "completer-le-formulaire-dadhesion"
+            and service_data["formulaire_en_ligne"] is None
+            else mode,
+            service_data["modes_orientation_accompagnateur"],
+        )
         coach_orientation_modes = CoachOrientationMode.objects.filter(
-            value__in=service_data["modes_orientation_accompagnateur"]
+            value__in=coach_orientation_mode_values
         )
 
     profils = None

--- a/back/dora/data_inclusion/tests.py
+++ b/back/dora/data_inclusion/tests.py
@@ -4,6 +4,24 @@ from .constants import THEMATIQUES_MAPPING_DI_TO_DORA
 from .mappings import map_service
 from .test_utils import FakeDataInclusionClient, make_di_service_data
 
+ALL_DI_COACH_ORIENTATION_MODES = [
+    "autre",
+    "completer-le-formulaire-dadhesion",
+    "envoyer-un-mail",
+    "envoyer-un-mail-avec-une-fiche-de-prescription",
+    "telephoner",
+    "prendre-rdv",
+]
+
+ALL_DORA_COACH_ORIENTATION_MODES = [
+    "autre",
+    "completer-le-formulaire-dadhesion",
+    "envoyer-un-mail",
+    "envoyer-un-mail-avec-une-fiche-de-prescription",
+    "formulaire-dora",
+    "telephoner",
+]
+
 
 def test_map_service_thematiques_mapping():
     input_thematiques = [
@@ -50,3 +68,41 @@ def test_di_client_search_thematiques_mapping(thematiques_dora, thematiques_di):
     results = di_client.search_services(thematiques=thematiques_dora)
 
     assert len(results) == 1
+
+
+def test_map_service_coach_orientation_modes_mapping_with_dora_form():
+    di_service_data = make_di_service_data(
+        modes_orientation_accompagnateur=ALL_DI_COACH_ORIENTATION_MODES,
+        formulaire_en_ligne=None,
+    )
+    service = map_service(di_service_data, False)
+
+    expected_dora_coach_orientation_modes = list(
+        filter(
+            lambda m: m != "completer-le-formulaire-dadhesion",
+            ALL_DORA_COACH_ORIENTATION_MODES,
+        )
+    )
+
+    assert sorted(service["coach_orientation_modes"]) == sorted(
+        expected_dora_coach_orientation_modes
+    )
+
+
+def test_map_service_coach_orientation_modes_mapping_without_dora_form():
+    di_service_data = make_di_service_data(
+        modes_orientation_accompagnateur=ALL_DI_COACH_ORIENTATION_MODES,
+        formulaire_en_ligne="https://example.com",
+    )
+    service = map_service(di_service_data, False)
+
+    expected_dora_coach_orientation_modes = list(
+        filter(
+            lambda m: m != "formulaire-dora",
+            ALL_DORA_COACH_ORIENTATION_MODES,
+        )
+    )
+
+    assert sorted(service["coach_orientation_modes"]) == sorted(
+        expected_dora_coach_orientation_modes
+    )


### PR DESCRIPTION
Si un service DI comporte le mode `completer-le-formulaire-dadhesion` et que le champ `formulaire_en_ligne` est nul, on remplace ce mode par le mode `formulaire-dora`.