### PR TITLE
fix: correction d'une erreur de formulaire dans l'admin

### DIFF
--- a/back/config/settings/base.py
+++ b/back/config/settings/base.py
@@ -193,6 +193,11 @@ STORAGES = {
     },
 }
 
+# Limitations de Django pour la taille des formulaires :
+# Nombre de champs max. du formulaire (x2)
+# augmentation de la valeur par défaut pour tous les environnements
+DATA_UPLOAD_MAX_NUMBER_FIELDS = 2_000
+
 # Stockage S3 CleverCloud :
 AWS_S3_ENDPOINT_URL = os.getenv("AWS_S3_ENDPOINT_URL")
 AWS_ACCESS_KEY_ID = os.getenv("AWS_ACCESS_KEY_ID")

--- a/back/config/settings/prod.py
+++ b/back/config/settings/prod.py
@@ -46,7 +46,7 @@ SECURE_SSL_REDIRECT = True
 # peuvent contenir un grand nombre de champs associés (par ex. membres)
 # et déclencher une erreur de type : `TooManyFieldsSent` lors de la modification
 # et de la validation des enregistrements.
-DATA_UPLOAD_MAX_NUMBER_FIELDS = 2_000
+DATA_UPLOAD_MAX_NUMBER_FIELDS = 4_000
 
 # Sentry :
 # uniquement sur les environnememts de production / staging


### PR DESCRIPTION
Voir : 
- https://trello.com/c/vvs4q4yW/260-fix-bug-labellisation-des-cd-bloquer-le-label-une-fois-corrig%C3%A9
- https://trello.com/c/30LWF6Xq/311-label-savoie-non-fonctionnel

Certaines structures ont un nombre conséquent de membres et
d'invitations en cours, ce qui peut poser des problèmes lors de l'envoi
du formulaire de modification dans l'admin Django.

Plusieurs paramètres Django permettent de dimensionner les limitations
de ce qui est envoyé par formulaire au serveur.

Dans le cas présent : la valeur `DATA_UPLOAD_MAX_NUMBER_FIELDS` a été
doublée pour pouvoir modifier certaines structures sans erreurs.

Corrélée à : #91, le nombre d'éléments était insuffisant
