### PR TITLE
fix: zoomToStructures() : gère le cas où coordinates est vide

### DIFF
--- a/front/src/routes/admin/structures/structures-map.svelte
+++ b/front/src/routes/admin/structures/structures-map.svelte
@@ -37,6 +37,11 @@
       }
     } else if (department) {
       const coordinates = department.geom.coordinates[0];
+      // Quand la géométries a été sursimplifiée, on n'a pas de coordonnées.
+      // Dans ce cas, on ne fait rien en attendant que la logique de simplification soit mise à jour.
+      if (!coordinates) {
+        return;
+      }
       const bounds = coordinates.reduce(
         function (acc, coord) {
           return acc.extend(coord);


### PR DESCRIPTION
La géométrie du département est simplifiée sur le back-end dans le  `DeptSerializer`. Dans le cas de certains départements, la simplification est trop importante et on n'a plus de coordonnées.

En attendant de corriger proprement ce problème côté back-end, je gère le cas où on n'a pas de coordonnées côté front-end pour éviter un plantage.