### PR TITLE
fix: affichage inconditionnel du bouton Voir la fiche détaillée sur les résultats de recherche

### DIFF
--- a/front/src/routes/recherche/search-result.svelte
+++ b/front/src/routes/recherche/search-result.svelte
@@ -107,14 +107,12 @@
               Source&nbsp;: {result.diSourceDisplay}, via data·inclusion
             </div>
           {/if}
-          {#if result.isOrientable && result.coachOrientationModes?.includes("formulaire-dora")}
-            <LinkButton
-              to={servicePagePath}
-              label="Orienter votre bénéficiaire"
-              secondary
-              small
-            />
-          {/if}
+          <LinkButton
+            to={servicePagePath}
+            label="Voir la fiche détaillée"
+            secondary
+            small
+          />
         </div>
       {/if}
     </div>


### PR DESCRIPTION
À l'époque où le bouton _Orienter votre bénéficiaire_ sur un résultat de recherche menait au formulaire Dora, il était affiché conditionnellement à l'orientabilité du service via formulaire Dora.

Depuis, le bouton a changé pour mener a la fiche service au lieu du formulaire Dora. Son affichage conditionnel ne faisait plus sens.

Cette PR affiche le bouton de façon inconditionnelle et met à jour son libellé.