### PR TITLE
fix: affichage du fond de carte (directive CSP)

### DIFF
--- a/front/svelte.config.js
+++ b/front/svelte.config.js
@@ -22,6 +22,7 @@ const config = {
           "https://sentry.gip-inclusion.org",
           "https://sentry.gip-inclusion.cloud-ed.fr",
           "https://api-adresse.data.gouv.fr/",
+          "https://openmaptiles.data.gouv.fr",
           "https://openmaptiles.geo.data.gouv.fr/",
           "https://openmaptiles.github.io/osm-bright-gl-style/",
           "https://matomo.inclusion.beta.gouv.fr",


### PR DESCRIPTION
Le fond de carte ne s'affichait plus. Il semble que l'URL a changé. Ajout de l'URL dans les directives CSP.