### PR TITLE
feat: Ajout d'un indicateur de suivi de complétion de la durée de prestation d'un service

### DIFF
--- a/back/queries/metabase/01-base/0020_mb_all_service.sql
+++ b/back/queries/metabase/01-base/0020_mb_all_service.sql
@@ -24,6 +24,8 @@ select
     services_service.city,
     services_service.recurrence,
     services_service.suspension_date,
+    services_service.duration_weekly_hours,
+    services_service.duration_weeks,
     services_service.creation_date,
     services_service.modification_date,
     services_service.creator_id,


### PR DESCRIPTION
### 🍣 Problème

On souhaite suivre le taux de complétion des champs déclaratifs de durée de la prestation d'un service dans Metabse.

Ces champs – `services_service.duration_weekly_hours` et `services_service.duration_weeks` – ne sont pas remontés par défaut.

### 🦄 Solution

1. Ajouter les champs dans la table analytique `mb_all_services` (dans le package `back/queries`).
2. Les exploiter dans Metabase, à travers une nouvelle question

### Détail

A priori, pas besoin de faire une table précalculée spécifique. Metabase accepte jusqu'à 100 segments. Un segment ici correspond à 1 mois_année. 

Pour les départements, ce n'est qu'un filtre (une clause `WHERE`).

<img width="1624" alt="image" src="https://github.com/user-attachments/assets/8d615657-7fe0-4024-b901-b5d8d50ee0b9" />
