### PR TITLE
fix: résolution de l'affichage des fiches services data·inclusion con…

### DIFF
--- a/back/config/urls.py
+++ b/back/config/urls.py
@@ -73,12 +73,9 @@ private_api_patterns = [
         dora.services.views.search,
     ),
     path("stats/event/", dora.stats.views.log_event),
+    path("services-di/<str:di_id>/", dora.services.views.service_di),
     path(
-        "services-di/<slug:di_id>/",
-        dora.services.views.service_di,
-    ),
-    path(
-        "services-di/<slug:di_id>/share/",
+        "services-di/<str:di_id>/share/",
         dora.services.views.share_di_service,
     ),
     path("admin-division-search/", dora.admin_express.views.search),

--- a/back/dora/services/views.py
+++ b/back/dora/services/views.py
@@ -1,5 +1,6 @@
 from datetime import timedelta
 from operator import itemgetter
+from urllib.parse import unquote
 
 import requests
 from django.conf import settings
@@ -726,7 +727,7 @@ def service_di(request, di_id: str):
 
     The output format matches the ServiceSerializer.
     """
-
+    di_id = unquote(di_id)
     source_di, di_service_id = di_id.split("--")
 
     di_client = data_inclusion.di_client_factory()


### PR DESCRIPTION
…tenant un caractère diacritique dans leur ID

Les services DORA ont pour ID un Slug (cf. RFC https://datatracker.ietf.org/doc/html/rfc3986).

Les services data·inclusion ont pour ID une String (cf. schéma https://github.com/gip-inclusion/data-inclusion-schema/blob/2d13ee3a864964dbf15e4b3a1f6e4dd58db47ac5/schemas/service.json#L466-L469)

Côté routeur Django API, le endpoint était `services-di/<slug:di_id>/`. Conséquence : quand le front appelait le back avec un accent, on ne rentrait même pas dans le route handler et ça sortait direct en 404.

Ex : http://localhost:3000/services/di--mediation-numerique--Conseiller-Numerique_6645e7ff531d5c075e8cca27__Coop-num%C3%A9rique_74b162b9-205c-46a8-ae17-1ba226d7f282-mediation-numerique?searchId=149342

Ce commit modifie le type des paramètres de routage pour les routes `services-di/<di_id>/` et `services-di/<di_id>/share/`.

A noter :
- côté front, le '/' est toujours ajouté (cf. méthode `fetch` du package @tsnode/types)
- côté back, après réflexion nous avons conclu que ce n'était pas nécessaire d'ajouter un tests de config d'URL