### PR TITLE
fix(stats): Problème d'affichage du dashboard Metabase dans la page /stats

### DIFF
--- a/front/svelte.config.js
+++ b/front/svelte.config.js
@@ -50,6 +50,7 @@ const config = {
         "font-src": ["self"],
         "frame-src": [
           "self",
+          "https://metabase.dora.inclusion.beta.gouv.fr",
           "https://cse.google.com",
           "https://syndicatedsearch.goog",
         ],


### PR DESCRIPTION
### Problème

La page [/stats](https://dora.inclusion.beta.gouv.fr/stats) intègre un dashboard Metabase publique. Celui-ci ne s'affiche plus depuis quelques jours.

### Solution

Ajouter une CSP de type `frame-src` pour le domaine https://metabase.dora.inclusion.beta.gouv.fr.

<img width="920" alt="image" src="https://github.com/user-attachments/assets/38f83c91-e221-4fd4-bcbe-c51a59bdc12b" />

### Recette

- [ ] Accéder à la page `/stats` ([localhost](http://localhost:3000/stats) / [staging](https://dora.inclusion.beta.gouv.fr/stats)) et vérifier que tout s'affiche correctement