### PR TITLE
feat: Supression du choix de label national "Conseil départemental"

### DIFF
--- a/back/dora/structures/constants.py
+++ b/back/dora/structures/constants.py
@@ -15,4 +15,4 @@ RESTRICTED_STRUCTURE_TYPOLOGIES = (Typologie.FT,)
 # Note / TODO :
 # ce sont des `EnumModel`, donc pas de typage.
 # Il serait intéressant de les avoir sous forme de fixture.
-RESTRICTED_NATIONAL_LABELS = ("adie", "cap-emploi-reseau-cheops", "france-travail", "conseil-departemental")
+RESTRICTED_NATIONAL_LABELS = ("adie", "cap-emploi-reseau-cheops", "conseil-departemental", "france-travail")

--- a/back/dora/structures/constants.py
+++ b/back/dora/structures/constants.py
@@ -15,4 +15,4 @@ RESTRICTED_STRUCTURE_TYPOLOGIES = (Typologie.FT,)
 # Note / TODO :
 # ce sont des `EnumModel`, donc pas de typage.
 # Il serait intéressant de les avoir sous forme de fixture.
-RESTRICTED_NATIONAL_LABELS = ("adie", "cap-emploi-reseau-cheops", "france-travail")
+RESTRICTED_NATIONAL_LABELS = ("adie", "cap-emploi-reseau-cheops", "france-travail", "conseil-departemental")

--- a/back/dora/structures/migrations/0073_add_label_conseil_departemental.py
+++ b/back/dora/structures/migrations/0073_add_label_conseil_departemental.py
@@ -1,0 +1,22 @@
+from django.db import migrations
+
+
+def add_label_conseil_departemental(apps, schema_editor):
+    StructureNationalLabel = apps.get_model("structures", "StructureNationalLabel")
+
+    if not StructureNationalLabel.objects.filter(
+        value="conseil-departemental"
+    ).exists():
+        StructureNationalLabel.objects.create(
+            value="conseil-departemental", label="Conseil départemental"
+        )
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("structures", "0072_alter_structure_name"),
+    ]
+
+    operations = [
+        migrations.RunPython(add_label_conseil_departemental, migrations.RunPython.noop)
+    ]


### PR DESCRIPTION
### 🌍 Contexte

**Définition** 

Un label est un regroupement de Structures, par réseau ("France Travail", "ADIE") ou typologie ("Conseil départemental", "Mission locale", "SIAE"). Avant on avait typologie et label, mais on ne s'y fie plus ,bien qu'on le laisse vivre.

**Cas d'usage**

En tant que gestionnaire, lorsque j'édite la fiche d'une structure, je peux identifier des labels nationaux grâce à une liste déroulante multi-choix.

Historiquement, ces labels étaient laissés à la main complète des utilisateurs. Avec le temps, ça a créé des soucis de doublons, de variations inappropriées ou d'incohérence. 

Un système de restriction a été mis en place (dans les [PR dora-back#353](https://github.com/gip-inclusion/dora-back/pull/353) et [dora-front#438](https://github.com/gip-inclusion/dora-front/pull/438)), qui permet de faire en sorte que certains labels spécifiques ne puissent être sélectionné par l'utilisateur, mais gérés exclusivement par les admins DORA, depuis le back-office.

On bloque là où on est sûrs d'avoir la maîtrise de qui a le "droit" à ce label :
- nombre fini et non mouvant de structures (ex : conseils départementaux/FT  pour éviter que des prestataires s'auto labellisent CD/FT alors qu'ils ne sont pas de CD/FT par ex)
- nombre fini et peu mouvant de structures (ex : ADIE, avec qui on a un bon contact et qui à passe par moi quand des structures sont a enlever / rajouter du label)

L'intention de tout ceci est de viser un dataset le plus petit, propre, qualitatif et maîtrisable possible.

### 🍣 Problème

On souhaite empêcher les gestionnaires de saisir en autonomie le label "Conseil départemental", au même titre que d'autres structures telles que les agences France Travail, Cap Emploi ou ADIE.

### 🎼 Solution

Faire en sorte que le label Conseil Départemental ne soit plus sélectionnable par les utilisateurs dans la liste déroulante (même process que pour les autres labels déjà “bloqués”, comme "france-travail", "adie", "cap-emploi-reseau-cheops").

Techniquement, ces labels nationaux particuliers, sont inscrits en dur dans le code, dans le fichier `back/structures.constants.py`, dans la constante `RESTRICTED_NATIONAL_LABELS`. Il s'agit d'un tableau contenant la propriété "value", associée à des entrées de type `StructureNationalLabel(EnumModel)`.

Chaque StructureNationalLabel à restreindre est ajoutée sous forme de liste en tant que champs spécifique dans le endpoint `GET /structure-options`, utilisé côté front-end comme un pré-filtre des choix possibles.

<img width="1512" alt="image" src="https://github.com/user-attachments/assets/3d8e0b69-63f7-4648-ae0b-c8c43e3dd5eb" />

> ⚠️ En résumé : nous avons une règle de gestion (permettre ou non la saisie d'une valeur) qui repose sur une constante, dont chaque valeur est à considérer avec des données en base. A noter que si une valeur de la constante n'existe pas en base, ça ne soulève pas d'erreur.

### 🤖 Implémentation

**TL;DR**

Je voulais faire un truc un peu plus malin, je me suis contenté de faire une migration SQL pour ajouter l'entrée en BDD locale (sachant qu'elle est déjà en prod) et la déclarer dans la constante `RESTRICTED_NATIONAL_LABELS`.

**Détail**

Tout a commencé lorsque j'ai rencontré un souci, dans l'exécution des tests unitaires. 

En prod, il y a bien une entrée `structures_structurenationallabel` qui vaut "conseil-departemental" / "Conseil départemental". Mais pas dans dans les données de développement, construites via les migrations SQL.

En discutant et pour commencer à préparer / anticiper un besoin futur (plus de finesse dans la gestion des labels, par structure, pour les gestionnaires), nous avons évoqué l'idée d'enrichir l'objet `StructureNationalLabel` avec une propriété `is_restricted`.

Problème : la classe actuelle hérite de `back/core.models.EnumModel`. Aucune classe héritée ne l'étend. Ça ne semble pas être quelque chose d'envisagé / couvert / souhaitable. 

Lorsqu'on voudra passer et offrir plus de maîtrise aux gestionnaires de structures, on n'aura donc pas trop d'autre choix que de faire le grand écart direct vers une classe (type table-de-jointure) dédiée.

### 🔎 Test

En tant que gestionnaire d'une structure, accéder au formulaire d'édition de celle-ci.

Dans le champs "Labels nationaux", vérifier que l'entrée "Conseil départemental" n'apparaît pas, et ne peut pas être sélectionnée.

<img width="754" alt="image" src="https://github.com/user-attachments/assets/3d3ab381-bf08-4d76-bbcf-a6a4f1759ed6" />
