### PR TITLE
fix: suppression du formatage des horaires du service

### DIFF
--- a/front/src/lib/components/specialized/services/display/extended-service-key-informations.svelte
+++ b/front/src/lib/components/specialized/services/display/extended-service-key-informations.svelte
@@ -10,9 +10,7 @@
   import type { Service, ServicesOptions, ShortService } from "$lib/types";
   import { getLabelFromValue } from "$lib/utils/choice";
   import { shortenString } from "$lib/utils/misc";
-  import { isValidformatOsmHours } from "$lib/utils/opening-hours";
   import { isNotFreeService } from "$lib/utils/service";
-  import OsmHours from "../../osm-hours.svelte";
 
   export let service: Service | ShortService;
   export let servicesOptions: ServicesOptions;
@@ -90,11 +88,7 @@
         Fréquence et horaires
       </h3>
       <p>
-        {#if isValidformatOsmHours(service.recurrence)}
-          <OsmHours osmHours={service.recurrence} />
-        {:else}
-          {service.recurrence}
-        {/if}
+        {service.recurrence}
       </p>
     </div>
   {/if}

--- a/front/src/lib/components/specialized/services/display/service-key-informations.svelte
+++ b/front/src/lib/components/specialized/services/display/service-key-informations.svelte
@@ -14,9 +14,7 @@
   import type { Service, ServicesOptions } from "$lib/types";
   import { getLabelFromValue } from "$lib/utils/choice";
   import { shortenString } from "$lib/utils/misc";
-  import { isValidformatOsmHours } from "$lib/utils/opening-hours";
   import { isNotFreeService } from "$lib/utils/service";
-  import OsmHours from "../../osm-hours.svelte";
   import ServiceDuration from "./service-duration.svelte";
   import SubcategoryList from "./subcategory-list.svelte";
 
@@ -197,11 +195,7 @@
           Fréquence et horaires
         </h3>
         <p>
-          {#if isValidformatOsmHours(service.recurrence)}
-            <OsmHours osmHours={service.recurrence} />
-          {:else}
-            {service.recurrence}
-          {/if}
+          {service.recurrence}
         </p>
       </div>
     {/if}

--- a/front/src/lib/utils/opening-hours.ts
+++ b/front/src/lib/utils/opening-hours.ts
@@ -1,5 +1,4 @@
 import type { DayPeriod, DayPrefix, OsmDay, OsmOpeningHours } from "$lib/types";
-import openingHours from "opening_hours";
 
 export const INVALID_OPENING_HOURS_MARKER = "##INVALID##";
 
@@ -178,15 +177,6 @@ function formatHour(hour: string) {
   hour = hour.replace(/:/g, "h");
   hour = hour.replace(/,/g, " / ");
   return hour;
-}
-
-export function isValidformatOsmHours(value: string) {
-  try {
-    new openingHours(value, null, { locale: "fr" });
-    return true;
-  } catch {
-    return false;
-  }
 }
 
 export function formatOsmHours(value: string) {


### PR DESCRIPTION
Les horaires d’un service sont dans certains cas interprétés comme étant au format d’horaires OSM. Seulement, cela n’est pas indiqué explicitement et génère des faux horaires formatés.

Il a été décidé de supprimer ce formatage. Seul le contenu brut du champ doit être affiché.

Avant :
![image](https://github.com/user-attachments/assets/af0245d9-0abe-4eb1-8652-1fe064f66e24)

Après :
![image](https://github.com/user-attachments/assets/6f72834a-0211-427c-883e-4f8a14e8d9f6)
