### PR TITLE
build(dependabot): Amélioration de la config Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,12 @@ updates:
     commit-message:
       prefix: "build"
       prefix-development: "build(dev)"
+    groups:
+      minor-and-patch:
+        applies-to: version-updates
+        update-types:
+          - "patch"
+          - "minor"
 
   - package-ecosystem: "npm"
     directory: "/front"
@@ -20,3 +26,10 @@ updates:
     commit-message:
       prefix: "build"
       prefix-development: "build(dev)"
+    groups:
+      minor-and-patch:
+        applies-to: version-updates
+        update-types:
+          - "patch"
+          - "minor"
+

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,7 +11,7 @@ updates:
       interval: "weekly"
     commit-message:
       prefix: "build"
-      prefix-development: "dev requirement"
+      prefix-development: "build(dev)"
 
   - package-ecosystem: "npm"
     directory: "/front"
@@ -19,4 +19,4 @@ updates:
       interval: "weekly"
     commit-message:
       prefix: "build"
-      prefix-development: "dev requirement"
+      prefix-development: "build(dev)"


### PR DESCRIPTION
### Problème 

Tous les lundis, il y a plein de nouvelles PR de type "version upatde". Le plus souvent, il s'agit de versions mineures, qui contiennent des micro-fonctionnalités qui ne nous concernent pas ou ne nous sont pas utiles. 

Le plus souvent encore, nous faisons l'effort de regrouper ces updates au sein d'une seule et même PR front et une autre back.

Autre souci, par défaut Dependabot limite le nombre de PR ouvertes en même temps à 5 (pour le type version update).

### Solution

Dependabot permet de regrouper les version updates au sein de PR uniques ([doc](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/optimizing-pr-creation-version-updates#example-4-grouped-pull-requests-for-minorpatch-updates-and-no-pull-requests-for-major-updates)).

Cette PR propose d'activer cette fonctionnalité et de regrouper toutes les versions update de type minor ou patch par PR.

Cette PR ne couvre pas les versions majeures, qui continueront d'être proposées régulièrement.

Enfin, cette PR en profite pour régler le problème de nommage du titre des PR qui cassent le linting GitHub Action.