### PR TITLE
fix(tailwind): correction des plantages dûs à la mise à niveau de Tailwind CSS

### DIFF
--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -18,7 +18,6 @@
         "@sveltejs/adapter-node": "^5.2.12",
         "@sveltejs/kit": "2.17.1",
         "@sveltejs/vite-plugin-svelte": "^3.1.2",
-        "@tailwindcss/postcss": "^4.0.6",
         "@tailwindcss/typography": "^0.5.16",
         "@tiptap/core": "^2.11.5",
         "@tiptap/extension-link": "^2.11.5",
@@ -39,8 +38,6 @@
         "lint-staged": "^15.4.3",
         "maplibre-gl": "^5.1.0",
         "opening_hours": "^3.8.0",
-        "postcss": "^8.5.2",
-        "postcss-load-config": "^6.0.1",
         "prettier": "^3.5.0",
         "prettier-plugin-svelte": "^3.3.3",
         "prettier-plugin-tailwindcss": "^0.6.11",
@@ -61,18 +58,6 @@
       "engines": {
         "node": ">=18.18",
         "npm": ">=8"
-      }
-    },
-    "node_modules/@alloc/quick-lru": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/@alloc/quick-lru/-/quick-lru-5.2.0.tgz",
-      "integrity": "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==",
-      "dev": true,
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -2381,229 +2366,6 @@
         "@jridgewell/sourcemap-codec": "^1.5.0"
       }
     },
