### PR TITLE
chore(deps): MaJ de Django vers la version 4.2.18

### DIFF
--- a/back/requirements/base.txt
+++ b/back/requirements/base.txt
@@ -1,6 +1,6 @@
 data-inclusion-schema==0.19.0
 dj-database-url==2.3.0
-Django==4.2.17
+Django==4.2.18
 django-cors-headers==4.6.0
 django-csp==3.8
 django-filter==24.3


### PR DESCRIPTION
Voir :
https://www.djangoproject.com/weblog/2025/jan/14/security-releases/
