### PR TITLE
feat(search): Ajout d'un Button-Lien vers la page de recherche textuelle

### DIFF
--- a/front/src/routes/+page.svelte
+++ b/front/src/routes/+page.svelte
@@ -9,6 +9,7 @@
   import InviteStructureLink from "$lib/components/specialized/invite-structure-link.svelte";
   import PartnerList from "$lib/components/specialized/partner-list.svelte";
   import SearchForm from "$lib/components/specialized/service-search.svelte";
+  import { GOOGLE_CSE_ID } from "$lib/env";
 
   import type { PageData } from "./$types";
   import { videoIcon } from "$lib/icons";
@@ -39,6 +40,16 @@
     label={data.cityLabel}
     initialSearch
   />
+
+  {#if GOOGLE_CSE_ID}
+    <div class="mt-s32 mb-s32 flex items-center justify-center">
+      <div class="mr-s16">ou</div>
+      <LinkButton
+        label="Faire une recherche par mots-clés"
+        to={`/recherche-textuelle`}
+      />
+    </div>
+  {/if}
 </CenteredGrid>
 
 <CenteredGrid>


### PR DESCRIPTION
### Problème

On souhaite disposer d'un moyen simple et visible depuis la page d'accueil pour accéder à la nouvelle page expérimentale de recherche de solutions d'insertion par mots-clés.

### Solution

On met un gros bouton-lien CTA-like sous le formulaire standard qui redirige vers la page `/recherche-textuelle`.

On conditionne l'affichage de ce bouton-lien à la définition de la variable d'environnement `VITE_GOOGLE_CSE_ID`, côté front.

<img width="1512" alt="image" src="https://github.com/user-attachments/assets/0d016407-fc4b-4bc1-a36b-b143ac704dab" />

### Tracking

Pour le tracking web analytics via Matomo, on prend le parti de faire un trigger de type "element click" basé sur le libellé du lien "Rechercher par mots-clés".

### Recette

- [ ] Sur la page d'accueil, on voit le bouton "Rechercher par mots-clés" en magenta sous le formulaire classique
- [ ] Quand on clique, on est redirigé vers la page `/recherche-textuelle`
- [ ] Si la variable `VITE_GOOGLE_CSE_ID` n'est pas définie, alors le bouton n'est pas visible