-    "node_modules/@tailwindcss/node": {
-      "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.0.6.tgz",
-      "integrity": "sha512-jb6E0WeSq7OQbVYcIJ6LxnZTeC4HjMvbzFBMCrQff4R50HBlo/obmYNk6V2GCUXDeqiXtvtrQgcIbT+/boB03Q==",
-      "dev": true,
-      "dependencies": {
-        "enhanced-resolve": "^5.18.0",
-        "jiti": "^2.4.2",
-        "tailwindcss": "4.0.6"
-      }
-    },
-    "node_modules/@tailwindcss/oxide": {
-      "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.0.6.tgz",
-      "integrity": "sha512-lVyKV2y58UE9CeKVcYykULe9QaE1dtKdxDEdrTPIdbzRgBk6bdxHNAoDqvcqXbIGXubn3VOl1O/CFF77v/EqSA==",
-      "dev": true,
-      "engines": {
-        "node": ">= 10"
-      },
-      "optionalDependencies": {
-        "@tailwindcss/oxide-android-arm64": "4.0.6",
-        "@tailwindcss/oxide-darwin-arm64": "4.0.6",
-        "@tailwindcss/oxide-darwin-x64": "4.0.6",
-        "@tailwindcss/oxide-freebsd-x64": "4.0.6",
-        "@tailwindcss/oxide-linux-arm-gnueabihf": "4.0.6",
-        "@tailwindcss/oxide-linux-arm64-gnu": "4.0.6",
-        "@tailwindcss/oxide-linux-arm64-musl": "4.0.6",
-        "@tailwindcss/oxide-linux-x64-gnu": "4.0.6",
-        "@tailwindcss/oxide-linux-x64-musl": "4.0.6",
-        "@tailwindcss/oxide-win32-arm64-msvc": "4.0.6",
-        "@tailwindcss/oxide-win32-x64-msvc": "4.0.6"
-      }
-    },
-    "node_modules/@tailwindcss/oxide-android-arm64": {
-      "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-android-arm64/-/oxide-android-arm64-4.0.6.tgz",
-      "integrity": "sha512-xDbym6bDPW3D2XqQqX3PjqW3CKGe1KXH7Fdkc60sX5ZLVUbzPkFeunQaoP+BuYlLc2cC1FoClrIRYnRzof9Sow==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@tailwindcss/oxide-darwin-arm64": {
-      "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-arm64/-/oxide-darwin-arm64-4.0.6.tgz",
-      "integrity": "sha512-1f71/ju/tvyGl5c2bDkchZHy8p8EK/tDHCxlpYJ1hGNvsYihZNurxVpZ0DefpN7cNc9RTT8DjrRoV8xXZKKRjg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@tailwindcss/oxide-darwin-x64": {
-      "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-x64/-/oxide-darwin-x64-4.0.6.tgz",
-      "integrity": "sha512-s/hg/ZPgxFIrGMb0kqyeaqZt505P891buUkSezmrDY6lxv2ixIELAlOcUVTkVh245SeaeEiUVUPiUN37cwoL2g==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@tailwindcss/oxide-freebsd-x64": {
-      "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-freebsd-x64/-/oxide-freebsd-x64-4.0.6.tgz",
-      "integrity": "sha512-Z3Wo8FWZnmio8+xlcbb7JUo/hqRMSmhQw8IGIRoRJ7GmLR0C+25Wq+bEX/135xe/yEle2lFkhu9JBHd4wZYiig==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@tailwindcss/oxide-linux-arm-gnueabihf": {
-      "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm-gnueabihf/-/oxide-linux-arm-gnueabihf-4.0.6.tgz",
-      "integrity": "sha512-SNSwkkim1myAgmnbHs4EjXsPL7rQbVGtjcok5EaIzkHkCAVK9QBQsWeP2Jm2/JJhq4wdx8tZB9Y7psMzHYWCkA==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@tailwindcss/oxide-linux-arm64-gnu": {
-      "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-gnu/-/oxide-linux-arm64-gnu-4.0.6.tgz",
-      "integrity": "sha512-tJ+mevtSDMQhKlwCCuhsFEFg058kBiSy4TkoeBG921EfrHKmexOaCyFKYhVXy4JtkaeeOcjJnCLasEeqml4i+Q==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@tailwindcss/oxide-linux-arm64-musl": {
-      "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-musl/-/oxide-linux-arm64-musl-4.0.6.tgz",
-      "integrity": "sha512-IoArz1vfuTR4rALXMUXI/GWWfx2EaO4gFNtBNkDNOYhlTD4NVEwE45nbBoojYiTulajI4c2XH8UmVEVJTOJKxA==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@tailwindcss/oxide-linux-x64-gnu": {
-      "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.0.6.tgz",
-      "integrity": "sha512-QtsUfLkEAeWAC3Owx9Kg+7JdzE+k9drPhwTAXbXugYB9RZUnEWWx5x3q/au6TvUYcL+n0RBqDEO2gucZRvRFgQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@tailwindcss/oxide-linux-x64-musl": {
-      "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-musl/-/oxide-linux-x64-musl-4.0.6.tgz",
-      "integrity": "sha512-QthvJqIji2KlGNwLcK/PPYo7w1Wsi/8NK0wAtRGbv4eOPdZHkQ9KUk+oCoP20oPO7i2a6X1aBAFQEL7i08nNMA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
-      "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.0.6.tgz",
-      "integrity": "sha512-+oka+dYX8jy9iP00DJ9Y100XsqvbqR5s0yfMZJuPR1H/lDVtDfsZiSix1UFBQ3X1HWxoEEl6iXNJHWd56TocVw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@tailwindcss/oxide-win32-x64-msvc": {
-      "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.0.6.tgz",
-      "integrity": "sha512-+o+juAkik4p8Ue/0LiflQXPmVatl6Av3LEZXpBTfg4qkMIbZdhCGWFzHdt2NjoMiLOJCFDddoV6GYaimvK1Olw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@tailwindcss/postcss": {
-      "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/postcss/-/postcss-4.0.6.tgz",
-      "integrity": "sha512-noTaGPHjGCXTCc487TWnfAEN0VMjqDAecssWDOsfxV2hFrcZR0AHthX7IdY/0xHTg/EtpmIPdssddlZ5/B7JnQ==",
-      "dev": true,
-      "dependencies": {
-        "@alloc/quick-lru": "^5.2.0",
-        "@tailwindcss/node": "^4.0.6",
-        "@tailwindcss/oxide": "^4.0.6",
-        "lightningcss": "^1.29.1",
-        "postcss": "^8.4.41",
-        "tailwindcss": "4.0.6"
-      }
-    },
     "node_modules/@tailwindcss/typography": {
       "version": "0.5.16",
       "resolved": "https://registry.npmjs.org/@tailwindcss/typography/-/typography-0.5.16.tgz",
@@ -4124,8 +3886,9 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
       "integrity": "sha512-pGjwhsmsp4kL2RTz08wcOlGN83otlqHeD/Z5T8GXZB+/YcpQ/dgo+lbU8ZsGxV0HIvqqxo9l7mqYwyYMD9bKDg==",
-      "devOptional": true,
       "license": "Apache-2.0",
+      "optional": true,
+      "peer": true,
       "bin": {
         "detect-libc": "bin/detect-libc.js"
       },
@@ -4220,19 +3983,6 @@
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.4.0.tgz",
       "integrity": "sha512-EC+0oUMY1Rqm4O6LLrgjtYDvcVYTy7chDnM4Q7030tP4Kwj3u/pR6gP9ygnp2CJMK5Gq+9Q2oqmrFJAz01DXjw==",
       "dev": true
-    },
-    "node_modules/enhanced-resolve": {
-      "version": "5.18.1",
-      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.18.1.tgz",
-      "integrity": "sha512-ZSW3ma5GkcQBIpwZTSRAI8N71Uuwgs93IezB7mf7R60tC8ZbJideoDNKjHn2O9KIlx6rkGTTEk1xUCK2E1Y2Yg==",
-      "dev": true,
-      "dependencies": {
-        "graceful-fs": "^4.2.4",
-        "tapable": "^2.2.0"
-      },
-      "engines": {
-        "node": ">=10.13.0"
-      }
     },
     "node_modules/entities": {
       "version": "4.5.0",
@@ -4997,12 +4747,6 @@
       "resolved": "https://registry.npmjs.org/globrex/-/globrex-0.1.2.tgz",
       "integrity": "sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg=="
     },
-    "node_modules/graceful-fs": {
-      "version": "4.2.11",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
-      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
-      "dev": true
-    },
     "node_modules/graphemer": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
@@ -5315,6 +5059,8 @@
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.4.2.tgz",
       "integrity": "sha512-rg9zJN+G4n2nfJl5MW3BMygZX56zKPNVEYYqq7adpmMh4Jn2QNEwhvQlFy6jPVdcod7txZtKHWnyZiA3a0zP7A==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
       }
@@ -5437,8 +5183,9 @@
       "version": "1.29.1",
       "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.29.1.tgz",
       "integrity": "sha512-FmGoeD4S05ewj+AkhTY+D+myDvXI6eL27FjHIjoyUkO/uw7WZD1fBVs0QxeYWa7E17CUHJaYX/RUGISCtcrG4Q==",
-      "devOptional": true,
       "license": "MPL-2.0",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "detect-libc": "^1.0.3"
       },
@@ -5474,6 +5221,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -5494,6 +5242,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -5514,6 +5263,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -5534,6 +5284,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -5554,6 +5305,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -5574,6 +5326,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -5594,6 +5347,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -5614,6 +5368,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -5634,6 +5389,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -5654,6 +5410,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -6445,48 +6202,6 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
-      }
-    },
-    "node_modules/postcss-load-config": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-6.0.1.tgz",
-      "integrity": "sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/postcss/"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "dependencies": {
-        "lilconfig": "^3.1.1"
-      },
-      "engines": {
-        "node": ">= 18"
-      },
-      "peerDependencies": {
-        "jiti": ">=1.21.0",
-        "postcss": ">=8.0.9",
-        "tsx": "^4.8.1",
-        "yaml": "^2.4.2"
-      },
-      "peerDependenciesMeta": {
-        "jiti": {
-          "optional": true
-        },
-        "postcss": {
-          "optional": true
-        },
-        "tsx": {
-          "optional": true
-        },
-        "yaml": {
-          "optional": true
-        }
       }
     },
     "node_modules/postcss-safe-parser": {
@@ -7636,15 +7351,6 @@
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.0.6.tgz",
       "integrity": "sha512-mysewHYJKaXgNOW6pp5xon/emCsfAMnO8WMaGKZZ35fomnR/T5gYnRg2/yRTTrtXiEl1tiVkeRt0eMO6HxEZqw==",
       "dev": true
-    },
-    "node_modules/tapable": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.1.tgz",
-      "integrity": "sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=6"
-      }
     },
     "node_modules/tiny-glob": {
       "version": "0.2.9",

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -19,6 +19,7 @@
         "@sveltejs/kit": "2.17.1",
         "@sveltejs/vite-plugin-svelte": "^3.1.2",
         "@tailwindcss/typography": "^0.5.16",
+        "@tailwindcss/vite": "^4.0.6",
         "@tiptap/core": "^2.11.5",
         "@tiptap/extension-link": "^2.11.5",
         "@tiptap/extension-placeholder": "^2.11.5",
@@ -2366,6 +2367,228 @@
         "@jridgewell/sourcemap-codec": "^1.5.0"
       }
     },
+    "node_modules/@tailwindcss/node": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.0.6.tgz",
+      "integrity": "sha512-jb6E0WeSq7OQbVYcIJ6LxnZTeC4HjMvbzFBMCrQff4R50HBlo/obmYNk6V2GCUXDeqiXtvtrQgcIbT+/boB03Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "enhanced-resolve": "^5.18.0",
+        "jiti": "^2.4.2",
+        "tailwindcss": "4.0.6"
+      }
+    },
+    "node_modules/@tailwindcss/oxide": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.0.6.tgz",
+      "integrity": "sha512-lVyKV2y58UE9CeKVcYykULe9QaE1dtKdxDEdrTPIdbzRgBk6bdxHNAoDqvcqXbIGXubn3VOl1O/CFF77v/EqSA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10"
+      },
+      "optionalDependencies": {
+        "@tailwindcss/oxide-android-arm64": "4.0.6",
+        "@tailwindcss/oxide-darwin-arm64": "4.0.6",
+        "@tailwindcss/oxide-darwin-x64": "4.0.6",
+        "@tailwindcss/oxide-freebsd-x64": "4.0.6",
+        "@tailwindcss/oxide-linux-arm-gnueabihf": "4.0.6",
+        "@tailwindcss/oxide-linux-arm64-gnu": "4.0.6",
+        "@tailwindcss/oxide-linux-arm64-musl": "4.0.6",
+        "@tailwindcss/oxide-linux-x64-gnu": "4.0.6",
+        "@tailwindcss/oxide-linux-x64-musl": "4.0.6",
+        "@tailwindcss/oxide-win32-arm64-msvc": "4.0.6",
+        "@tailwindcss/oxide-win32-x64-msvc": "4.0.6"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-android-arm64": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-android-arm64/-/oxide-android-arm64-4.0.6.tgz",
+      "integrity": "sha512-xDbym6bDPW3D2XqQqX3PjqW3CKGe1KXH7Fdkc60sX5ZLVUbzPkFeunQaoP+BuYlLc2cC1FoClrIRYnRzof9Sow==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-darwin-arm64": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-arm64/-/oxide-darwin-arm64-4.0.6.tgz",
+      "integrity": "sha512-1f71/ju/tvyGl5c2bDkchZHy8p8EK/tDHCxlpYJ1hGNvsYihZNurxVpZ0DefpN7cNc9RTT8DjrRoV8xXZKKRjg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-darwin-x64": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-x64/-/oxide-darwin-x64-4.0.6.tgz",
+      "integrity": "sha512-s/hg/ZPgxFIrGMb0kqyeaqZt505P891buUkSezmrDY6lxv2ixIELAlOcUVTkVh245SeaeEiUVUPiUN37cwoL2g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-freebsd-x64": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-freebsd-x64/-/oxide-freebsd-x64-4.0.6.tgz",
+      "integrity": "sha512-Z3Wo8FWZnmio8+xlcbb7JUo/hqRMSmhQw8IGIRoRJ7GmLR0C+25Wq+bEX/135xe/yEle2lFkhu9JBHd4wZYiig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-arm-gnueabihf": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm-gnueabihf/-/oxide-linux-arm-gnueabihf-4.0.6.tgz",
+      "integrity": "sha512-SNSwkkim1myAgmnbHs4EjXsPL7rQbVGtjcok5EaIzkHkCAVK9QBQsWeP2Jm2/JJhq4wdx8tZB9Y7psMzHYWCkA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-arm64-gnu": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-gnu/-/oxide-linux-arm64-gnu-4.0.6.tgz",
+      "integrity": "sha512-tJ+mevtSDMQhKlwCCuhsFEFg058kBiSy4TkoeBG921EfrHKmexOaCyFKYhVXy4JtkaeeOcjJnCLasEeqml4i+Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-arm64-musl": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-musl/-/oxide-linux-arm64-musl-4.0.6.tgz",
+      "integrity": "sha512-IoArz1vfuTR4rALXMUXI/GWWfx2EaO4gFNtBNkDNOYhlTD4NVEwE45nbBoojYiTulajI4c2XH8UmVEVJTOJKxA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-x64-gnu": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.0.6.tgz",
+      "integrity": "sha512-QtsUfLkEAeWAC3Owx9Kg+7JdzE+k9drPhwTAXbXugYB9RZUnEWWx5x3q/au6TvUYcL+n0RBqDEO2gucZRvRFgQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-x64-musl": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-musl/-/oxide-linux-x64-musl-4.0.6.tgz",
+      "integrity": "sha512-QthvJqIji2KlGNwLcK/PPYo7w1Wsi/8NK0wAtRGbv4eOPdZHkQ9KUk+oCoP20oPO7i2a6X1aBAFQEL7i08nNMA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.0.6.tgz",
+      "integrity": "sha512-+oka+dYX8jy9iP00DJ9Y100XsqvbqR5s0yfMZJuPR1H/lDVtDfsZiSix1UFBQ3X1HWxoEEl6iXNJHWd56TocVw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-win32-x64-msvc": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.0.6.tgz",
+      "integrity": "sha512-+o+juAkik4p8Ue/0LiflQXPmVatl6Av3LEZXpBTfg4qkMIbZdhCGWFzHdt2NjoMiLOJCFDddoV6GYaimvK1Olw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "node_modules/@tailwindcss/typography": {
       "version": "0.5.16",
       "resolved": "https://registry.npmjs.org/@tailwindcss/typography/-/typography-0.5.16.tgz",
@@ -2379,6 +2602,22 @@
       },
       "peerDependencies": {
         "tailwindcss": ">=3.0.0 || insiders || >=4.0.0-alpha.20 || >=4.0.0-beta.1"
+      }
+    },
+    "node_modules/@tailwindcss/vite": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/vite/-/vite-4.0.6.tgz",
+      "integrity": "sha512-O25vZ/URWbZ2JHdk2o8wH7jOKqEGCsYmX3GwGmYS5DjE4X3mpf93a72Rn7VRnefldNauBzr5z2hfZptmBNtTUQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@tailwindcss/node": "^4.0.6",
+        "@tailwindcss/oxide": "^4.0.6",
+        "lightningcss": "^1.29.1",
+        "tailwindcss": "4.0.6"
+      },
+      "peerDependencies": {
+        "vite": "^5.2.0 || ^6"
       }
     },
     "node_modules/@tiptap/core": {
@@ -3886,9 +4125,8 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
       "integrity": "sha512-pGjwhsmsp4kL2RTz08wcOlGN83otlqHeD/Z5T8GXZB+/YcpQ/dgo+lbU8ZsGxV0HIvqqxo9l7mqYwyYMD9bKDg==",
+      "devOptional": true,
       "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
       "bin": {
         "detect-libc": "bin/detect-libc.js"
       },
@@ -3983,6 +4221,20 @@
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.4.0.tgz",
       "integrity": "sha512-EC+0oUMY1Rqm4O6LLrgjtYDvcVYTy7chDnM4Q7030tP4Kwj3u/pR6gP9ygnp2CJMK5Gq+9Q2oqmrFJAz01DXjw==",
       "dev": true
+    },
+    "node_modules/enhanced-resolve": {
+      "version": "5.18.1",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.18.1.tgz",
+      "integrity": "sha512-ZSW3ma5GkcQBIpwZTSRAI8N71Uuwgs93IezB7mf7R60tC8ZbJideoDNKjHn2O9KIlx6rkGTTEk1xUCK2E1Y2Yg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.4",
+        "tapable": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
     },
     "node_modules/entities": {
       "version": "4.5.0",
@@ -4747,6 +4999,13 @@
       "resolved": "https://registry.npmjs.org/globrex/-/globrex-0.1.2.tgz",
       "integrity": "sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg=="
     },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/graphemer": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
