### PR TITLE
fix: sélectionne le filtre En présentiel par défaut lorsque la recherche est actualisée

### DIFF
--- a/front/src/routes/recherche/+page.svelte
+++ b/front/src/routes/recherche/+page.svelte
@@ -55,7 +55,7 @@
       kinds: [],
       fundingLabels: [],
       feeConditions: [],
-      locationKinds: [],
+      locationKinds: ["en-presentiel"],
     };
   }
 


### PR DESCRIPTION
Problème : le filtre par défaut _En présentiel_ était désélectionné lors de l'actualisation de la recherche.

Solution : sélection du filtre _En présentiel_ quand la recherche est actualisée (fonction `resetFilters()`).


https://trello.com/c/Y76POaJN/348-filtre-en-pr%C3%A9sentiel-coch%C3%A9-par-d%C3%A9faut