### PR TITLE
fix(sitemap): Sitemap paginé

### DIFF
--- a/front/src/lib/consts.ts
+++ b/front/src/lib/consts.ts
@@ -6,3 +6,5 @@ export const enum TallyFormId {
 }
 
 export const TEST_WORDS = ["test", "truc", "bidule"];
+
+export const SITEMAP_PAGE_SIZE = 1000;

--- a/front/src/lib/requests/services.ts
+++ b/front/src/lib/requests/services.ts
@@ -58,6 +58,17 @@ export async function getServiceDI(diId): Promise<Service> {
   return serviceToFront(response.data);
 }
 
+export async function getPublishedServiceCount(): Promise<number | null> {
+  const url = new URL("/services/", getApiURL());
+
+  url.searchParams.append("published", "1");
+  url.searchParams.append("page_size", "1");
+
+  const data = (await fetchData<{ count: number }>(url.toString())).data;
+
+  return data?.count || null;
+}
+
 export async function getPublishedServices(): Promise<ShortService[]> {
   const url = `${getApiURL()}/services/?published=1`;
   return (await fetchData<ShortService[]>(url)).data;

--- a/front/src/lib/requests/services.ts
+++ b/front/src/lib/requests/services.ts
@@ -69,9 +69,23 @@ export async function getPublishedServiceCount(): Promise<number | null> {
   return data?.count || null;
 }
 
-export async function getPublishedServices(): Promise<ShortService[]> {
-  const url = `${getApiURL()}/services/?published=1`;
-  return (await fetchData<ShortService[]>(url)).data;
+export async function getPublishedServices({
+  pageSize,
+  page,
+}: {
+  pageSize: number;
+  page: number;
+}): Promise<ShortService[] | null> {
+  const url = new URL("/services/", getApiURL());
+
+  url.searchParams.append("published", "1");
+  url.searchParams.append("page_size", pageSize.toString());
+  url.searchParams.append("page", page.toString());
+
+  const data = (await fetchData<{ results: ShortService[] }>(url.toString()))
+    .data;
+
+  return data?.results || null;
 }
 
 export async function getModel(slug): Promise<Model> {

--- a/front/src/lib/requests/services.ts
+++ b/front/src/lib/requests/services.ts
@@ -58,34 +58,22 @@ export async function getServiceDI(diId): Promise<Service> {
   return serviceToFront(response.data);
 }
 
-export async function getPublishedServiceCount(): Promise<number | null> {
-  const url = new URL("/services/", getApiURL());
-
-  url.searchParams.append("published", "1");
-  url.searchParams.append("page_size", "1");
-
-  const data = (await fetchData<{ count: number }>(url.toString())).data;
-
-  return data?.count || null;
-}
-
 export async function getPublishedServices({
   pageSize,
   page,
 }: {
   pageSize: number;
   page: number;
-}): Promise<ShortService[] | null> {
+}) {
   const url = new URL("/services/", getApiURL());
 
   url.searchParams.append("published", "1");
   url.searchParams.append("page_size", pageSize.toString());
   url.searchParams.append("page", page.toString());
 
-  const data = (await fetchData<{ results: ShortService[] }>(url.toString()))
-    .data;
-
-  return data?.results || null;
+  return (
+    await fetchData<{ count: number; results: ShortService[] }>(url.toString())
+  ).data;
 }
 
 export async function getModel(slug): Promise<Model> {

--- a/front/src/lib/requests/structures.ts
+++ b/front/src/lib/requests/structures.ts
@@ -68,34 +68,24 @@ export async function getManagedStructures(
   return (await fetchData<ShortStructure[]>(url)).data;
 }
 
-export async function getActiveStructureCount(): Promise<number | null> {
-  const url = new URL("/structures/", getApiURL());
-
-  url.searchParams.append("active", "1");
-  url.searchParams.append("page_size", "1");
-
-  const data = (await fetchData<{ count: number }>(url.toString())).data;
-
-  return data?.count || null;
-}
-
 export async function getActiveStructures({
   pageSize,
   page,
 }: {
   pageSize: number;
   page: number;
-}): Promise<ShortStructure[] | null> {
+}) {
   const url = new URL("/structures/", getApiURL());
 
   url.searchParams.append("active", "1");
   url.searchParams.append("page_size", pageSize.toString());
   url.searchParams.append("page", page.toString());
 
-  const data = (await fetchData<{ results: ShortStructure[] }>(url.toString()))
-    .data;
-
-  return data?.results || null;
+  return (
+    await fetchData<{ count: number; results: ShortStructure[] }>(
+      url.toString()
+    )
+  ).data;
 }
 
 export async function getStructure(slug: string): Promise<Structure | null> {

--- a/front/src/lib/requests/structures.ts
+++ b/front/src/lib/requests/structures.ts
@@ -68,6 +68,17 @@ export async function getManagedStructures(
   return (await fetchData<ShortStructure[]>(url)).data;
 }
 
+export async function getActiveStructureCount(): Promise<number | null> {
+  const url = new URL("/structures/", getApiURL());
+
+  url.searchParams.append("active", "1");
+  url.searchParams.append("page_size", "1");
+
+  const data = (await fetchData<{ count: number }>(url.toString())).data;
+
+  return data?.count || null;
+}
+
 export async function getActiveStructures(): Promise<ShortStructure[]> {
   const url = `${getApiURL()}/structures/?active=1`;
   return (await fetchData<ShortStructure[]>(url)).data;

--- a/front/src/lib/requests/structures.ts
+++ b/front/src/lib/requests/structures.ts
@@ -79,9 +79,23 @@ export async function getActiveStructureCount(): Promise<number | null> {
   return data?.count || null;
 }
 
-export async function getActiveStructures(): Promise<ShortStructure[]> {
-  const url = `${getApiURL()}/structures/?active=1`;
-  return (await fetchData<ShortStructure[]>(url)).data;
+export async function getActiveStructures({
+  pageSize,
+  page,
+}: {
+  pageSize: number;
+  page: number;
+}): Promise<ShortStructure[] | null> {
+  const url = new URL("/structures/", getApiURL());
+
+  url.searchParams.append("active", "1");
+  url.searchParams.append("page_size", pageSize.toString());
+  url.searchParams.append("page", page.toString());
+
+  const data = (await fetchData<{ results: ShortStructure[] }>(url.toString()))
+    .data;
+
+  return data?.results || null;
 }
 
 export async function getStructure(slug: string): Promise<Structure | null> {

--- a/front/src/lib/utils/date.ts
+++ b/front/src/lib/utils/date.ts
@@ -12,3 +12,8 @@ export function formatLongDate(dateString: string) {
     year: "numeric",
   });
 }
+
+export function toISODate(apiDate: string) {
+  const date = new Date(apiDate).toISOString();
+  return date.slice(0, date.indexOf("T"));
+}

--- a/front/src/lib/utils/date.ts
+++ b/front/src/lib/utils/date.ts
@@ -14,6 +14,10 @@ export function formatLongDate(dateString: string) {
 }
 
 export function toISODate(apiDate: string) {
-  const date = new Date(apiDate).toISOString();
-  return date.slice(0, date.indexOf("T"));
+  const date = new Date(apiDate);
+  if (isNaN(date.getTime())) {
+    return "";
+  }
+  const isoDateString = date.toISOString();
+  return isoDateString.slice(0, isoDateString.indexOf("T"));
 }

--- a/front/src/routes/(endpoints)/sitemap-services-[page].xml/+server.ts
+++ b/front/src/routes/(endpoints)/sitemap-services-[page].xml/+server.ts
@@ -1,0 +1,56 @@
+import { error } from "@sveltejs/kit";
+
+import { SITEMAP_PAGE_SIZE } from "$lib/consts";
+import { CANONICAL_URL, ENVIRONMENT } from "$lib/env";
+import { getPublishedServices } from "$lib/requests/services";
+
+import type { RequestHandler } from "./$types";
+
+function toISODate(apiDate) {
+  const date = new Date(apiDate).toISOString();
+  return date.slice(0, date.indexOf("T"));
+}
+
+async function getUrlEntries(page: number) {
+  const publishedServices = await getPublishedServices({
+    pageSize: SITEMAP_PAGE_SIZE,
+    page: page,
+  });
+
+  if (!publishedServices) {
+    return "";
+  }
+
+  return publishedServices
+    .map(
+      (service) =>
+        `<url>
+      <loc>${CANONICAL_URL}/services/${service.slug}</loc>
+      <lastmod>${toISODate(service.modificationDate)}</lastmod>
+      <priority>0.5</priority>
+    </url>`
+    )
+    .join("\n");
+}
+
+async function getUrlSet(page: number) {
+  return `
+  <?xml version="1.0" encoding="UTF-8" ?>
+  <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+    ${await getUrlEntries(page)}
+  </urlset>`.trim();
+}
+
+export const GET: RequestHandler = async ({ params }) => {
+  if (!["production", "local", "dev"].includes(ENVIRONMENT)) {
+    error(404, "Page Not Found");
+  }
+
+  const urlSet = await getUrlSet(Number(params.page));
+
+  return new Response(urlSet, {
+    headers: {
+      "Content-Type": "application/xml",
+    },
+  });
+};

--- a/front/src/routes/(endpoints)/sitemap-services-[page].xml/+server.ts
+++ b/front/src/routes/(endpoints)/sitemap-services-[page].xml/+server.ts
@@ -12,16 +12,16 @@ function toISODate(apiDate) {
 }
 
 async function getUrlEntries(page: number) {
-  const publishedServices = await getPublishedServices({
+  const services = await getPublishedServices({
     pageSize: SITEMAP_PAGE_SIZE,
     page: page,
   });
 
-  if (!publishedServices) {
+  if (!services) {
     return "";
   }
 
-  return publishedServices
+  return services.results
     .map(
       (service) =>
         `<url>

--- a/front/src/routes/(endpoints)/sitemap-services-[page].xml/+server.ts
+++ b/front/src/routes/(endpoints)/sitemap-services-[page].xml/+server.ts
@@ -3,13 +3,9 @@ import { error } from "@sveltejs/kit";
 import { SITEMAP_PAGE_SIZE } from "$lib/consts";
 import { CANONICAL_URL, ENVIRONMENT } from "$lib/env";
 import { getPublishedServices } from "$lib/requests/services";
+import { toISODate } from "$lib/utils/date";
 
 import type { RequestHandler } from "./$types";
-
-function toISODate(apiDate) {
-  const date = new Date(apiDate).toISOString();
-  return date.slice(0, date.indexOf("T"));
-}
 
 async function getUrlEntries(page: number) {
   const services = await getPublishedServices({

--- a/front/src/routes/(endpoints)/sitemap-services-[page].xml/+server.ts
+++ b/front/src/routes/(endpoints)/sitemap-services-[page].xml/+server.ts
@@ -1,7 +1,5 @@
-import { error } from "@sveltejs/kit";
-
 import { SITEMAP_PAGE_SIZE } from "$lib/consts";
-import { CANONICAL_URL, ENVIRONMENT } from "$lib/env";
+import { CANONICAL_URL } from "$lib/env";
 import { getPublishedServices } from "$lib/requests/services";
 import { toISODate } from "$lib/utils/date";
 
@@ -38,10 +36,6 @@ async function getUrlSet(page: number) {
 }
 
 export const GET: RequestHandler = async ({ params }) => {
-  if (!["production", "local", "dev"].includes(ENVIRONMENT)) {
-    error(404, "Page Not Found");
-  }
-
   const urlSet = await getUrlSet(Number(params.page));
 
   return new Response(urlSet, {

--- a/front/src/routes/(endpoints)/sitemap-structures-[page].xml/+server.ts
+++ b/front/src/routes/(endpoints)/sitemap-structures-[page].xml/+server.ts
@@ -1,7 +1,5 @@
-import { error } from "@sveltejs/kit";
-
 import { SITEMAP_PAGE_SIZE } from "$lib/consts";
-import { CANONICAL_URL, ENVIRONMENT } from "$lib/env";
+import { CANONICAL_URL } from "$lib/env";
 import { getActiveStructures } from "$lib/requests/structures";
 import { toISODate } from "$lib/utils/date";
 
@@ -38,10 +36,6 @@ async function getUrlSet(page: number) {
 }
 
 export const GET: RequestHandler = async ({ params }) => {
-  if (!["production", "local", "dev"].includes(ENVIRONMENT)) {
-    error(404, "Page Not Found");
-  }
-
   const urlSet = await getUrlSet(Number(params.page));
 
   return new Response(urlSet, {

--- a/front/src/routes/(endpoints)/sitemap-structures-[page].xml/+server.ts
+++ b/front/src/routes/(endpoints)/sitemap-structures-[page].xml/+server.ts
@@ -1,0 +1,56 @@
+import { error } from "@sveltejs/kit";
+
+import { SITEMAP_PAGE_SIZE } from "$lib/consts";
+import { CANONICAL_URL, ENVIRONMENT } from "$lib/env";
+import { getActiveStructures } from "$lib/requests/structures";
+
+import type { RequestHandler } from "./$types";
+
+function toISODate(apiDate) {
+  const date = new Date(apiDate).toISOString();
+  return date.slice(0, date.indexOf("T"));
+}
+
+async function getUrlEntries(page: number) {
+  const activeStructures = await getActiveStructures({
+    pageSize: SITEMAP_PAGE_SIZE,
+    page: page,
+  });
+
+  if (!activeStructures) {
+    return "";
+  }
+
+  return activeStructures
+    .map(
+      (structure) =>
+        `<url>
+      <loc>${CANONICAL_URL}/structures/${structure.slug}</loc>
+      <lastmod>${toISODate(structure.modificationDate)}</lastmod>
+      <priority>0.7</priority>
+    </url>`
+    )
+    .join("\n");
+}
+
+async function getUrlSet(page: number) {
+  return `
+  <?xml version="1.0" encoding="UTF-8" ?>
+  <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+    ${await getUrlEntries(page)}
+  </urlset>`.trim();
+}
+
+export const GET: RequestHandler = async ({ params }) => {
+  if (!["production", "local", "dev"].includes(ENVIRONMENT)) {
+    error(404, "Page Not Found");
+  }
+
+  const urlSet = await getUrlSet(Number(params.page));
+
+  return new Response(urlSet, {
+    headers: {
+      "Content-Type": "application/xml",
+    },
+  });
+};

--- a/front/src/routes/(endpoints)/sitemap-structures-[page].xml/+server.ts
+++ b/front/src/routes/(endpoints)/sitemap-structures-[page].xml/+server.ts
@@ -3,13 +3,9 @@ import { error } from "@sveltejs/kit";
 import { SITEMAP_PAGE_SIZE } from "$lib/consts";
 import { CANONICAL_URL, ENVIRONMENT } from "$lib/env";
 import { getActiveStructures } from "$lib/requests/structures";
+import { toISODate } from "$lib/utils/date";
 
 import type { RequestHandler } from "./$types";
-
-function toISODate(apiDate) {
-  const date = new Date(apiDate).toISOString();
-  return date.slice(0, date.indexOf("T"));
-}
 
 async function getUrlEntries(page: number) {
   const structures = await getActiveStructures({

--- a/front/src/routes/(endpoints)/sitemap-structures-[page].xml/+server.ts
+++ b/front/src/routes/(endpoints)/sitemap-structures-[page].xml/+server.ts
@@ -12,16 +12,16 @@ function toISODate(apiDate) {
 }
 
 async function getUrlEntries(page: number) {
-  const activeStructures = await getActiveStructures({
+  const structures = await getActiveStructures({
     pageSize: SITEMAP_PAGE_SIZE,
     page: page,
   });
 
-  if (!activeStructures) {
+  if (!structures) {
     return "";
   }
 
-  return activeStructures
+  return structures.results
     .map(
       (structure) =>
         `<url>

--- a/front/src/routes/(endpoints)/sitemap.xml/+server.ts
+++ b/front/src/routes/(endpoints)/sitemap.xml/+server.ts
@@ -1,7 +1,5 @@
-import { error } from "@sveltejs/kit";
-
 import { SITEMAP_PAGE_SIZE } from "$lib/consts";
-import { CANONICAL_URL, ENVIRONMENT } from "$lib/env";
+import { CANONICAL_URL } from "$lib/env";
 import { getPublishedServices } from "$lib/requests/services";
 import { getActiveStructures } from "$lib/requests/structures";
 
@@ -54,17 +52,10 @@ async function getSitemapIndex() {
 
 export async function GET() {
   const sitemapIndex = await getSitemapIndex();
-  if (
-    ENVIRONMENT === "production" ||
-    ENVIRONMENT === "local" ||
-    ENVIRONMENT === "dev"
-  ) {
-    return new Response(sitemapIndex, {
-      headers: {
-        "Content-Type": "application/xml",
-      },
-    });
-  } else {
-    error(404, "Page Not Found");
-  }
+
+  return new Response(sitemapIndex, {
+    headers: {
+      "Content-Type": "application/xml",
+    },
+  });
 }

--- a/front/src/routes/(endpoints)/sitemap.xml/+server.ts
+++ b/front/src/routes/(endpoints)/sitemap.xml/+server.ts
@@ -3,6 +3,26 @@ import { error } from "@sveltejs/kit";
 import { SITEMAP_PAGE_SIZE } from "$lib/consts";
 import { CANONICAL_URL, ENVIRONMENT } from "$lib/env";
 import { getActiveStructureCount } from "$lib/requests/structures";
+import { getPublishedServiceCount } from "$lib/requests/services";
+
+async function getServiceSitemaps() {
+  const serviceCount = await getPublishedServiceCount();
+
+  if (serviceCount === null) {
+    return "";
+  }
+
+  const pageCount = Math.ceil(serviceCount / SITEMAP_PAGE_SIZE);
+
+  return Array.from({ length: pageCount })
+    .map(
+      (_item, index) =>
+        `<sitemap>
+           <loc>${CANONICAL_URL}/sitemap-services-${index + 1}.xml</loc>
+         </sitemap>`
+    )
+    .join("\n");
+}
 
 async function getStructureSitemaps() {
   const structureCount = await getActiveStructureCount();
@@ -17,7 +37,7 @@ async function getStructureSitemaps() {
     .map(
       (_item, index) =>
         `<sitemap>
-           <loc>${CANONICAL_URL}/sitemap-structures-${index + 1}.xml</loc>
+           <loc>${CANONICAL_URL}/sitemap-services-${index + 1}.xml</loc>
          </sitemap>`
     )
     .join("\n");
@@ -27,6 +47,7 @@ async function getSitemapIndex() {
   return `
   <?xml version="1.0" encoding="UTF-8" ?>
   <sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+    ${await getServiceSitemaps()}
     ${await getStructureSitemaps()}
   </sitemapindex>`.trim();
 }

--- a/front/src/routes/(endpoints)/sitemap.xml/+server.ts
+++ b/front/src/routes/(endpoints)/sitemap.xml/+server.ts
@@ -2,8 +2,8 @@ import { error } from "@sveltejs/kit";
 
 import { SITEMAP_PAGE_SIZE } from "$lib/consts";
 import { CANONICAL_URL, ENVIRONMENT } from "$lib/env";
-import { getActiveStructureCount } from "$lib/requests/structures";
 import { getPublishedServiceCount } from "$lib/requests/services";
+import { getActiveStructures } from "$lib/requests/structures";
 
 async function getServiceSitemaps() {
   const serviceCount = await getPublishedServiceCount();
@@ -25,19 +25,19 @@ async function getServiceSitemaps() {
 }
 
 async function getStructureSitemaps() {
-  const structureCount = await getActiveStructureCount();
+  const structures = await getActiveStructures({ page: 1, pageSize: 1 });
 
-  if (structureCount === null) {
+  if (!structures) {
     return "";
   }
 
-  const pageCount = Math.ceil(structureCount / SITEMAP_PAGE_SIZE);
+  const pageCount = Math.ceil(structures.count / SITEMAP_PAGE_SIZE);
 
   return Array.from({ length: pageCount })
     .map(
       (_item, index) =>
         `<sitemap>
-           <loc>${CANONICAL_URL}/sitemap-services-${index + 1}.xml</loc>
+           <loc>${CANONICAL_URL}/sitemap-structures-${index + 1}.xml</loc>
          </sitemap>`
     )
     .join("\n");

--- a/front/src/routes/(endpoints)/sitemap.xml/+server.ts
+++ b/front/src/routes/(endpoints)/sitemap.xml/+server.ts
@@ -2,17 +2,17 @@ import { error } from "@sveltejs/kit";
 
 import { SITEMAP_PAGE_SIZE } from "$lib/consts";
 import { CANONICAL_URL, ENVIRONMENT } from "$lib/env";
-import { getPublishedServiceCount } from "$lib/requests/services";
+import { getPublishedServices } from "$lib/requests/services";
 import { getActiveStructures } from "$lib/requests/structures";
 
 async function getServiceSitemaps() {
-  const serviceCount = await getPublishedServiceCount();
+  const services = await getPublishedServices({ page: 1, pageSize: 1 });
 
-  if (serviceCount === null) {
+  if (!services) {
     return "";
   }
 
-  const pageCount = Math.ceil(serviceCount / SITEMAP_PAGE_SIZE);
+  const pageCount = Math.ceil(services.count / SITEMAP_PAGE_SIZE);
 
   return Array.from({ length: pageCount })
     .map(


### PR DESCRIPTION
https://trello.com/c/2MXHfwXs/323-g%C3%A9n%C3%A9ration-de-multiples-fichiers-sitemap-contenant-tous-les-services-et-toutes-les-structures

Documentation Google sur le fichier d'index de sitemaps : https://developers.google.com/search/docs/crawling-indexing/sitemaps/large-sitemaps?hl=fr

Les ViewSet DRF pour les structures et services supportaient déjà une pagination optionnelle. Je l'exploite pour paginer le sitemap.

Le chemin `/sitemap.xml` indexe les sous-sitemaps des services et structures.

Le chemin `/sitemap-services-[page].xml` affiche une page de sitemap pour les services.

Le chemin `/sitemap-structures-[page].xml` affiche une page de sitemap pour les structures.

J'ai enlevé le chemin statique `/contribuer` qui ne me semble pas utile car navigable naturellement.

J'ai supprimé le test sur l'environnement qui vise, je pense, à ne pas générer de `sitemap.xml` pour staging. Il me semble inutile car `robots.txt` empêche déjà l'indexation. Ainsi, on pourra tester le sitemap en staging.