### PR TITLE
fix: évite une erreur lors de la récupération des favoris

### DIFF
--- a/back/dora/data_inclusion/client.py
+++ b/back/dora/data_inclusion/client.py
@@ -92,9 +92,9 @@ class DataInclusionClient:
     def retrieve_service(self, source: str, id: str) -> Optional[dict]:
         url = self.base_url.copy()
         url = url / "services" / source / id
-        response = self._get(url)
 
         try:
+            response = self._get(url)
             return response.json()
         except requests.HTTPError:
             return None


### PR DESCRIPTION
Les services D·I dont le lien est cassé sont correctement interceptés et affichés comme inaccessibles.

Auparavant une erreur empêchait la liste des autres favoris de s'afficher si un des favoris était en erreur.

À la charge de l'utilisateur de les supprimer dans sa liste de favoris.

![image](https://github.com/user-attachments/assets/2197201f-d76c-44d2-8126-84f6e4d51647)

