### PR TITLE
build: Renommage des Pull Request générées par Dependabot pour respecter Conventionnal Commmit

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,7 +10,7 @@ updates:
     schedule:
       interval: "weekly"
     commit-message:
-      prefix: "requirement"
+      prefix: "build"
       prefix-development: "dev requirement"
 
   - package-ecosystem: "npm"
@@ -18,5 +18,5 @@ updates:
     schedule:
       interval: "weekly"
     commit-message:
-      prefix: "requirement"
+      prefix: "build"
       prefix-development: "dev requirement"


### PR DESCRIPTION
### Problème

Les PR générées par Dependabot sont préfxiées "requirement:" ce qui fait échouer l'action de vérification du titre (basée sur conventionnal commit)

### Solution

Modifier la config de Dependabot dans le fichier `dependabot.yaml`.

On part sur "build:" d'après notre interprétation de https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#-commit-message-guidelines