### PR TITLE
fix(a11y): Correction de warnings d'accessibilité

### DIFF
--- a/front/src/lib/components/specialized/establishment-search/search-by-commune.svelte
+++ b/front/src/lib/components/specialized/establishment-search/search-by-commune.svelte
@@ -133,7 +133,7 @@
       >Annuaire des entreprises
       <span
         class="h-s20 w-s20 pl-s4 pt-s6 inline-block fill-current"
-        aria-hidden
+        aria-hidden="true"
       >
         {@html externalLinkIcon}
       </span>

--- a/front/src/routes/+layout.svelte
+++ b/front/src/routes/+layout.svelte
@@ -36,7 +36,7 @@
 <SkipLink />
 <Header />
 
-<main id="main-content" role="main">
+<main id="main-content">
   {#if $userInfo && !$userInfo.mainActivity}
     <UserOnboardingModal />
   {/if}

--- a/front/src/routes/_index/footer.svelte
+++ b/front/src/routes/_index/footer.svelte
@@ -29,7 +29,7 @@
     />
   </div>
 </CenteredGrid>
-<footer class="border-france-blue border-t-2 print:hidden" role="contentinfo">
+<footer class="border-france-blue border-t-2 print:hidden">
   <CenteredGrid>
     <div class="gap-s24 flex lg:flex-row">
       <div class="mb-s24 lg:w-1/2">

--- a/front/src/routes/_index/menu-mon-compte.svelte
+++ b/front/src/routes/_index/menu-mon-compte.svelte
@@ -52,14 +52,20 @@
 
   {#if OIDC_AUTH_BACKEND === "proconnect"}
     <a href="/auth/pc-logout" class={aClass}>
-      <span class="mr-s10 h-s24 w-s24 inline-block fill-current" aria-hidden="true">
+      <span
+        class="mr-s10 h-s24 w-s24 inline-block fill-current"
+        aria-hidden="true"
+      >
         {@html logoutBoxLineIcon}
       </span>
       Déconnexion
     </a>
   {:else}
     <a href="/auth/deconnexion" class={aClass}>
-      <span class="mr-s10 h-s24 w-s24 inline-block fill-current" aria-hidden="true">
+      <span
+        class="mr-s10 h-s24 w-s24 inline-block fill-current"
+        aria-hidden="true"
+      >
         {@html logoutBoxLineIcon}
       </span>
       Déconnexion

--- a/front/src/routes/_index/menu-mon-compte.svelte
+++ b/front/src/routes/_index/menu-mon-compte.svelte
@@ -20,7 +20,7 @@
     <span
       class="mr-s10 h-s24 w-s24 inline-block fill-current"
       class:text-magenta-cta={$page.url.pathname === "/mon-compte"}
-      aria-hidden
+      aria-hidden="true"
     >
       {@html accountCircleLineIcon}
     </span>
@@ -31,7 +31,7 @@
     <span
       class="mr-s10 h-s24 w-s24 inline-block fill-current"
       class:text-magenta-cta={$page.url.pathname === "/favoris"}
-      aria-hidden
+      aria-hidden="true"
     >
       {@html starSmileLineIcon}
     </span>
@@ -42,7 +42,7 @@
     <span
       class="mr-s10 h-s24 w-s24 inline-block fill-current"
       class:text-magenta-cta={$page.url.pathname === "/mes-alertes"}
-      aria-hidden
+      aria-hidden="true"
     >
       {@html notificationIcon}
     </span>Mes alertes
@@ -52,14 +52,14 @@
 
   {#if OIDC_AUTH_BACKEND === "proconnect"}
     <a href="/auth/pc-logout" class={aClass}>
-      <span class="mr-s10 h-s24 w-s24 inline-block fill-current" aria-hidden>
+      <span class="mr-s10 h-s24 w-s24 inline-block fill-current" aria-hidden="true">
         {@html logoutBoxLineIcon}
       </span>
       Déconnexion
     </a>
   {:else}
     <a href="/auth/deconnexion" class={aClass}>
-      <span class="mr-s10 h-s24 w-s24 inline-block fill-current" aria-hidden>
+      <span class="mr-s10 h-s24 w-s24 inline-block fill-current" aria-hidden="true">
         {@html logoutBoxLineIcon}
       </span>
       Déconnexion

--- a/front/src/routes/_index/sub-menu.svelte
+++ b/front/src/routes/_index/sub-menu.svelte
@@ -76,7 +76,7 @@
         Nouveautés
         <span
           class="h-s20 w-s20 pl-s4 pt-s6 inline-block fill-current {externalIconColor}"
-          aria-hidden
+          aria-hidden="true"
         >
           {@html externalLinkIcon}
         </span>
@@ -94,7 +94,7 @@
         Communauté de l’inclusion
         <span
           class="h-s20 w-s20 pl-s4 pt-s6 inline-block fill-current {externalIconColor}"
-          aria-hidden
+          aria-hidden="true"
         >
           {@html externalLinkIcon}
         </span>

--- a/front/src/routes/mes-alertes/+page.svelte
+++ b/front/src/routes/mes-alertes/+page.svelte
@@ -84,7 +84,7 @@
             Découvrez comment créer une alerte
             <span
               class="h-s20 w-s20 pl-s4 pt-s6 inline-block fill-current"
-              aria-hidden
+              aria-hidden="true"
             >
               {@html externalLinkIcon}
             </span>

--- a/front/src/routes/structures/[slug]/empty-notice.svelte
+++ b/front/src/routes/structures/[slug]/empty-notice.svelte
@@ -34,7 +34,7 @@
                 {label}
                 <span
                   class="h-s20 w-s20 pt-s4 inline-block fill-current"
-                  aria-hidden
+                  aria-hidden="true"
                 >
                   {@html externalLinkIcon}
                 </span>


### PR DESCRIPTION
### Problème

En explorant la migration de Svelte v4 à v5, des warnings d'accessibilité apparaissent dans la console. Autant les régler en amont.

![image](https://github.com/user-attachments/assets/c1899dd4-09e0-4508-a291-ba86eb53a458)

### Solution

Correction des règles :
1. Ne pas préciser de rôle "main" pour une balise `<main>`
2. Toujours spécifier la valeur "true" pour les propriétés `aria-hidden`.
3. Ne pas préciser de rôle "contentinfo" pour une balise <footer>