### PR TITLE
ci(pr): Ajout d'une action GitHub de validation du titre de la PR

### DIFF
--- a/.github/workflows/lint-pr.yml
+++ b/.github/workflows/lint-pr.yml
@@ -1,0 +1,21 @@
+name: "Lint PR"
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - synchronize
+      - reopened
+
+permissions:
+  pull-requests: read
+
+jobs:
+  main:
+    name: Valide le titre de la PR
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
On utilise [action-semantic-pull-request](https://github.com/amannn/action-semantic-pull-request). J'ai juste recopié la configuration proposée et traduit le nom de la tâche en français.

L'action ne sera déclenchée qu'une fois présente dans main dû à l'utilisation de [pull_request_target](https://docs.github.com/en/actions/reference/events-that-trigger-workflows#pull_request_target).

https://trello.com/c/3KDV7wMk/332-ci-ajout-dune-action-de-validation-du-titre-de-la-pr-action-semantic-pull-request