### PR TITLE
feat(data): Ajout des données Services et Structures de data•inclusion à la base analytics de DORA

### DIFF
--- a/analytics/sync-analytics.sh
+++ b/analytics/sync-analytics.sh
@@ -76,9 +76,9 @@ fetch_and_export_dora_data() {
     cat models/_sources.yml | grep '      - name' | cut -d':' -f2 >tables.txt
     xargs -I {} echo -n "-t {} " <tables.txt >args.txt
 
-    time pg_dump $DORA_DATABASE_URL --jobs=8 --format=directory --compress=1 --clean --if-exists --no-owner --no-privileges --verbose $(cat args.txt) --file=/tmp/out.dump
-    time psql $DATABASE_URL -c "DROP SCHEMA public CASCADE; CREATE SCHEMA public; CREATE EXTENSION IF NOT EXISTS postgis;"
-    time pg_restore --dbname=$DATABASE_URL --jobs=8 --format=directory --clean --if-exists --no-owner --no-privileges --verbose /tmp/out.dump
+    time pg_dump "$DORA_DATABASE_URL" --jobs=8 --format=directory --compress=1 --clean --if-exists --no-owner --no-privileges --verbose $(cat args.txt) --file=/tmp/out.dump
+    time psql "$DATABASE_URL" -c "DROP SCHEMA public CASCADE; CREATE SCHEMA public; CREATE EXTENSION IF NOT EXISTS postgis;"
+    time pg_restore --dbname="$DATABASE_URL" --jobs=8 --format=directory --clean --if-exists --no-owner --no-privileges --verbose /tmp/out.dump
 
     echo "✔️ Fait."
     echo ""

--- a/analytics/sync-analytics.sh
+++ b/analytics/sync-analytics.sh
@@ -5,19 +5,22 @@
 # with an enabled proxy to the DORA database.
 
 load_env_file_if_exists() {
-    echo "Load env file if it exists..."
+    echo "💎 Chargement du fichier .env (si existant)..."
 
     if [ -f .env ]; then
-        echo "Fichier .env trouvé"
+        echo "Fichier .env trouvé."
         source .env
+        echo "Fichier .env chargé."
+    else 
+        echo "Aucun fichier .env trouvé."
     fi
 
-    echo "Done."
+    echo "✔️ Fait."
     echo ""
 }
 
 check_required_vars() {
-    echo "Check required vars..."
+    echo "💎 Vérification des variables d'environnement requises..."
 
     required_vars=("DORA_DATABASE_URL" "DATABASE_URL" "S3_BUCKET_VARIANT" "S3_ACCESS_KEY" "S3_SECRET_KEY")
     missing_vars=()
@@ -36,12 +39,12 @@ check_required_vars() {
         exit 1
     fi
 
-    echo "Done."
+    echo "✔️ Fait."
     echo ""
 }
 
 configure_pg_env() {
-    echo "Configure PG environment variables..."
+    echo "💎 Extraction des informations de connexion à la base de données..."
 
     cleaned_url=${DATABASE_URL#postgresql://}
     cleaned_url=${cleaned_url#postgres://}
@@ -55,12 +58,12 @@ configure_pg_env() {
     export PGPORT=$(echo "$hostportdb" | cut -d: -f2 | cut -d/ -f1)
     export PGDATABASE=$(echo "$hostportdb" | cut -d/ -f2 | cut -d'?' -f1)
 
-    echo "Done."
+    echo "✔️ Fait."
     echo ""
 }
 
 fetch_and_export_dora_data() {
-    echo "Fetch and export DORA data..."
+    echo "💎 Récupération et synchronisation des données DORA..."
 
     # Specific to Scalingo, cf. https://doc.scalingo.com/platform/databases/access#manually-install-the-databases-cli-in-one-off
     # The program dbclient-fetcher on Scalingo downloads various CLI tools, such as psql, pg_dump, pg_restore, pg_ctl, etc.
@@ -77,25 +80,25 @@ fetch_and_export_dora_data() {
     time psql $DATABASE_URL -c "DROP SCHEMA public CASCADE; CREATE SCHEMA public; CREATE EXTENSION IF NOT EXISTS postgis;"
     time pg_restore --dbname=$DATABASE_URL --jobs=8 --format=directory --clean --if-exists --no-owner --no-privileges --verbose /tmp/out.dump
 
-    echo "Done."
+    echo "✔️ Fait."
     echo ""
 }
 
 fetch_and_export_di_data() {
-    echo "Fetch and export data·inclusion data..."
+    echo "💎 Récupération et synchronisation des données de data·inclusion..."
 
     # Installation of tool `duckdb` on Scalingo/Linux
     if command -v duckdb &>/dev/null; then
-        echo "duckdb is already installed, skipping download."
+        echo "duckdb est déjà installé, installation ignorée."
     else
         if [[ "$OSTYPE" == linux* ]]; then
-            echo "duckdb not found. Installing duckdb..."
+            echo "Installation de duckdb pour Linux..."
             curl -L -o /tmp/duckdb_cli.zip https://github.com/duckdb/duckdb/releases/latest/download/duckdb_cli-linux-amd64.zip
             unzip -o /tmp/duckdb_cli.zip -d /tmp/duckdb
             export PATH="/tmp/duckdb:${PATH}"
-            echo "duckdb installed."
+            echo "duckdb installé."
         else
-            echo "duckdb is not yet installed. "
+            echo "duckdb est requis. Vous pouvez le télécharger depuis https://duckdb.org/docs/installation"
             exit 1
         fi
     fi
@@ -140,19 +143,19 @@ EOF
     # Execute SQL export/import orders
     time duckdb < "$DUCKSQL"
 
-    echo "Done."
+    echo "✔️ Fait."
     echo ""
 }
 
 run_dbt_model_generation_and_validation() {
-    echo "Run DBT model generation and validation..."
+    echo "💎 Génération et validation du modèle DBT..."
 
     dbt debug
     dbt deps
     dbt seed
     dbt build
 
-    echo "Done."
+    echo "✔️ Fait."
     echo ""
 }
 


### PR DESCRIPTION
### 🍣 Problème

Nous avons une instance de Metabase (MB) qui nous sert à faire de l'exploration et de l'analyse de données, afin d'améliorer le produit, connaître nos usagers et le marché, et avoir un "pilotage par l'impact" du projet. 

Ce MB s'appuie sur une base de données obtenue à partir de la base de production, certaines tables étant recopiées (certains champs étant ignorés ou anonymisés) et d'autres étant pre-construites ou déduites (tables dites "intermediate" et "staging"). 

Pour augmenter notre capacité d'exploitation de la donnée récoltée / produite dans DORA, nous aimerions recouper les informations et les manipuler avec celles concernant les services et structures de data·inclusion.

A noter que la mise à jour de la "base analytics" et la synchronisation depuis la base de production de DORA est effectuée régulièrement, plusieurs fois par jour, via un script shell – `sync-analytics.sh`.

### 💡 Solution

L'objet de cette PR consiste à enrichir le script de synchronisation, pour qu'il réalise 2 actions supplémentaires : 
1. récupérer les données exploitables complètes de services et structures de data·inclusion (i.e. celles publiées par l'équipe data·inclusion)
2. charger ses données dans la même base – dora-analytics – que les autres tables issues de `pg_restore`(_public_)  ou `dbt`(_public_intermediate_ et _public_staging_)

Après échange avec @vperron à l'origine du Metabase et @vmttn (tous deux team data·inclusion), et en accord avec la vision stratégique et technique de la Plateforme (faire de data·inclusion un commun numérique le plus autonome, sans oublier que c'est un produit fraternel de DORA), nous avons décider de récupérer les fichiers au format .parquet (`services.parquet` et `structures.parquet`) déposés par DI régulièrement sur leur Object Storage.

Les autres pistes techniques évaluées : 
* récupérer les données depuis data.gouv.fr → KO car certains éditeurs refusent que DI exposent aussi ouvertement leurs données
* recopier les données directement depuis la base de production de DI → KO car s'éloigne trop de la vision "commun numérique" poursuivie par et pour DI

⚠️ Une contrainte importante est que le script puisse être exécuté automatiquement, plusieurs fois par jour, dans un conteneur Scalingo de type one-off. Il doit aussi pouvoir être exécuté manuellement (toujours dans un one-off) si besoin.

💡 La synchronisation prend 5mn.

### 🤖 Implémentation

ℹ️ Pour commencer, cette PR découpe les traitements en différentes fonctions, pour rendre le code plus lisible et maintenable. Ça permet d'avoir les grandes opérations en un coup d'œil à la fin.

<img width="388" alt="image" src="https://github.com/user-attachments/assets/0f6f4b58-7c74-4e77-b2ae-1541bc441187" />

ℹ️ Les outils introduits par cette PR : 
* ~~[`mc`](https://github.com/minio/mc), alias MinIO Client : il s'agit d'un client S3, plus léger et simple à installer + configurer que AWS CLI~~ (DuckDB permet d'[importer directement des fichiers parquet depuis un S3](https://duckdb.org/docs/stable/guides/network_cloud_storage/s3_import.html) 🤩)
* [`duckdb`](https://github.com/duckdb/duckdb) : une sorte de SQLite in-process qui permet de traiter des données à fort volume, en particulier au format `.parquet`  (en les important directement depuis un Object Storage S3 !) et capable de lire et écrire du SQL

Un troisième outil a été essayé et utilisé – le Scaleway CLI, [`scw`](https://github.com/scaleway/scaleway-cli) – mais il s'avère que ce n'est qu'un client de gestion des ressources pour un utilisateur admin, pas pensé pour manipuler du contenu traité par ces ressources techniques. Il nous a tout de même été utile pour améliorer notre compréhension de la gestion des ressources dans Scaleway et leur accès par des applications.

ℹ️ Nous nous sommes posés la question de faire le chargement dans PG par DuckDB via un script Python. Après tout, le conteneur one-off est basé sur celui de l'application Web, qui embarque un environnement Python. Nous avons privilégié le script SH par simplicité de langage (ne pas multiplier les langages pour maintenir l'opération de synchronisation de la  base analytics).

ℹ️ Pour ne pas alourdir le script, sur la partie récupération et installation des dépendances, le script prend le parti que : 
* a) nous sommes sur un environnement Scalingo one-off avec possibilité d'installer les utilitaires nécessaires pour PostgreSQL ou
* b) nous sommes sur un environnement Linux
* c) nous sommes sur un environnement autre (Mac, Windows) mais nous avons préalablement installé les outils (pg_dump, pg_restore, duckdb)

ℹ️ La façon de procéder de DuckDB (pour ce script) : 
1. Il récupère le fichier .parquet
2. Il le charge en mémoire, dans un équivalent de la table sur la base cible
3. Il recopie la table concernée (ex : di_services) vers la base/table cible (via un `CREATE xxx AS SELECT xxx`)

Quand tout s'est bien passé, on voit les 2 tables apparaître dans Metabase !

<img width="1512" alt="image" src="https://github.com/user-attachments/assets/38cae759-febd-4bb2-80c7-827f58bb4219" />

