### PR TITLE
 feat(services): corrections notification de besoin d'actualisation des services

### DIFF
--- a/front/src/routes/structures/[slug]/services/service-card.svelte
+++ b/front/src/routes/structures/[slug]/services/service-card.svelte
@@ -67,20 +67,19 @@
     </div>
 
     <div
-      class="gap-s10 border-t-gray-03 px-s20 py-s12 flex min-h-[100px] flex-col justify-center border-t"
+      class="gap-s8 border-t-gray-03 px-s20 py-s12 flex min-h-[100px] flex-col justify-center border-t"
     >
-      <div class="text-f14 text-gray-text flex items-center">
+      <div class="flex items-center">
         <span class="mr-s8">
           <UpdateNeededIcon updateNeeded={service.updateNeeded} small />
         </span>
-        {#if service.status !== "PUBLISHED" || service.updateNeeded}
+        <div class="text-f14">
           <RelativeDateLabel
             date={service.modificationDate}
             prefix="Actualisé"
+            bold={service.updateNeeded}
           />
-        {:else}
-          <span class="font-bold">Actualisation conseillée</span>
-        {/if}
+        </div>
       </div>
 
       {#if !readOnly && service.model}

--- a/front/src/routes/structures/[slug]/services/services-to-update-notice.svelte
+++ b/front/src/routes/structures/[slug]/services/services-to-update-notice.svelte
@@ -84,7 +84,7 @@
 
     <div class="mt-s16 w-full">
       <Button
-        label="Accepter pour tous les services"
+        label="Tout marquer comme à jour"
         extraClass="py-s8 text-f14! px-s12!"
         on:click={() => handleMarkServicesAsUpToDate(servicesToUpdate)}
       />


### PR DESCRIPTION
https://www.notion.so/gip-inclusion/ETQ-membre-d-une-structure-avec-des-services-actualiser-je-peux-visualiser-une-notice-de-mise-j-1a45f321b60480999516f8757672973e?pvs=4

Corrections apportées suite au test de #244 :
- Changement du libellé du bouton de mise à jour ;
- CHangement du statut d'actualisation sur la carte service sur le modèle de la fiche service.


![image](https://github.com/user-attachments/assets/30bbdbd0-13bd-4f44-894f-4da632523b19)
![image](https://github.com/user-attachments/assets/fd01162f-5108-4cd1-8f39-61c150248439)