@@ -5059,8 +5318,6 @@
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.4.2.tgz",
       "integrity": "sha512-rg9zJN+G4n2nfJl5MW3BMygZX56zKPNVEYYqq7adpmMh4Jn2QNEwhvQlFy6jPVdcod7txZtKHWnyZiA3a0zP7A==",
       "dev": true,
-      "optional": true,
-      "peer": true,
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
       }
@@ -5183,9 +5440,8 @@
       "version": "1.29.1",
       "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.29.1.tgz",
       "integrity": "sha512-FmGoeD4S05ewj+AkhTY+D+myDvXI6eL27FjHIjoyUkO/uw7WZD1fBVs0QxeYWa7E17CUHJaYX/RUGISCtcrG4Q==",
+      "devOptional": true,
       "license": "MPL-2.0",
-      "optional": true,
-      "peer": true,
       "dependencies": {
         "detect-libc": "^1.0.3"
       },
@@ -5216,12 +5472,12 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -5237,12 +5493,12 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -5258,12 +5514,12 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -5279,12 +5535,12 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -5300,12 +5556,12 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -5321,12 +5577,12 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -5342,12 +5598,12 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -5363,12 +5619,12 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -5384,12 +5640,12 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -5405,12 +5661,12 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -7351,6 +7607,16 @@
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.0.6.tgz",
       "integrity": "sha512-mysewHYJKaXgNOW6pp5xon/emCsfAMnO8WMaGKZZ35fomnR/T5gYnRg2/yRTTrtXiEl1tiVkeRt0eMO6HxEZqw==",
       "dev": true
