### PR TITLE
Catégorisation des actions pour les connexions directes

### DIFF
--- a/back/dora/auth_links/enums.py
+++ b/back/dora/auth_links/enums.py
@@ -1,0 +1,11 @@
+import enum
+
+
+class AuthLinkAction(enum.StrEnum):
+    """
+    Actions loggées pour les liens d'identification.
+    """
+
+    SENT_AUTH_LINK = "sent_auth_link"
+    DID_AUTHENTICATE_WITH_AUTH_LINK = "did_authenticate_with_auth_link"
+    USED_EXPIRED_AUTH_LINK = "used_expired_auth_link"

--- a/back/dora/auth_links/views.py
+++ b/back/dora/auth_links/views.py
@@ -10,6 +10,7 @@ from rest_framework.authtoken.models import Token
 from sesame.utils import get_token, get_user
 
 from dora.auth_links.emails import send_authentication_link
+from dora.auth_links.enums import AuthLinkAction
 from dora.users.models import User
 
 logger = logging.getLogger("dora.logs.core")
@@ -38,6 +39,7 @@ def send_link(request):
         "Demande de connexion par lien direct",
         {
             "legal": True,
+            "action": AuthLinkAction.SENT_AUTH_LINK,
             "userId": user.pk,
             "userEmail": user.email,
         },
@@ -53,6 +55,7 @@ def authenticate_with_link(request, sesame):
                 "Connexion par lien direct",
                 {
                     "legal": True,
+                    "action": AuthLinkAction.DID_AUTHENTICATE_WITH_AUTH_LINK,
                     "userId": user.pk,
                     "userEmail": user.email,
                 },
@@ -68,7 +71,10 @@ def authenticate_with_link(request, sesame):
 
     logger.warning(
         "Lien direct invalide ou expiré",
-        {"sesameLink": f"...{sesame[:-5]}"},
+        {
+            "action": AuthLinkAction.USED_EXPIRED_AUTH_LINK,
+            "sesameLink": f"...{sesame[:-5]}",
+        },
     )
 
     # le lien est invalide ou expiré :


### PR DESCRIPTION
Relatif à : https://trello.com/c/wWLEviB6/308-tableaux-de-suivi-migration-pro-connect

Ajoute un champ `action` dans le corps des logs permettra de contruire un
tableau de suivi plus facilement (les actions relatives à la connexion
directe sont catégorisées).
