### PR TITLE
fix(front): ne pas afficher "null" quand l'adresse principale n'est pas définie

### DIFF
--- a/front/src/lib/components/specialized/services/display/service-key-informations.svelte
+++ b/front/src/lib/components/specialized/services/display/service-key-informations.svelte
@@ -158,7 +158,9 @@
           {#if service.locationKinds.includes("en-presentiel")}
             <p class="mb-s6">
               Présentiel,<br />
-              {service.address1}{#if service.address2}, {service.address2}{/if},
+              {#if service.address1}
+                {service.address1}{#if service.address2}, {service.address2}{/if},
+              {/if}
               {service.postalCode}&nbsp;{service.city}
             </p>
           {/if}


### PR DESCRIPTION
[Ticket [256]](https://trello.com/c/0T55msku/256-fiche-services-services-di-avec-adresse-null)

### Problème

Si l'adresse 1 n'est pas définie pour un service, alors l'écran affiche "null".

![image](https://github.com/user-attachments/assets/f89e206b-348d-48ae-9344-79b42f3c09a2)

### Solution

Ne pas afficher l'adresse (ni 1 ni 2, même si elle est définie) si l'adresse principale n'est pas définie.

### Test

Recherche : **Lille (59)** + **Équipement et alimentation**

http://localhost:3000/services/di--soliguide--62568b2e16f4f04fa2486c53?searchId=149318