+    },
+    "node_modules/tapable": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.1.tgz",
+      "integrity": "sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/tiny-glob": {
       "version": "0.2.9",

--- a/front/package.json
+++ b/front/package.json
@@ -35,6 +35,7 @@
     "@sveltejs/kit": "2.17.1",
     "@sveltejs/vite-plugin-svelte": "^3.1.2",
     "@tailwindcss/typography": "^0.5.16",
+    "@tailwindcss/vite": "^4.0.6",
     "@tiptap/core": "^2.11.5",
     "@tiptap/extension-link": "^2.11.5",
     "@tiptap/extension-placeholder": "^2.11.5",

--- a/front/package.json
+++ b/front/package.json
@@ -34,7 +34,6 @@
     "@sveltejs/adapter-node": "^5.2.12",
     "@sveltejs/kit": "2.17.1",
     "@sveltejs/vite-plugin-svelte": "^3.1.2",
-    "@tailwindcss/postcss": "^4.0.6",
     "@tailwindcss/typography": "^0.5.16",
     "@tiptap/core": "^2.11.5",
     "@tiptap/extension-link": "^2.11.5",
@@ -55,8 +54,6 @@
     "lint-staged": "^15.4.3",
     "maplibre-gl": "^5.1.0",
     "opening_hours": "^3.8.0",
-    "postcss": "^8.5.2",
-    "postcss-load-config": "^6.0.1",
     "prettier": "^3.5.0",
     "prettier-plugin-svelte": "^3.3.3",
     "prettier-plugin-tailwindcss": "^0.6.11",
@@ -80,7 +77,7 @@
       "prettier --write",
       "eslint --fix"
     ],
-    "*.{json,css,postcss,html,md}": [
+    "*.{json,css,html,md}": [
       "prettier --write"
     ],
     "*": [

--- a/front/postcss.config.mjs
+++ b/front/postcss.config.mjs
@@ -1,5 +1,0 @@
-export default {
-  plugins: {
-    "@tailwindcss/postcss": {},
-  },
-};

--- a/front/src/app.css
+++ b/front/src/app.css
@@ -220,12 +220,6 @@
     --col-wait: #f29023;
     --col-wait-dark: #fe9800;
 
-    --s2: 0.125rem;
-    --s4: 0.25rem;
-    --s8: 0.5rem;
-    --s16: 1rem;
-    --s24: 1.5rem;
-
     --shadow-sm: 0 0 1px 0 rgba(0, 0, 0, 0.05), 0 2px 1px 0 rgba(0, 0, 0, 0.05);
     --shadow-md: 0 2px 10px 0 rgba(0, 0, 0, 0.1), 0 0 2px 0 rgba(0, 0, 0, 0.2);
   }

--- a/front/src/lib/components/display/breadcrumb.svelte
+++ b/front/src/lib/components/display/breadcrumb.svelte
@@ -85,15 +85,20 @@
   }
 
   $: structureData = getStructureData(currentLocation);
