### PR TITLE
fix: retrait de la version de postgres hardcodée dans le script de synchro

### DIFF
--- a/analytics/sync-analytics.sh
+++ b/analytics/sync-analytics.sh
@@ -29,7 +29,7 @@ if [ ${#missing_vars[@]} -ne 0 ]; then
 fi
 
 if command -v dbclient-fetcher &> /dev/null; then
-    dbclient-fetcher pgsql 15
+    dbclient-fetcher pgsql
 fi
 
 # Generate the list of tables to be exported


### PR DESCRIPTION
## 👿 Problème

Impossible de dumper depuis la montée en version à postgres 16 sur la db car le script de synchro force l'utilisation de postgres 15.


## 😈 Solution

Retrait de la condition