### PR TITLE
fix: restauration de la détection et formattage des horaires OSM pour les services DI

### DIFF
--- a/front/src/lib/components/specialized/services/display/extended-service-key-informations.svelte
+++ b/front/src/lib/components/specialized/services/display/extended-service-key-informations.svelte
@@ -10,7 +10,9 @@
   import type { Service, ServicesOptions, ShortService } from "$lib/types";
   import { getLabelFromValue } from "$lib/utils/choice";
   import { shortenString } from "$lib/utils/misc";
+  import { isValidformatOsmHours } from "$lib/utils/opening-hours";
   import { isNotFreeService } from "$lib/utils/service";
+  import OsmHours from "../../osm-hours.svelte";
 
   export let service: Service | ShortService;
   export let servicesOptions: ServicesOptions;
@@ -88,7 +90,11 @@
         Fréquence et horaires
       </h3>
       <p>
-        {service.recurrence}
+        {#if isValidformatOsmHours(service.recurrence)}
+          <OsmHours osmHours={service.recurrence} />
+        {:else}
+          {service.recurrence}
+        {/if}
       </p>
     </div>
   {/if}

--- a/front/src/lib/components/specialized/services/display/extended-service-key-informations.svelte
+++ b/front/src/lib/components/specialized/services/display/extended-service-key-informations.svelte
@@ -17,6 +17,8 @@
   export let service: Service | ShortService;
   export let servicesOptions: ServicesOptions;
   export let display: "sidebar" | "full" = "full";
+
+  $: isDI = "source" in service;
 </script>
 
 <h2 class:text-f23={display === "sidebar"}>Informations clés</h2>
@@ -90,7 +92,7 @@
         Fréquence et horaires
       </h3>
       <p>
-        {#if isValidformatOsmHours(service.recurrence)}
+        {#if isDI && isValidformatOsmHours(service.recurrence)}
           <OsmHours osmHours={service.recurrence} />
         {:else}
           {service.recurrence}

--- a/front/src/lib/components/specialized/services/display/service-key-informations.svelte
+++ b/front/src/lib/components/specialized/services/display/service-key-informations.svelte
@@ -14,7 +14,9 @@
   import type { Service, ServicesOptions } from "$lib/types";
   import { getLabelFromValue } from "$lib/utils/choice";
   import { shortenString } from "$lib/utils/misc";
+  import { isValidformatOsmHours } from "$lib/utils/opening-hours";
   import { isNotFreeService } from "$lib/utils/service";
+  import OsmHours from "../../osm-hours.svelte";
   import ServiceDuration from "./service-duration.svelte";
   import SubcategoryList from "./subcategory-list.svelte";
 
@@ -197,7 +199,11 @@
           Fréquence et horaires
         </h3>
         <p>
-          {service.recurrence}
+          {#if isValidformatOsmHours(service.recurrence)}
+            <OsmHours osmHours={service.recurrence} />
+          {:else}
+            {service.recurrence}
+          {/if}
         </p>
       </div>
     {/if}

--- a/front/src/lib/components/specialized/services/display/service-key-informations.svelte
+++ b/front/src/lib/components/specialized/services/display/service-key-informations.svelte
@@ -23,6 +23,8 @@
   export let service: Service;
   export let servicesOptions: ServicesOptions;
 
+  $: isDI = "source" in service;
+
   // trier les types dans l'ordre d'affichage du formulaire
   $: sortedServiceKindsDisplay = service.kindsDisplay?.sort((a, b) =>
     a.localeCompare(b)
@@ -199,7 +201,7 @@
           Fréquence et horaires
         </h3>
         <p>
-          {#if isValidformatOsmHours(service.recurrence)}
+          {#if isDI && isValidformatOsmHours(service.recurrence)}
             <OsmHours osmHours={service.recurrence} />
           {:else}
             {service.recurrence}

--- a/front/src/lib/utils/opening-hours.ts
+++ b/front/src/lib/utils/opening-hours.ts
@@ -1,4 +1,5 @@
 import type { DayPeriod, DayPrefix, OsmDay, OsmOpeningHours } from "$lib/types";
+import openingHours from "opening_hours";
 
 export const INVALID_OPENING_HOURS_MARKER = "##INVALID##";
 
@@ -177,6 +178,15 @@ function formatHour(hour: string) {
   hour = hour.replace(/:/g, "h");
   hour = hour.replace(/,/g, " / ");
   return hour;
+}
+
+export function isValidformatOsmHours(value: string) {
+  try {
+    new openingHours(value, null, { locale: "fr" });
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 export function formatOsmHours(value: string) {


### PR DESCRIPTION
## Problème

Beaucoup de services DI fournissent le champ `recurrence` au format OSM. Le problème qui avait motivé la suppression de cette détection et formatage est la détection erronée du format OSM sur une valeur saisie sur un service Dora. Or, l'édition de service Dora n’offre pas de formulaire adapté pour la saisie d’horaires au format OSM.

## Solution

Restauration et formatage des horaires OSM pour les services DI seulement.

## Test

Service Dora avec valeur 9h-16h auparavant erronément détectée comme étant au format OSM :

![image](https://github.com/user-attachments/assets/5849753e-52cc-4802-a02c-0fbd65a4db9b)

Service DI utilisant le format OSM :

![image](https://github.com/user-attachments/assets/0558eea1-a33c-49c1-b8eb-f927732f09b5)