+
+  $: linkClasses = `${dark ? "text-gray-text" : "text-magenta-40"} print:text-france-blue`;
+  $: currentClasses = `font-bold ${dark ? "text-gray-text" : "text-white"} print:text-france-blue`;
 </script>
 
 <nav aria-label="vous êtes ici :" class="print:hidden" class:dark>
   <ol class="text-f14">
     <li class="inline">
       {#if currentLocation === "home"}
-        <span aria-current="page" class="current">Accueil</span>
+        <span aria-current="page" class={currentClasses}>Accueil</span>
       {:else}
-        <a href="/" title="Retour à l’accueil du site">Accueil</a>
+        <a href="/" class={linkClasses} title="Retour à l’accueil du site"
+          >Accueil</a
+        >
       {/if}
     </li>
 
@@ -101,13 +106,13 @@
       <li class="inline before:content-['/']">
         {#if structure.slug}
           {#if currentLocation === "structure-informations"}
-            <span class="current" aria-current="page">
+            <span class={currentClasses} aria-current="page">
               <span class="hidden lg:inline">
                 Structure&nbsp;•&nbsp;</span
               >{structure.name}
             </span>
           {:else}
-            <a href="/structures/{structure.slug}">
+            <a href="/structures/{structure.slug}" class={linkClasses}>
               <span class="hidden lg:inline">
                 Structure&nbsp;•&nbsp;</span
               >{structure.name}
@@ -130,12 +135,12 @@
     {#if service}
       <li class="inline before:content-['/']">
         {#if currentLocation === "service"}
-          <span class="current" aria-current="page">
+          <span class={currentClasses} aria-current="page">
             <span class="hidden lg:inline">Service&nbsp;•&nbsp;</span
             >{service.name}
           </span>
         {:else}
-          <a href="/services/{service.slug}">
+          <a href="/services/{service.slug}" class={linkClasses}>
             <span class="hidden lg:inline">Service&nbsp;•&nbsp;</span
             >{service.name}
           </a>
@@ -143,21 +148,21 @@
       </li>
     {:else if currentLocation.startsWith("structure-") && currentLocation !== "structure-informations"}
       <li class="inline before:content-['/']">
-        <span class="current" aria-current="page">
+        <span class={currentClasses} aria-current="page">
           {structureData.name}
         </span>
       </li>
     {/if}
     {#if currentLocation === "saved-search"}
       <li class="inline before:content-['/']">
-        <a href="/mes-alertes">
+        <a href="/mes-alertes" class={linkClasses}>
           <span class="hidden lg:inline">Mes alertes</span>
         </a>
       </li>
     {/if}
     {#if Object.keys(locationToText).includes(currentLocation)}
       <li class="inline before:content-['/']">
-        <span aria-current="page" class="current">
+        <span aria-current="page" class={currentClasses}>
           {locationToText[currentLocation]}
         </span>
       </li>
@@ -166,12 +171,12 @@
     {#if model}
       <li class="inline before:content-['/']">
         {#if currentLocation === "model"}
-          <span class="current" aria-current="page">
+          <span class={currentClasses} aria-current="page">
             <span class="hidden lg:inline">Modèle&nbsp;•&nbsp;</span
             >{model.name}
           </span>
         {:else}
-          <a href="/modeles/{model.slug}">
+          <a href="/modeles/{model.slug}" class={linkClasses}>
             <span class="hidden lg:inline">Modèle&nbsp;•&nbsp;</span
             >{model.name}
           </a>
@@ -184,23 +189,11 @@
 <style lang="postcss">
   @reference "../../../app.css";
 
-  a {
-    @apply text-magenta-40 print:text-france-blue;
-  }
-
-  .current {
-    @apply print:text-france-blue font-bold text-white;
-  }
-
   nav li + li::before {
-    @apply ml-s8 mr-s8 text-magenta-40 print:text-france-blue inline;
+    @apply ml-s8 mr-s8 text-magenta-40 inline;
   }
 
-  .dark a {
-    @apply text-gray-text;
-  }
-  .dark li::before,
-  .dark .current {
+  .dark li::before {
     @apply text-gray-text;
   }
 </style>

--- a/front/src/lib/components/display/breadcrumb.svelte
+++ b/front/src/lib/components/display/breadcrumb.svelte
@@ -85,20 +85,15 @@
   }
 
   $: structureData = getStructureData(currentLocation);
-
-  $: linkClasses = `${dark ? "text-gray-text" : "text-magenta-40"} print:text-france-blue`;
-  $: currentClasses = `font-bold ${dark ? "text-gray-text" : "text-white"} print:text-france-blue`;
 </script>
 
 <nav aria-label="vous êtes ici :" class="print:hidden" class:dark>
   <ol class="text-f14">
     <li class="inline">
       {#if currentLocation === "home"}
-        <span aria-current="page" class={currentClasses}>Accueil</span>
+        <span aria-current="page" class="current">Accueil</span>
       {:else}
-        <a href="/" class={linkClasses} title="Retour à l’accueil du site"
-          >Accueil</a
-        >
+        <a href="/" title="Retour à l’accueil du site">Accueil</a>
       {/if}
     </li>
 
@@ -106,13 +101,13 @@
       <li class="inline before:content-['/']">
         {#if structure.slug}
           {#if currentLocation === "structure-informations"}
-            <span class={currentClasses} aria-current="page">
+            <span class="current" aria-current="page">
               <span class="hidden lg:inline">
                 Structure&nbsp;•&nbsp;</span
               >{structure.name}
             </span>
           {:else}
-            <a href="/structures/{structure.slug}" class={linkClasses}>
+            <a href="/structures/{structure.slug}">
               <span class="hidden lg:inline">
                 Structure&nbsp;•&nbsp;</span
               >{structure.name}
@@ -135,12 +130,12 @@
     {#if service}
       <li class="inline before:content-['/']">
         {#if currentLocation === "service"}
-          <span class={currentClasses} aria-current="page">
+          <span class="current" aria-current="page">
             <span class="hidden lg:inline">Service&nbsp;•&nbsp;</span
             >{service.name}
           </span>
         {:else}
-          <a href="/services/{service.slug}" class={linkClasses}>
+          <a href="/services/{service.slug}">
             <span class="hidden lg:inline">Service&nbsp;•&nbsp;</span
             >{service.name}
           </a>
@@ -148,21 +143,21 @@
       </li>
     {:else if currentLocation.startsWith("structure-") && currentLocation !== "structure-informations"}
       <li class="inline before:content-['/']">
-        <span class={currentClasses} aria-current="page">
+        <span class="current" aria-current="page">
           {structureData.name}
         </span>
       </li>
     {/if}
     {#if currentLocation === "saved-search"}
       <li class="inline before:content-['/']">
-        <a href="/mes-alertes" class={linkClasses}>
+        <a href="/mes-alertes">
           <span class="hidden lg:inline">Mes alertes</span>
         </a>
       </li>
     {/if}
     {#if Object.keys(locationToText).includes(currentLocation)}
       <li class="inline before:content-['/']">
-        <span aria-current="page" class={currentClasses}>
+        <span aria-current="page" class="current">
           {locationToText[currentLocation]}
         </span>
       </li>
@@ -171,12 +166,12 @@
     {#if model}
       <li class="inline before:content-['/']">
         {#if currentLocation === "model"}
-          <span class={currentClasses} aria-current="page">
+          <span class="current" aria-current="page">
             <span class="hidden lg:inline">Modèle&nbsp;•&nbsp;</span
             >{model.name}
           </span>
         {:else}
-          <a href="/modeles/{model.slug}" class={linkClasses}>
+          <a href="/modeles/{model.slug}">
             <span class="hidden lg:inline">Modèle&nbsp;•&nbsp;</span
             >{model.name}
           </a>
@@ -189,11 +184,23 @@
 <style lang="postcss">
   @reference "../../../app.css";
 
-  nav li + li::before {
-    @apply ml-s8 mr-s8 text-magenta-40 inline;
+  a {
+    @apply text-magenta-40 print:text-france-blue;
   }
 
-  .dark li::before {
+  .current {
+    @apply print:text-france-blue font-bold text-white;
+  }
+
+  nav li + li::before {
+    @apply ml-s8 mr-s8 text-magenta-40 print:text-france-blue inline;
+  }
+
+  .dark a {
+    @apply text-gray-text;
+  }
+  .dark li::before,
+  .dark .current {
     @apply text-gray-text;
   }
 </style>

--- a/front/src/lib/components/display/breadcrumb.svelte
+++ b/front/src/lib/components/display/breadcrumb.svelte
@@ -185,15 +185,29 @@
   @reference "../../../app.css";
 
   a {
-    @apply text-magenta-40 print:text-france-blue;
+    @apply text-magenta-40;
   }
 
   .current {
-    @apply print:text-france-blue font-bold text-white;
+    @apply font-bold text-white;
   }
 
   nav li + li::before {
-    @apply ml-s8 mr-s8 text-magenta-40 print:text-france-blue inline;
+    @apply ml-s8 mr-s8 text-magenta-40 inline;
+  }
+
+  @media print {
+    a {
+      color: var(--color-france-blue);
+    }
+
+    .current {
+      color: var(--color-france-blue);
+    }
+
+    nav li + li::before {
+      color: var(--color-france-blue);
+    }
   }
 
   .dark a {

--- a/front/src/lib/components/display/dropdown-menu.svelte
+++ b/front/src/lib/components/display/dropdown-menu.svelte
@@ -8,7 +8,6 @@
   export let label: string | undefined = undefined;
   export let hideLabel = false;
   export let mobileDesign = false;
-  export let minWidth: string | undefined = undefined;
 
   let isOpen = false;
   let dropdownButton;
@@ -81,10 +80,7 @@
 
     <div
       {id}
-      class="
-        border-gray-00 absolute top-[100%] right-0 z-1000 hidden flex-col justify-end rounded-lg border bg-white shadow-md
-        {minWidth ? `min-w-[${minWidth}]` : ''}
-        "
+      class="border-gray-00 absolute top-[100%] right-0 z-1000 hidden flex-col justify-end rounded-lg border bg-white shadow-md"
       class:left-0={mobileDesign}
       class:!flex={isOpen}
     >

--- a/front/src/lib/components/display/label.svelte
+++ b/front/src/lib/components/display/label.svelte
@@ -14,7 +14,9 @@
 </script>
 
 <div
-  class="text-f14 flex flex-row items-center"
+  class="text-f14 flex flex-row items-center {darkBg
+    ? 'print:text-gray-text text-white'
+    : ''}"
   class:bold
   class:italic
   class:success
@@ -22,7 +24,6 @@
   class:info
   class:wait
   class:light
-  class:dark-bg={darkBg}
 >
   {#if icon}
     <i class="icon flex-none" class:small-icon={smallIcon} class:mr-s8={label}>
@@ -64,10 +65,6 @@
 
   .italic {
     font-style: italic;
-  }
-
-  .dark-bg {
-    @apply print:text-gray-text text-white;
   }
 
   .icon {

--- a/front/src/lib/components/display/label.svelte
+++ b/front/src/lib/components/display/label.svelte
@@ -68,14 +68,14 @@
   }
 
   .icon {
-    width: var(--s24);
-    height: var(--s24);
+    width: var(--spacing-s24);
+    height: var(--spacing-s24);
     fill: currentColor;
   }
 
   .small-icon {
-    width: var(--s16);
-    height: var(--s16);
+    width: var(--spacing-s16);
+    height: var(--spacing-s16);
     fill: currentColor;
   }
 </style>

--- a/front/src/lib/components/forms/field-wrapper.svelte
+++ b/front/src/lib/components/forms/field-wrapper.svelte
@@ -42,7 +42,7 @@
   class:lg:items-stretch={vertical}
   class:hidden
 >
-  <div class="label-container flex flex-col" class:one-fourth={!vertical}>
+  <div class="label-container flex flex-col {!vertical ? 'lg:w-1/3' : ''}">
     <label
       for={id}
       class="mt-s8"
@@ -64,7 +64,7 @@
       </div>
     {/if}
   </div>
-  <div class="flex flex-col" class:three-fourths={!vertical}>
+  <div class="flex flex-col {!vertical ? 'lg:w-2/3' : ''}">
     <!-- Slot principal -->
     <slot onBlur={handleBlur} onChange={handleChange} {errorMessages} />
     <!--  -->
@@ -73,15 +73,3 @@
     {/each}
   </div>
 </div>
-
-<style lang="postcss">
-  @reference "../../../app.css";
-
-  .one-fourth {
-    @apply lg:w-1/3;
-  }
-
-  .three-fourths {
-    @apply lg:w-2/3;
-  }
-</style>

--- a/front/src/lib/components/forms/fields/basic-input-field.svelte
+++ b/front/src/lib/components/forms/fields/basic-input-field.svelte
@@ -54,6 +54,9 @@
     placeholder,
     maxLength,
   };
+
+  const inputClasses =
+    "h-s48 border-gray-03 px-s12 py-s6 text-f16 placeholder-gray-text-alt focus:shadow-focus rounded-sm border outline-hidden read-only:text-gray-03 disabled:bg-gray-00 grow";
 </script>
 
 {#if $currentSchema && id in $currentSchema}
@@ -82,6 +85,7 @@
       {#if type === "text"}
         <input
           type="text"
+          class={inputClasses}
           bind:value
           on:blur={onBlur}
           on:change={onChange}
@@ -90,6 +94,7 @@
       {:else if type === "date"}
         <input
           type="date"
+          class={inputClasses}
           bind:value
           on:blur={onBlur}
           on:change={onChange}
@@ -98,6 +103,7 @@
       {:else if type === "number"}
         <input
           type="text"
+          class={inputClasses}
           bind:value
           on:blur={onBlur}
           on:change={onChange}
@@ -107,6 +113,7 @@
       {:else if type === "email"}
         <input
           type="email"
+          class={inputClasses}
           bind:value
           on:blur={onBlur}
           on:change={onChange}
@@ -115,6 +122,7 @@
       {:else if type === "tel"}
         <input
           type="tel"
+          class={inputClasses}
           bind:value={phoneValue}
           on:blur={(evt) => {
             handlePhoneBlur();
@@ -128,6 +136,7 @@
       {:else if type === "url"}
         <input
           type="url"
+          class={inputClasses}
           bind:value
           on:blur={onBlur}
           on:change={onChange}
@@ -144,21 +153,4 @@
       {/if}
     </div>
   </FieldWrapper>
-
-  <style lang="postcss">
-    @reference "../../../../app.css";
-
-    input[type="text"],
-    input[type="number"],
-    input[type="url"],
-    input[type="email"],
-    input[type="tel"],
-    input[type="date"] {
-      @apply h-s48 border-gray-03 px-s12 py-s6 text-f16 placeholder-gray-text-alt focus:shadow-focus rounded-sm border outline-hidden;
-    }
-
-    input {
-      @apply read-only:text-gray-03 disabled:bg-gray-00 grow;
-    }
-  </style>
 {/if}

--- a/front/src/lib/components/forms/fields/textarea-field.svelte
+++ b/front/src/lib/components/forms/fields/textarea-field.svelte
@@ -54,6 +54,7 @@
         {rows}
         maxlength={maxLength}
         aria-describedby={formatErrors(id, errorMessages)}
+        class="border-gray-03 px-s12 py-s6 text-f16 placeholder-gray-text-alt focus:shadow-focus read-only:text-gray-03 disabled:bg-gray-00 min-h-[3rem] grow rounded-sm border outline-hidden"
       />
       {#if value && maxLength != null && !readonly && !disabled}
         <div
@@ -66,12 +67,3 @@
     </div>
   </FieldWrapper>
 {/if}
-
-<style lang="postcss">
-  @reference "../../../../app.css";
-
-  textarea {
-    @apply border-gray-03 px-s12 py-s6 text-f16 placeholder-gray-text-alt focus:shadow-focus min-h-[3rem] rounded-sm border outline-hidden;
-    @apply read-only:text-gray-03 disabled:bg-gray-00 grow;
-  }
-</style>

--- a/front/src/lib/components/inputs/obsolete/select-field.svelte
+++ b/front/src/lib/components/inputs/obsolete/select-field.svelte
@@ -275,7 +275,8 @@
     @apply text-magenta-cta;
   }
   :global(.hover) {
-    @apply !bg-magenta-10 !text-magenta-cta;
+    background-color: var(--color-magenta-10) !important;
+    color: var(--color-magenta-cta) !important;
   }
   .combobox {
     @apply relative;
@@ -283,7 +284,7 @@
 
   @media (width >= 64rem) {
     .vertical {
-      @apply w-3/4;
+      width: 75%;
     }
   }
 
@@ -294,23 +295,25 @@
 
   @media (width >= 64rem) {
     .filter-search {
-      @apply p-s12;
+      padding: var(--spacing-s12);
     }
   }
 
   .filter-search .chevron {
-    @apply !text-gray-dark;
+    color: var(--color-gray-dark) !important;
   }
   .filter-search .placeholder {
-    @apply !text-gray-text;
+    color: var(--color-gray-text) !important;
   }
   .filter-search :global(.option) {
-    @apply p-s8 !min-h-min;
+    padding: var(--spacing-s8) !important;
+    min-height: min-content !important;
   }
   .filter-search .optgroup:hover,
   .filter-search .option:hover,
   .filter-search :global(.hover) {
-    @apply !bg-magenta-10 !text-magenta-cta;
+    background-color: var(--color-magenta-10) !important;
+    color: var(--color-magenta-cta) !important;
   }
   .filter-search.has-value .chevron,
   .filter-search.has-value .placeholder,
@@ -364,7 +367,8 @@
   }
   .filter-style .option:hover,
   .filter-style :global(.hover) {
-    @apply !bg-magenta-10 !text-magenta-cta;
+    background-color: var(--color-magenta-10) !important;
+    color: var(--color-magenta-cta) !important;
   }
 
   .filter-style.expanded {

--- a/front/src/lib/components/inputs/opening-hours/days-grid.svelte
+++ b/front/src/lib/components/inputs/opening-hours/days-grid.svelte
@@ -83,14 +83,14 @@
     grid-column-end: 5;
   }
   .day-grid.day > div {
-    @apply mb-s24;
+    margin-bottom: var(--s24);
   }
 
   @media (width >= 48rem) {
     .day-grid {
       display: grid;
       grid-template-columns: 1fr 2fr 2fr;
-      @apply mb-s24;
+      margin-bottom: var(--s24);
     }
     .day-grid.day > div:first-child {
       grid-column-start: auto;

--- a/front/src/lib/components/inputs/opening-hours/days-grid.svelte
+++ b/front/src/lib/components/inputs/opening-hours/days-grid.svelte
@@ -83,14 +83,14 @@
     grid-column-end: 5;
   }
   .day-grid.day > div {
-    margin-bottom: var(--s24);
+    margin-bottom: var(--spacing-s24);
   }
 
   @media (width >= 48rem) {
     .day-grid {
       display: grid;
       grid-template-columns: 1fr 2fr 2fr;
-      margin-bottom: var(--s24);
+      margin-bottom: var(--spacing-s24);
     }
     .day-grid.day > div:first-child {
       grid-column-start: auto;

--- a/front/src/lib/components/inputs/radio-buttons.svelte
+++ b/front/src/lib/components/inputs/radio-buttons.svelte
@@ -23,7 +23,7 @@
 <div class="gap-s8 flex flex-col">
   {#each choices as choice, i}
     <label
-      class="focus-within:shadow-focus flex flex-row items-center"
+      class="focus-within:shadow-focus p-s2 flex flex-row items-center rounded outline-0"
       class:outline={choice.value === focusValue}
     >
       <input
@@ -59,9 +59,5 @@
 
   input[type="radio"]:checked + div div {
     @apply block;
-  }
-  label {
-    @apply p-s2 rounded;
-    outline: none;
   }
 </style>

--- a/front/src/lib/components/inputs/select/simple-autocomplete.svelte
+++ b/front/src/lib/components/inputs/select/simple-autocomplete.svelte
@@ -1014,8 +1014,8 @@
   .tags {
     display: flex;
     flex-direction: row;
-    border-radius: var(--s4);
-    padding: var(--s2) var(--s8);
+    border-radius: var(--spacing-s4);
+    padding: var(--spacing-s2) var(--spacing-s8);
   }
 
   .tag-delete {
@@ -1024,8 +1024,8 @@
     margin-left: 4px;
     cursor: pointer;
     fill: currentColor;
-    width: var(--s16);
-    height: var(--s16);
+    width: var(--spacing-s16);
+    height: var(--spacing-s16);
     shrink: 0;
   }
 </style>

--- a/front/src/lib/components/inputs/select/simple-autocomplete.svelte
+++ b/front/src/lib/components/inputs/select/simple-autocomplete.svelte
@@ -748,7 +748,8 @@
   <div class="input-container">
     <input
       type="text"
-      class="{inputClassName || ''} input autocomplete-input"
+      class="{inputClassName ||
+        ''} input autocomplete-input read-only:text-gray-03 disabled:bg-gray-00"
       id={inputId}
       autocomplete={html5autocomplete ? "on" : "off"}
       placeholder={multiple && value.length ? placeholderMulti : placeholder}
@@ -876,10 +877,6 @@
 
 <style lang="postcss">
   @reference "../../../../app.css";
-
-  input {
-    @apply read-only:text-gray-03 disabled:bg-gray-00;
-  }
 
   .autocomplete {
     position: relative;

--- a/front/src/lib/components/specialized/favorite-icon.svelte
+++ b/front/src/lib/components/specialized/favorite-icon.svelte
@@ -30,14 +30,18 @@
 </script>
 
 <button
-  class="tooltip icon h-s20 w-s20 text-gray-text-alt2 hover:text-magenta-cta inline-block shrink-0 fill-current print:hidden"
+  class="tooltip icon h-s20 w-s20 text-gray-text-alt2 hover:text-magenta-cta relative inline-block shrink-0 fill-current print:hidden"
   class:active
   class:disabled
   aria-label={title}
   on:click={handleClick}
 >
   {@html currentIcon}
-  <div class="tooltiptext">{@html title}</div>
+  <div
+    class="tooltiptext bg-magenta-dark px-s8 py-s2 text-f12 invisible absolute top-[-1000px] left-[-1000px] z-10 w-max -translate-x-1/2 rounded-sm text-center font-bold text-white"
+  >
+    {@html title}
+  </div>
 </button>
 
 <style lang="postcss">
@@ -49,13 +53,6 @@
 
   .disabled {
     @apply text-gray-text-alt;
-  }
-  .tooltip {
-    @apply relative inline-block print:hidden;
-  }
-
-  .tooltip .tooltiptext {
-    @apply bg-magenta-dark px-s8 py-s2 text-f12 invisible absolute top-[-1000px] left-[-1000px] z-10 w-max -translate-x-1/2 rounded-sm text-center font-bold text-white;
   }
 
   .tooltip .tooltiptext::after {

--- a/front/src/lib/components/specialized/service-search.svelte
+++ b/front/src/lib/components/specialized/service-search.svelte
@@ -304,7 +304,8 @@
   }
 
   .subcategories-search :global(.field-wrapper) {
-    @apply relative w-[100%];
+    position: relative;
+    width: 100%;
   }
   .subcategories-search :global(.label-container) {
     @apply sr-only;

--- a/front/src/lib/components/specialized/tally-popup.svelte
+++ b/front/src/lib/components/specialized/tally-popup.svelte
@@ -118,6 +118,8 @@
   @reference "../../../app.css";
 
   :global(.tally-popup) {
-    @apply print:!hidden;
+    @media print {
+      display: none !important;
+    }
   }
 </style>

--- a/front/src/routes/(modeles-services)/_common/service-description.svelte
+++ b/front/src/routes/(modeles-services)/_common/service-description.svelte
@@ -13,7 +13,7 @@
   @reference "../../../app.css";
 
   .markdown-wrapper {
-    margin-top: var(--s16);
+    margin-top: var(--spacing-s16);
   }
 
   .markdown-wrapper :global(h1),

--- a/front/vite.config.ts
+++ b/front/vite.config.ts
@@ -1,6 +1,7 @@
 import { sveltekit } from "@sveltejs/kit/vite";
 import { defineConfig, loadEnv } from "vite";
 import { sentrySvelteKit } from "@sentry/sveltekit";
+import tailwindcss from "@tailwindcss/vite";
 
 export default defineConfig(({ mode }) => {
   // Charge les variables d'environnement des fichiers .env
@@ -13,6 +14,7 @@ export default defineConfig(({ mode }) => {
         },
       }),
       sveltekit(),
+      tailwindcss(),
     ],
 
     build: {


### PR DESCRIPTION
Correction des plantages de `npm run dev` suite à la mise a niveau de Tailwind CSS version la version 4 (#220).

 - Utilisation de _@tailwincss/vite_ au lieu de _@tailwindcss/postcss_ ;
 - Suppression de la classe Tailwind CSS invalide `min-w-[${minWidth}]` et de la prop `minWidth` inutilisée dans `DropdownMenu` ;
 - Conversion des classes Tailwind CSS problématiques (contenant généralement un caractère `:`, `/` ou `!`) dans les directives `@apply` ;
 - Remplacement des variables `--s*` par les variables `--spacing-s*` ( faisait doublon).

Je n'ai plus constaté de plantages avec ces modifications. Il y a peut-être des corrections qui occasionnent des différences de rendu, mais je n'en ai pas constaté.