### PR TITLE
fix: modification de l'e-mail envoyé pour les notifications de services (attente et brouillon) 

### DIFF
--- a/back/dora/services/templates/notification-services.mjml
+++ b/back/dora/services/templates/notification-services.mjml
@@ -42,16 +42,6 @@
 
   {% endif%}
 
-  <p background-color="#e0e0e0" border-radius="8px">
-    <mj-text font-weight="bold">💡 Boîte à outils :</mj-text>
-    <mj-raw>
-      <ul>
-        <li><a href="{{ help_update_services_url }}">Comment actualiser vos services ?</a></li>
-      </ul>
-    </mj-raw>
-  </p>
-  <mj-spacer height="20px" />
-
   {% if draft_services %}
     <mj-text font-weight="bold">📝 Vos services en brouillon</mj-text>
 
@@ -77,6 +67,17 @@
 
     <mj-spacer height="20px" />
   {% endif %}
+
+  <p background-color="#e0e0e0" border-radius="8px">
+    <mj-text font-weight="bold">💡 Boîte à outils :</mj-text>
+    <mj-raw>
+      <ul>
+        <li><a href="{{ help_update_services_url }}">Comment actualiser vos services ?</a></li>
+      </ul>
+    </mj-raw>
+  </p>
+
+  <mj-spacer height="20px" />
 
   <mj-text font-weight="bold">Besoin d’aide ?</mj-text>
 


### PR DESCRIPTION
Dans l'e-mail de notification pour les services en attente
d'actualisation et brouillons, la section "boîte à outils" est déplacée vers la fin du contenu.
