### PR TITLE
fix: sitemap: ne charge plus tous les services et structures pour éviter plantage. Prise en compte de l'environnement dev.

### DIFF
--- a/front/src/routes/(endpoints)/sitemap.xml/+server.ts
+++ b/front/src/routes/(endpoints)/sitemap.xml/+server.ts
@@ -1,40 +1,5 @@
 import { CANONICAL_URL, ENVIRONMENT } from "$lib/env";
-import { getPublishedServices } from "$lib/requests/services";
-import { getActiveStructures } from "$lib/requests/structures";
 import { error } from "@sveltejs/kit";
-
-function toISODate(apiDate) {
-  const date = new Date(apiDate).toISOString();
-  return date.slice(0, date.indexOf("T"));
-}
-
-async function getServicesEntries() {
-  const response = await getPublishedServices();
-
-  return response
-    .filter((service) => (service.status = "PUBLISHED")) // Pas indispensable, mais c'est une sécurité supplémentaire
-    .map((service) =>
-      `<url>
-      <loc>${CANONICAL_URL}/services/${service.slug}</loc>
-      <lastmod>${toISODate(service.modificationDate)}</lastmod>
-      <priority>0.5</priority>
-    </url>`.trim()
-    )
-    .join("\n");
-}
-
-async function getStructuresEntries() {
-  const response = await getActiveStructures();
-  return response
-    .map((structure) =>
-      `<url>
-      <loc>${CANONICAL_URL}/structures/${structure.slug}</loc>
-      <lastmod>${toISODate(structure.modificationDate)}</lastmod>
-      <priority>0.7</priority>
-    </url>`.trim()
-    )
-    .join("\n");
-}
 
 function getStaticEntries() {
   return ["contribuer"]
@@ -47,7 +12,7 @@ function getStaticEntries() {
     .join("\n");
 }
 
-async function getContent() {
+function getContent() {
   const content = `
   <?xml version="1.0" encoding="UTF-8" ?>
     <urlset
@@ -56,17 +21,19 @@ async function getContent() {
         <loc>${CANONICAL_URL}/</loc>
         <priority>1</priority>
       </url>
-      ${await getStructuresEntries()}
-      ${await getServicesEntries()}
       ${getStaticEntries()}
     </urlset>`.trim();
 
   return content;
 }
 
-export async function GET() {
-  const content = await getContent();
-  if (ENVIRONMENT === "production" || ENVIRONMENT === "local") {
+export function GET() {
+  const content = getContent();
+  if (
+    ENVIRONMENT === "production" ||
+    ENVIRONMENT === "local" ||
+    ENVIRONMENT === "dev"
+  ) {
     return new Response(content, {
       headers: {
         "Content-Type": "application/xml",


### PR DESCRIPTION
Erreur Sentry : https://sentry.gip-inclusion.org/organizations/gip-inclusion/issues/12195/?project=5&query=is%3Aunresolved&referrer=issue-stream&statsPeriod=14d&stream_index=0

La page `/sitemap.xml` charge l’ensemble des structures et des services, ce qui fait beaucoup trop de volume, surcharge le serveur et finit par planter.

Pour résoudre ce problème, j’ai supprimé purement le chargement de ces données.