### PR TITLE
feat: modèles : ajout d'une table contenant les modèles de services

### DIFF
--- a/analytics/models/intermediate/_intermediate_models.yml
+++ b/analytics/models/intermediate/_intermediate_models.yml
@@ -1,0 +1,5 @@
+models:
+  - name: int_services_models
+    description:
+      Services créés à partir de modèles.
+      Une ligne par service, il faut donc bien penser à passer par un distinct(id_model) pour obtenir le modèles sans doublons.

--- a/analytics/models/intermediate/int_services_models.sql
+++ b/analytics/models/intermediate/int_services_models.sql
@@ -1,0 +1,18 @@
+SELECT
+    models.id     as model_id,
+    models.name   as model_name,
+    services.id   as service_id,
+    structures.id as structure_id,
+    structures.name,
+    structures.department,
+    structures.postal_code,
+    structures.email,
+    structures.phone
+FROM
+    {{ ref('stg_services_models') }} as models
+LEFT JOIN
+    {{ source('dora', 'services_service') }} as services
+    ON models.id = services.model_id
+LEFT JOIN
+    {{ ref('stg_structure') }} as structures
+    ON models.structure_id = structures.id

--- a/analytics/models/staging/stg_services_models.sql
+++ b/analytics/models/staging/stg_services_models.sql
@@ -1,0 +1,5 @@
+SELECT
+        services.*
+FROM
+        {{ source('dora', 'services_service') }} as services
+WHERE is_model is TRUE


### PR DESCRIPTION
## 🥝 Besoin

Afin de ne pas retomber dans les travers des mauvaises pratiques de metabase, [aka les multiples jointures](https://metabase.dora.inclusion.gouv.fr/question/47-liste-des-modeles-de-service-les-plus-utilises/notebook), besoin d'une table contenant les modèles de services et quelques infos de contact des structures qui les ont créées.


## 🍅 Solution

Création d'une `staging` isolant les modèles et d'une table `intermediate` contenant la liste des modèles et les services y étant associés.


