### PR TITLE
build: MaJ vers Django 4.2.19

### DIFF
--- a/back/requirements/base.txt
+++ b/back/requirements/base.txt
@@ -1,6 +1,6 @@
 data-inclusion-schema==0.20.0
 dj-database-url==2.3.0
-Django==4.2.18
+Django==4.2.19
 django-cors-headers==4.6.0
 django-csp==3.8
 django-filter==24.3


### PR DESCRIPTION
Voir : https://docs.djangoproject.com/en/5.1/releases/4.2.19/

A noter que pour la prochaine MAJ on pourrait prevoir une montée de version vers Django 5.1.x.

Absolument pas indispensable, mais ça évitera de se faire spammer par `dependabot`.