### PR TITLE
style: Uniformisation de taille de police

### DIFF
--- a/front/src/lib/components/specialized/services/display/service-duration.svelte
+++ b/front/src/lib/components/specialized/services/display/service-duration.svelte
@@ -18,9 +18,15 @@
   {#if !isValid}
     <p>Données non renseignées</p>
   {:else}
-    <p>
+    <p class="">
       {service.durationWeeklyHours} heure(s) sur {service.durationWeeks} semaine(s),
       soit {totalHours} heure(s) au total.
     </p>
   {/if}
 </div>
+
+<style lang="postcss">
+  p {
+    @apply m-s0 text-f16 text-gray-text;
+  }
+</style>

--- a/front/src/lib/components/specialized/services/display/service-duration.svelte
+++ b/front/src/lib/components/specialized/services/display/service-duration.svelte
@@ -18,7 +18,7 @@
   {#if !isValid}
     <p>Données non renseignées</p>
   {:else}
-    <p class="">
+    <p>
       {service.durationWeeklyHours} heure(s) sur {service.durationWeeks} semaine(s),
       soit {totalHours} heure(s) au total.
     </p>

--- a/front/src/lib/components/specialized/services/display/service-key-informations.svelte
+++ b/front/src/lib/components/specialized/services/display/service-key-informations.svelte
@@ -78,7 +78,7 @@
   <hr class="mb-s10 mt-s20" />
 
   <div>
-    <h3 class="!mb-s10 text-f17">
+    <h3 class="!mb-s10">
       <span class="mr-s8 h-s24 w-s24 fill-current">
         {@html listCheckIcon}
       </span>
@@ -90,9 +90,9 @@
   <hr class="mb-s10 mt-s20" />
 
   {#if service.durationWeeklyHours && service.durationWeeks}
-    <div>
-      <h3 class="!mb-s10 text-f17">
-        <span class="mr-s8 h-s24 w-s24 fill-current">
+    <div class="flex-1">
+      <h3>
+        <span class="mr-s8 h-s24 w-s24 shrink-0 self-baseline fill-current">
           {@html timerFlashIcon}
         </span>
         Durée de la prestation


### PR DESCRIPTION
La section <ServiceDuration/> étant un nouveau composant, elle ne bénéficie pas des styles inline pour les éléments `p` défini dans son composant parent.

Ce commit permet de conserer le même comportement.

Avant : 
<img width="509" alt="Capture_d’écran_2025-01-02_à_09 52 57" src="https://github.com/user-attachments/assets/1f200742-a6a6-41f0-b13e-6e5e45f6a982" />


Après : 
<img width="753" alt="image" src="https://github.com/user-attachments/assets/4d5732ec-6090-434e-a267-67e9aae28450" />

