### PR TITLE
fix(front): Correction des problèmes de CSP

### DIFF
--- a/front/svelte.config.js
+++ b/front/svelte.config.js
@@ -53,6 +53,8 @@ const config = {
           "https://metabase.dora.inclusion.beta.gouv.fr",
           "https://cse.google.com",
           "https://syndicatedsearch.goog",
+          "https://tally.so",
+          "https://tube.numerique.gouv.fr",
         ],
         "img-src": [
           "self",


### PR DESCRIPTION
### Problème

Suite à l'ajout de Google Search (Google CSE), pour l'expérimentation de recherche par mots-clés (cf. [/recherche-textuelle](https://dora.inclusion.beta.gouv.fr/recherche-textuelle)), nous avons déclaré la catégorie `frame-src` dans les CSP côté front-end.

Cela nous oblige à déclarer toutes les sources de ressources chargées dans des iframes.

Cela a créé des soucis d'affichage de tableau de bord (Metabase) (déjà fixé). Il reste des soucis d'affichage de vidéos (sur tube.numerique.gouv.fr) et de formulaires Tally (sur tally.so)

<img width="1624" alt="image" src="https://github.com/user-attachments/assets/eeca154e-a477-40ec-a095-7697e5649978" />

### Solution

Ajouter les CSP["frame-src"] manquantes.

<img width="1624" alt="image" src="https://github.com/user-attachments/assets/4912d528-19bb-4d88-a277-89b7d47e8d67" />
