### PR TITLE
fix: simplification et déduplication des appels à l'API

### DIFF
--- a/front/src/lib/components/inputs/geo/admin-division-search.svelte
+++ b/front/src/lib/components/inputs/geo/admin-division-search.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import Select from "$lib/components/inputs/select/select.svelte";
   import type { AdminDivisionType, GeoApiValue } from "$lib/types";
-  import { getApiURL } from "$lib/utils/api";
+  import { API_URL } from "$lib/env";
   import { getDepartmentFromCityCode } from "$lib/utils/misc";
   import {
     contextValidationKey,
@@ -21,7 +21,7 @@
   export let withGeom = false;
 
   async function searchAdminDivision(query) {
-    const url = `${getApiURL()}/admin-division-search/?type=${searchType}&q=${encodeURIComponent(
+    const url = `${API_URL}/admin-division-search/?type=${searchType}&q=${encodeURIComponent(
       query
     )}&${withGeom ? "with_geom=1" : ""}`;
     const response = await fetch(url);

--- a/front/src/lib/components/inputs/geo/city-search.svelte
+++ b/front/src/lib/components/inputs/geo/city-search.svelte
@@ -2,7 +2,7 @@
   import Select from "$lib/components/inputs/select/select.svelte";
   import { pinDistanceIcon } from "$lib/icons";
   import type { Choice, GeoApiValue } from "$lib/types";
-  import { getApiURL } from "$lib/utils/api";
+  import { API_URL } from "$lib/env";
   import { fetchData, getDepartmentFromCityCode } from "$lib/utils/misc";
 
   export let onChange: (newValue: GeoApiValue) => void;
@@ -14,7 +14,7 @@
 
   let choices: Choice[] = [];
   async function searchCity(query) {
-    const url = `${getApiURL()}/admin-division-search/?type=city&q=${encodeURIComponent(
+    const url = `${API_URL}/admin-division-search/?type=city&q=${encodeURIComponent(
       query
     )}`;
 
@@ -39,7 +39,7 @@
     const longitude = position.coords.longitude;
     const latitude = position.coords.latitude;
 
-    const url = `${getApiURL()}/admin-division-reverse-search/?type=city&lon=${encodeURIComponent(
+    const url = `${API_URL}/admin-division-reverse-search/?type=city&lon=${encodeURIComponent(
       longitude
     )}&lat=${encodeURIComponent(latitude)}`;
 

--- a/front/src/lib/components/inputs/uploader.svelte
+++ b/front/src/lib/components/inputs/uploader.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { deleteBinIcon } from "$lib/icons";
-  import { getApiURL } from "$lib/utils/api";
+  import { API_URL } from "$lib/env";
   import { shortenString } from "$lib/utils/misc";
   import Alert from "../display/alert.svelte";
 
@@ -43,8 +43,8 @@
       const file = files.item(i);
       // We can't use fetch if we want a progress indicator
       const url = structureSlug
-        ? `${getApiURL()}/upload/${structureSlug}/${file.name}/`
-        : `${getApiURL()}/safe-upload/${file.name}/`;
+        ? `${API_URL}/upload/${structureSlug}/${file.name}/`
+        : `${API_URL}/safe-upload/${file.name}/`;
       const request = new XMLHttpRequest();
       request.open("POST", url);
       request.setRequestHeader("Accept", "application/json; version=1.0");

--- a/front/src/lib/components/specialized/establishment-search/search-by-commune.svelte
+++ b/front/src/lib/components/specialized/establishment-search/search-by-commune.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { externalLinkIcon } from "$lib/icons";
-  import { getApiURL } from "$lib/utils/api";
+  import { API_URL } from "$lib/env";
   import CitySearch from "$lib/components/inputs/geo/city-search.svelte";
   import Select from "$lib/components/inputs/select/select.svelte";
   import FieldWrapper from "$lib/components/forms/field-wrapper.svelte";
@@ -32,7 +32,7 @@
 
   async function searchSirene(query) {
     if (city) {
-      const url = `${getApiURL()}/search-sirene/${
+      const url = `${API_URL}/search-sirene/${
         city.code
       }/?q=${encodeURIComponent(query)}`;
 

--- a/front/src/lib/components/specialized/establishment-search/search-by-safir.svelte
+++ b/front/src/lib/components/specialized/establishment-search/search-by-safir.svelte
@@ -3,7 +3,7 @@
   import FieldWrapper from "$lib/components/forms/field-wrapper.svelte";
   import type { Establishment } from "$lib/types";
 
-  import { getApiURL } from "$lib/utils/api";
+  import { API_URL } from "$lib/env";
 
   const safirRegexp = /^\d{5}$/u;
 
@@ -19,7 +19,7 @@
   $: safirIsValid = !!safirInput?.match(safirRegexp);
 
   async function handleValidateSafir() {
-    const url = `${getApiURL()}/search-safir/?safir=${encodeURIComponent(
+    const url = `${API_URL}/search-safir/?safir=${encodeURIComponent(
       safirInput
     )}`;
 

--- a/front/src/lib/components/specialized/establishment-search/search-by-siret.svelte
+++ b/front/src/lib/components/specialized/establishment-search/search-by-siret.svelte
@@ -3,7 +3,7 @@
   import FieldWrapper from "$lib/components/forms/field-wrapper.svelte";
   import type { Establishment } from "$lib/types";
 
-  import { getApiURL } from "$lib/utils/api";
+  import { API_URL } from "$lib/env";
   import { siretRegexp } from "$lib/validation/schema-utils";
 
   export let onEstablishmentChange: (
@@ -19,7 +19,7 @@
   $: siretIsValid = !!siretInput?.match(siretRegexp);
 
   async function handleValidateSiret() {
-    const url = `${getApiURL()}/search-siret/?siret=${encodeURIComponent(
+    const url = `${API_URL}/search-siret/?siret=${encodeURIComponent(
       siretInput
     )}`;
 

--- a/front/src/lib/components/specialized/pc-button.svelte
+++ b/front/src/lib/components/specialized/pc-button.svelte
@@ -1,10 +1,10 @@
 <script lang="ts">
-  import { getApiURL } from "$lib/utils/api";
+  import { API_URL } from "$lib/env";
   import logoPC from "$lib/assets/proconnect/bouton_proconnect.svg";
 
   export let nextPage: string;
 
-  const loginUrl = `${getApiURL()}/oidc/login/?next=${encodeURIComponent(nextPage)}`;
+  const loginUrl = `${API_URL}/oidc/login/?next=${encodeURIComponent(nextPage)}`;
 </script>
 
 <div class="text-center">

--- a/front/src/lib/env.ts
+++ b/front/src/lib/env.ts
@@ -1,6 +1,5 @@
 export const API_URL = import.meta.env.VITE_API_URL || "http://localhost:8000";
 export const ENVIRONMENT = import.meta.env.VITE_ENVIRONMENT;
-export const INTERNAL_API_URL = import.meta.env.VITE_INTERNAL_API_URL;
 export const SENTRY_DSN = import.meta.env.VITE_SENTRY_DSN;
 export const CANONICAL_URL = import.meta.env.VITE_PUBLIC_CANONICAL_URL;
 export const METABASE_EMBED_URL = import.meta.env.VITE_METABASE_EMBED_URL;

--- a/front/src/lib/requests/admin.ts
+++ b/front/src/lib/requests/admin.ts
@@ -4,7 +4,7 @@ import type {
   Service,
   Structure,
 } from "$lib/types";
-import { getApiURL } from "$lib/utils/api";
+import { API_URL } from "$lib/env";
 import { token } from "$lib/utils/auth";
 import { logException } from "$lib/utils/logger";
 import { fetchData } from "$lib/utils/misc";
@@ -13,7 +13,7 @@ import { get } from "svelte/store";
 export async function getStructuresAdmin(
   departmentCode
 ): Promise<AdminShortStructure[]> {
-  let url = `${getApiURL()}/structures-admin/`;
+  let url = `${API_URL}/structures-admin/`;
 
   if (departmentCode) {
     url += `?department=${departmentCode}`;
@@ -22,28 +22,28 @@ export async function getStructuresAdmin(
 }
 
 export async function getStructureAdmin(slug): Promise<AdminShortStructure> {
-  const url = `${getApiURL()}/structures-admin/${slug}/`;
+  const url = `${API_URL}/structures-admin/${slug}/`;
   return (await fetchData<Structure>(url)).data;
 }
 
 export async function getStructuresToModerate() {
-  const url = `${getApiURL()}/structures-admin/?moderation=1`;
+  const url = `${API_URL}/structures-admin/?moderation=1`;
   return (await fetchData(url)).data;
 }
 
 export async function getServicesAdmin() {
-  const url = `${getApiURL()}/services-admin/`;
+  const url = `${API_URL}/services-admin/`;
   return (await fetchData(url)).data;
 }
 
 export async function getServiceAdmin(slug) {
-  const url = `${getApiURL()}/services-admin/${slug}/`;
+  const url = `${API_URL}/services-admin/${slug}/`;
   return (await fetchData<Service>(url)).data;
 }
 
 export async function setModerationState(entity, status: ModerationStatus) {
   const urlFragment = entity.services ? "structures-admin" : "services-admin";
-  const url = `${getApiURL()}/${urlFragment}/${entity.slug}/`;
+  const url = `${API_URL}/${urlFragment}/${entity.slug}/`;
   const method = "PATCH";
   const response = await fetch(url, {
     method,
@@ -61,7 +61,7 @@ export async function setModerationState(entity, status: ModerationStatus) {
 }
 
 export async function getServiceSuggestions() {
-  const url = `${getApiURL()}/services-suggestions/`;
+  const url = `${API_URL}/services-suggestions/`;
   const results = (await fetchData(url)).data;
   if (!results) {
     return [];
@@ -71,7 +71,7 @@ export async function getServiceSuggestions() {
 }
 
 export async function deleteServiceSuggestion(suggestion) {
-  const url = `${getApiURL()}/services-suggestions/${suggestion.id}/`;
+  const url = `${API_URL}/services-suggestions/${suggestion.id}/`;
   const method = "DELETE";
   const res = await fetch(url, {
     method,
@@ -96,7 +96,7 @@ export async function deleteServiceSuggestion(suggestion) {
 }
 
 export async function acceptServiceSuggestion(suggestion) {
-  const url = `${getApiURL()}/services-suggestions/${suggestion.id}/validate/`;
+  const url = `${API_URL}/services-suggestions/${suggestion.id}/validate/`;
   const method = "POST";
   const res = await fetch(url, {
     method,
@@ -128,7 +128,7 @@ export async function acceptServiceSuggestion(suggestion) {
 }
 
 export function publishServiceSuggestion(suggestion, source) {
-  const url = `${getApiURL()}/services-suggestions/`;
+  const url = `${API_URL}/services-suggestions/`;
   const method = "POST";
   const { siret, name, ...contents } = suggestion;
   const authToken = get(token);

--- a/front/src/lib/requests/geo.ts
+++ b/front/src/lib/requests/geo.ts
@@ -1,9 +1,9 @@
-import { getApiURL } from "../utils/api";
+import { API_URL } from "$lib/env";
 import { log } from "../utils/logger";
 import { fetchData } from "../utils/misc";
 
 export async function getCityLabel(inseeCode): Promise<string> {
-  const url = `${getApiURL()}/city-label/${inseeCode}/`;
+  const url = `${API_URL}/city-label/${inseeCode}/`;
   const result = await fetchData<string>(url);
   if (result.ok) {
     return result.data;

--- a/front/src/lib/requests/saved-search.ts
+++ b/front/src/lib/requests/saved-search.ts
@@ -1,7 +1,7 @@
 import { fetchData } from "$lib/utils/misc";
 import { get } from "svelte/store";
 import { token } from "../utils/auth";
-import { getApiURL } from "../utils/api";
+import { API_URL } from "$lib/env";
 import type { SavedSearch, SavedSearchNotificationFrequency } from "$lib/types";
 import { getQueryString } from "../utils/service-search";
 
@@ -18,7 +18,7 @@ export async function saveSearch(
     | "fundingLabels"
   >
 ) {
-  const url = `${getApiURL()}/saved-searches/`;
+  const url = `${API_URL}/saved-searches/`;
   const method = "POST";
   const response = await fetch(url, {
     method,
@@ -38,7 +38,7 @@ export async function updateSavedSearchFrequency(
   savedSearchId: number,
   frequency: SavedSearchNotificationFrequency
 ) {
-  const url = `${getApiURL()}/saved-searches/${savedSearchId}/`;
+  const url = `${API_URL}/saved-searches/${savedSearchId}/`;
   const method = "PATCH";
 
   const response = await fetch(url, {
@@ -56,7 +56,7 @@ export async function updateSavedSearchFrequency(
 }
 
 export async function deleteSavedSearch(savedSearchId: number) {
-  const url = `${getApiURL()}/saved-searches/${savedSearchId}/`;
+  const url = `${API_URL}/saved-searches/${savedSearchId}/`;
   const method = "DELETE";
 
   const response = await fetch(url, {
@@ -73,7 +73,7 @@ export async function deleteSavedSearch(savedSearchId: number) {
 }
 
 export async function getRecentSearchResults(savedSearchId: number) {
-  const url = `${getApiURL()}/saved-searches/${savedSearchId}/recent/`;
+  const url = `${API_URL}/saved-searches/${savedSearchId}/recent/`;
 
   const response = await fetchData<SavedSearch[]>(url);
   if (!response.ok) {

--- a/front/src/lib/requests/services.ts
+++ b/front/src/lib/requests/services.ts
@@ -46,9 +46,12 @@ export async function getService(slug): Promise<Service> {
   return serviceToFront(response.data);
 }
 
-export async function getServiceDI(diId): Promise<Service> {
+export async function getServiceDI(
+  diId,
+  svelteFetch?: typeof fetch
+): Promise<Service> {
   const url = `${API_URL}/services-di/${diId}/`;
-  const response = await fetchData<Service>(url);
+  const response = await fetchData<Service>(url, svelteFetch);
 
   if (!response.data) {
     return null;

--- a/front/src/lib/requests/services.ts
+++ b/front/src/lib/requests/services.ts
@@ -1,4 +1,4 @@
-import { getApiURL } from "$lib/utils/api";
+import { API_URL } from "$lib/env";
 import { token } from "$lib/utils/auth";
 import { fetchData } from "$lib/utils/misc";
 import { get } from "svelte/store";
@@ -35,7 +35,7 @@ function serviceToFront(service) {
 }
 
 export async function getService(slug): Promise<Service> {
-  const url = `${getApiURL()}/services/${slug}/`;
+  const url = `${API_URL}/services/${slug}/`;
   const response = await fetchData<Service>(url);
 
   if (!response.data) {
@@ -47,7 +47,7 @@ export async function getService(slug): Promise<Service> {
 }
 
 export async function getServiceDI(diId): Promise<Service> {
-  const url = `${getApiURL()}/services-di/${diId}/`;
+  const url = `${API_URL}/services-di/${diId}/`;
   const response = await fetchData<Service>(url);
 
   if (!response.data) {
@@ -65,7 +65,7 @@ export async function getPublishedServices({
   pageSize: number;
   page: number;
 }) {
-  const url = new URL("/services/", getApiURL());
+  const url = new URL("/services/", API_URL);
 
   url.searchParams.append("published", "1");
   url.searchParams.append("page_size", pageSize.toString());
@@ -77,7 +77,7 @@ export async function getPublishedServices({
 }
 
 export async function getModel(slug): Promise<Model> {
-  const url = `${getApiURL()}/models/${slug}/`;
+  const url = `${API_URL}/models/${slug}/`;
   const response = await fetchData<Model>(url);
 
   if (!response.data) {
@@ -91,10 +91,10 @@ export async function getModel(slug): Promise<Model> {
 export function createOrModifyService(service: Service) {
   let method, url;
   if (service.slug) {
-    url = `${getApiURL()}/services/${service.slug}/`;
+    url = `${API_URL}/services/${service.slug}/`;
     method = "PATCH";
   } else {
-    url = `${getApiURL()}/services/`;
+    url = `${API_URL}/services/`;
     method = "POST";
   }
 
@@ -110,7 +110,7 @@ export function createOrModifyService(service: Service) {
 }
 
 export function markServiceAsSynced(service: Service | ShortService) {
-  return fetch(`${getApiURL()}/services/${service.slug}/`, {
+  return fetch(`${API_URL}/services/${service.slug}/`, {
     method: "PATCH",
     headers: {
       Accept: "application/json; version=1.0",
@@ -124,10 +124,10 @@ export function markServiceAsSynced(service: Service | ShortService) {
 export async function createOrModifyModel(model, updateAllServices = false) {
   let method, url;
   if (model.slug) {
-    url = `${getApiURL()}/models/${model.slug}/`;
+    url = `${API_URL}/models/${model.slug}/`;
     method = "PATCH";
   } else {
-    url = `${getApiURL()}/models/`;
+    url = `${API_URL}/models/`;
     method = "POST";
   }
 
@@ -150,7 +150,7 @@ export async function createOrModifyModel(model, updateAllServices = false) {
 }
 
 export async function deleteService(serviceSlug) {
-  const url = `${getApiURL()}/services/${serviceSlug}/`;
+  const url = `${API_URL}/services/${serviceSlug}/`;
   const method = "DELETE";
   const res = await fetch(url, {
     method,
@@ -175,12 +175,12 @@ export async function deleteService(serviceSlug) {
 }
 
 export async function getBookmarks(): Promise<ShortService[]> {
-  const url = `${getApiURL()}/bookmarks/`;
+  const url = `${API_URL}/bookmarks/`;
   return (await fetchData<ShortService[]>(url)).data;
 }
 
 export async function setBookmark(bookmarkSlug: string, isDI: boolean) {
-  const url = `${getApiURL()}/bookmarks/`;
+  const url = `${API_URL}/bookmarks/`;
   const method = "POST";
   const response = await fetch(url, {
     method,
@@ -197,7 +197,7 @@ export async function setBookmark(bookmarkSlug: string, isDI: boolean) {
 }
 
 export async function clearBookmark(bookmarkId: number) {
-  const url = `${getApiURL()}/bookmarks/${bookmarkId}/`;
+  const url = `${API_URL}/bookmarks/${bookmarkId}/`;
   const method = "DELETE";
   const response = await fetch(url, {
     method,
@@ -213,7 +213,7 @@ export async function clearBookmark(bookmarkId: number) {
 }
 
 export async function unPublishService(serviceSlug) {
-  const url = `${getApiURL()}/services/${serviceSlug}/`;
+  const url = `${API_URL}/services/${serviceSlug}/`;
   const method = "PATCH";
   const status: ServiceStatus = "DRAFT";
   const response = await fetch(url, {
@@ -232,7 +232,7 @@ export async function unPublishService(serviceSlug) {
 }
 
 export async function archiveService(serviceSlug) {
-  const url = `${getApiURL()}/services/${serviceSlug}/`;
+  const url = `${API_URL}/services/${serviceSlug}/`;
   const method = "PATCH";
   const status: ServiceStatus = "ARCHIVED";
 
@@ -252,7 +252,7 @@ export async function archiveService(serviceSlug) {
 }
 
 export async function unarchiveService(serviceSlug) {
-  const url = `${getApiURL()}/services/${serviceSlug}/`;
+  const url = `${API_URL}/services/${serviceSlug}/`;
   const method = "PATCH";
   const status: ServiceStatus = "DRAFT";
 
@@ -272,7 +272,7 @@ export async function unarchiveService(serviceSlug) {
 }
 
 export async function publishService(serviceSlug) {
-  const url = `${getApiURL()}/services/${serviceSlug}/`;
+  const url = `${API_URL}/services/${serviceSlug}/`;
   const method = "PATCH";
   const status: ServiceStatus = "PUBLISHED";
 
@@ -292,7 +292,7 @@ export async function publishService(serviceSlug) {
 }
 
 export async function convertSuggestionToDraft(serviceSlug) {
-  const url = `${getApiURL()}/services/${serviceSlug}/`;
+  const url = `${API_URL}/services/${serviceSlug}/`;
   const method = "PATCH";
   const status: ServiceStatus = "DRAFT";
 
@@ -312,14 +312,14 @@ export async function convertSuggestionToDraft(serviceSlug) {
 }
 
 export async function getServicesOptions(): Promise<ServicesOptions | null> {
-  const url = `${getApiURL()}/services-options/`;
+  const url = `${API_URL}/services-options/`;
   return (await fetchData<ServicesOptions>(url)).data;
 }
 
 export function updateServicesFromModel(
   services: Service[] | StructureService[]
 ) {
-  return fetch(`${getApiURL()}/services/update-from-model/`, {
+  return fetch(`${API_URL}/services/update-from-model/`, {
     method: "POST",
     headers: {
       Accept: "application/json; version=1.0",
@@ -340,7 +340,7 @@ type ModelToService = {
 export function addIgnoredServicesToUpdate(
   modelToServiceSlugs: ModelToService[]
 ) {
-  return fetch(`${getApiURL()}/services/reject-update-from-model/`, {
+  return fetch(`${API_URL}/services/reject-update-from-model/`, {
     method: "POST",
     headers: {
       Accept: "application/json; version=1.0",
@@ -354,7 +354,7 @@ export function addIgnoredServicesToUpdate(
 }
 
 export function markServicesAsUpToDate(services: { slug: string }[]) {
-  return fetch(`${getApiURL()}/services/mark-as-up-to-date/`, {
+  return fetch(`${API_URL}/services/mark-as-up-to-date/`, {
     method: "POST",
     headers: {
       Accept: "application/json; version=1.0",

--- a/front/src/lib/requests/structures.ts
+++ b/front/src/lib/requests/structures.ts
@@ -1,4 +1,4 @@
-import { getApiURL } from "$lib/utils/api";
+import { API_URL } from "$lib/env";
 import { token } from "$lib/utils/auth";
 import { fetchData } from "$lib/utils/misc";
 import { get } from "svelte/store";
@@ -32,7 +32,7 @@ function structureToFront(structure: Structure): Structure {
 }
 
 export async function siretWasAlreadyClaimed(siret: string) {
-  const url = `${getApiURL()}/siret-claimed/${siret}`;
+  const url = `${API_URL}/siret-claimed/${siret}`;
   const res = await fetch(url, {
     headers: {
       Accept: "application/json; version=1.0",
@@ -64,7 +64,7 @@ export async function getManagedStructures(
   searchText?: string
 ): Promise<ShortStructure[]> {
   const searchParam = searchText ? `&search=${searchText}` : "";
-  const url = `${getApiURL()}/structures/?managed=1${searchParam}`;
+  const url = `${API_URL}/structures/?managed=1${searchParam}`;
   return (await fetchData<ShortStructure[]>(url)).data;
 }
 
@@ -75,7 +75,7 @@ export async function getActiveStructures({
   pageSize: number;
   page: number;
 }) {
-  const url = new URL("/structures/", getApiURL());
+  const url = new URL("/structures/", API_URL);
 
   url.searchParams.append("active", "1");
   url.searchParams.append("page_size", pageSize.toString());
@@ -89,13 +89,13 @@ export async function getActiveStructures({
 }
 
 export async function getStructure(slug: string): Promise<Structure | null> {
-  const url = `${getApiURL()}/structures/${slug}/`;
+  const url = `${API_URL}/structures/${slug}/`;
   const structure = (await fetchData<Structure>(url)).data;
   return structure ? structureToFront(structure) : null;
 }
 
 export function createStructure(structure) {
-  const url = `${getApiURL()}/structures/`;
+  const url = `${API_URL}/structures/`;
   const method = "POST";
   return fetch(url, {
     method,
@@ -110,7 +110,7 @@ export function createStructure(structure) {
 }
 
 export function modifyStructure(structure) {
-  const url = `${getApiURL()}/structures/${structure.slug}/`;
+  const url = `${API_URL}/structures/${structure.slug}/`;
 
   const method = "PATCH";
   return fetch(url, {
@@ -129,7 +129,7 @@ let structuresOptions;
 
 export async function getStructuresOptions(): Promise<StructuresOptions> {
   if (!structuresOptions) {
-    const url = `${getApiURL()}/structures-options/`;
+    const url = `${API_URL}/structures-options/`;
     const res = await fetchData<StructuresOptions>(url);
     structuresOptions = res.data;
   }
@@ -137,7 +137,7 @@ export async function getStructuresOptions(): Promise<StructuresOptions> {
 }
 
 export async function getMembers(slug): Promise<Array<StructureMember> | null> {
-  const url = `${getApiURL()}/structure-members/?structure=${slug}`;
+  const url = `${API_URL}/structure-members/?structure=${slug}`;
 
   const result = await fetchData(url);
   if (result.ok) {
@@ -149,7 +149,7 @@ export async function getMembers(slug): Promise<Array<StructureMember> | null> {
 export async function getPutativeMembers(
   slug
 ): Promise<Array<PutativeStructureMember> | null> {
-  const url = `${getApiURL()}/structure-putative-members/?structure=${slug}`;
+  const url = `${API_URL}/structure-putative-members/?structure=${slug}`;
 
   const result = await fetchData(url);
   if (result.ok) {
@@ -159,7 +159,7 @@ export async function getPutativeMembers(
 }
 
 export async function deleteMember(uuid) {
-  const url = `${getApiURL()}/structure-members/${uuid}/`;
+  const url = `${API_URL}/structure-members/${uuid}/`;
   const method = "DELETE";
   const res = await fetch(url, {
     method,
@@ -184,7 +184,7 @@ export async function deleteMember(uuid) {
 }
 
 export async function resendInvite(uuid) {
-  const url = `${getApiURL()}/structure-putative-members/${uuid}/resend-invite/`;
+  const url = `${API_URL}/structure-putative-members/${uuid}/resend-invite/`;
   const method = "POST";
   const res = await fetch(url, {
     method,
@@ -209,7 +209,7 @@ export async function resendInvite(uuid) {
 }
 
 export async function cancelInvite(uuid) {
-  const url = `${getApiURL()}/structure-putative-members/${uuid}/cancel-invite/`;
+  const url = `${API_URL}/structure-putative-members/${uuid}/cancel-invite/`;
   const method = "POST";
   const res = await fetch(url, {
     method,
@@ -234,7 +234,7 @@ export async function cancelInvite(uuid) {
 }
 
 export async function acceptMember(uuid) {
-  const url = `${getApiURL()}/structure-putative-members/${uuid}/accept-membership-request/`;
+  const url = `${API_URL}/structure-putative-members/${uuid}/accept-membership-request/`;
   const method = "POST";
   const res = await fetch(url, {
     method,
@@ -259,7 +259,7 @@ export async function acceptMember(uuid) {
 }
 
 export async function rejectMembershipRequest(uuid) {
-  const url = `${getApiURL()}/structure-putative-members/${uuid}/reject-membership-request/`;
+  const url = `${API_URL}/structure-putative-members/${uuid}/reject-membership-request/`;
   const method = "POST";
   const res = await fetch(url, {
     method,

--- a/front/src/lib/utils/api.ts
+++ b/front/src/lib/utils/api.ts
@@ -1,11 +1,1 @@
-import { browser } from "$app/environment";
-import { API_URL, INTERNAL_API_URL } from "$lib/env";
-
-export function getApiURL() {
-  if (browser || !INTERNAL_API_URL) {
-    return API_URL;
-  }
-  return INTERNAL_API_URL;
-}
-
 export const defaultAcceptHeader = "application/json; version=1.0";

--- a/front/src/lib/utils/auth.ts
+++ b/front/src/lib/utils/auth.ts
@@ -1,5 +1,6 @@
 import { browser } from "$app/environment";
-import { defaultAcceptHeader, getApiURL } from "$lib/utils/api";
+import { defaultAcceptHeader } from "$lib/utils/api";
+import { API_URL } from "$lib/env";
 import { get, writable } from "svelte/store";
 import type { SavedSearch, ShortBookmark, ShortStructure } from "../types";
 import { log, logException } from "./logger";
@@ -50,7 +51,7 @@ export function setToken(newToken: string) {
 }
 
 function getUserInfo(authToken) {
-  return fetch(`${getApiURL()}/auth/user-info/`, {
+  return fetch(`${API_URL}/auth/user-info/`, {
     method: "POST",
     headers: {
       Accept: defaultAcceptHeader,

--- a/front/src/lib/utils/cgu.ts
+++ b/front/src/lib/utils/cgu.ts
@@ -1,6 +1,6 @@
 import { get } from "svelte/store";
 import { token } from "./auth";
-import { getApiURL } from "./api";
+import { API_URL } from "$lib/env";
 import { CGU_VERSION } from "../../routes/(static)/cgu/version";
 
 export function needToAcceptCgu(currentUserInfo) {
@@ -11,7 +11,7 @@ export function needToAcceptCgu(currentUserInfo) {
 }
 
 export async function acceptCgu() {
-  const url = `${getApiURL()}/auth/accept-cgu/`;
+  const url = `${API_URL}/auth/accept-cgu/`;
   const method = "POST";
   const response = await fetch(url, {
     method,

--- a/front/src/lib/utils/misc.ts
+++ b/front/src/lib/utils/misc.ts
@@ -39,15 +39,25 @@ export function htmlToMarkdown(html: string) {
   return "";
 }
 
-export async function fetchData<T>(url: string) {
+// L'implémentation Svelte de fetch (passée en paramètre) permet
+// de ne pas dupliquer la requête lorsqu'elle est appellée depuis
+// une fonction load() (qui est appelée à la fois sur le client et
+// sur le serveur). Pour que cela fonctionne, il faut que la
+// requête ait des headers identiques. Or on n'a pas accès au
+// token côté serveur. Par conséquent, on ne passe pas l'en-tête
+// Authorization si on utilise l'implémentation Svelte de fetch.
+// Elle ne peut donc être utilisée que pour les requêtes qui ne
+// nécessitent pas d'authentification. Il nous faudrait idéalement
+// trouver une solution pour les requêtes authentifiées.
+export async function fetchData<T>(url: string, svelteFetch?: typeof fetch) {
   const headers = { Accept: defaultAcceptHeader };
   const currentToken = get(token);
 
-  if (currentToken) {
+  if (currentToken && !svelteFetch) {
     headers.Authorization = `Token ${currentToken}`;
   }
 
-  const response = await fetch(url, {
+  const response = await (svelteFetch || fetch)(url, {
     headers,
   });
 

--- a/front/src/lib/utils/orientation.ts
+++ b/front/src/lib/utils/orientation.ts
@@ -1,16 +1,16 @@
-import { getApiURL } from "./api";
+import { API_URL } from "$lib/env";
 import { fetchData } from "./misc";
 import { TEST_WORDS } from "$lib/consts";
 import type { Choice, Orientation, Service } from "$lib/types";
 
 export function getOrientation(queryId: string, queryHash: string) {
   return fetchData<Orientation>(
-    `${getApiURL()}/orientations/${queryId}/?h=${queryHash}`
+    `${API_URL}/orientations/${queryId}/?h=${queryHash}`
   );
 }
 
 export async function refreshOrientationLink(queryId: string) {
-  const url = `${getApiURL()}/orientations/${queryId}/refresh/`;
+  const url = `${API_URL}/orientations/${queryId}/refresh/`;
   const method = "PATCH";
   await fetch(url, {
     method,
@@ -24,7 +24,7 @@ export function contactBeneficiary(
   ccReferent: boolean,
   message: string
 ) {
-  const url = `${getApiURL()}/orientations/${queryId}/contact/beneficiary/?h=${queryHash}`;
+  const url = `${API_URL}/orientations/${queryId}/contact/beneficiary/?h=${queryHash}`;
   const method = "POST";
   return fetch(url, {
     method,
@@ -47,7 +47,7 @@ export function contactPrescriber(
   ccReferent: boolean,
   message: string
 ) {
-  const url = `${getApiURL()}/orientations/${queryId}/contact/prescriber/?h=${queryHash}`;
+  const url = `${API_URL}/orientations/${queryId}/contact/prescriber/?h=${queryHash}`;
   const method = "POST";
   return fetch(url, {
     method,
@@ -68,7 +68,7 @@ export function denyOrientation(
   queryHash: string,
   { reasons, message }: { reasons: string[]; message: string }
 ) {
-  const url = `${getApiURL()}/orientations/${queryId}/reject/?h=${queryHash}`;
+  const url = `${API_URL}/orientations/${queryId}/reject/?h=${queryHash}`;
   const method = "POST";
   return fetch(url, {
     method,
@@ -94,7 +94,7 @@ export function acceptOrientation(
     beneficiaryMessage: string;
   }
 ) {
-  const url = `${getApiURL()}/orientations/${queryId}/validate/?h=${queryHash}`;
+  const url = `${API_URL}/orientations/${queryId}/validate/?h=${queryHash}`;
   const method = "POST";
   return fetch(url, {
     method,

--- a/front/src/lib/utils/stats.ts
+++ b/front/src/lib/utils/stats.ts
@@ -1,7 +1,7 @@
 import { browser } from "$app/environment";
 import { token } from "$lib/utils/auth";
 import { get } from "svelte/store";
-import { getApiURL } from "$lib/utils/api";
+import { API_URL } from "$lib/env";
 import { hexoid } from "hexoid";
 import type { Service, Structure } from "$lib/types";
 
@@ -33,7 +33,7 @@ async function logAnalyticsEvent(tag, path, params = {}) {
     headers.append("Authorization", `Token ${currentToken}`);
   }
 
-  const res = await fetch(`${getApiURL()}/stats/event/`, {
+  const res = await fetch(`${API_URL}/stats/event/`, {
     method: "POST",
     headers,
     body: JSON.stringify(data),

--- a/front/src/lib/utils/user.ts
+++ b/front/src/lib/utils/user.ts
@@ -1,5 +1,5 @@
 import { get } from "svelte/store";
-import { getApiURL } from "./api";
+import { API_URL } from "$lib/env";
 import { token, type DiscoveryMethod, type UserMainActivity } from "./auth";
 
 export interface UpdateUserProfileInput {
@@ -9,7 +9,7 @@ export interface UpdateUserProfileInput {
 }
 
 export function updateUserProfile(userProfileData: UpdateUserProfileInput) {
-  return fetch(`${getApiURL()}/profile/`, {
+  return fetch(`${API_URL}/profile/`, {
     method: "PATCH",
     body: JSON.stringify(userProfileData),
     headers: {

--- a/front/src/routes/(modeles-services)/components/sharing-modal.svelte
+++ b/front/src/routes/(modeles-services)/components/sharing-modal.svelte
@@ -2,7 +2,7 @@
   import Button from "$lib/components/display/button.svelte";
   import Form from "$lib/components/forms/form.svelte";
   import Modal from "$lib/components/hoc/modal.svelte";
-  import { getApiURL } from "$lib/utils/api";
+  import { API_URL } from "$lib/env";
   import { token } from "$lib/utils/auth";
   import BasicInputField from "$lib/components/forms/fields/basic-input-field.svelte";
   import * as v from "$lib/validation/schema-utils";
@@ -56,7 +56,7 @@
   function handleChange(_validatedData) {}
 
   function handleSubmit(validatedData) {
-    const url = `${getApiURL()}/services${isDI ? "-di" : ""}/${
+    const url = `${API_URL}/services${isDI ? "-di" : ""}/${
       service.slug
     }/share/`;
     const headers = new Headers({

--- a/front/src/routes/(modeles-services)/services/[slug]/+page.ts
+++ b/front/src/routes/(modeles-services)/services/[slug]/+page.ts
@@ -10,11 +10,14 @@ import { error, redirect } from "@sveltejs/kit";
 import { get } from "svelte/store";
 import type { PageLoad } from "./$types";
 
-export const load: PageLoad = async ({ url, params, parent }) => {
+export const load: PageLoad = async ({ fetch, url, params, parent }) => {
   await parent();
 
   if (params.slug.startsWith("di--")) {
-    const service = (await getServiceDI(params.slug.slice(4))) as Service;
+    const service = (await getServiceDI(
+      params.slug.slice(4),
+      fetch // on passe l'implémentation Svelte de fetch pour éviter de dupliquer la requête
+    )) as Service;
     if (!service) {
       error(404, "Page Not Found");
     }

--- a/front/src/routes/(modeles-services)/services/[slug]/orienter/+layout.ts
+++ b/front/src/routes/(modeles-services)/services/[slug]/orienter/+layout.ts
@@ -6,14 +6,18 @@ import {
   getServiceDI,
   getServicesOptions,
 } from "$lib/requests/services";
+import type { LayoutLoad } from "./$types";
 
 export const ssr = false;
 
-export const load = async ({ params, parent }) => {
+export const load: LayoutLoad = async ({ fetch, params, parent }) => {
   await parent();
 
   if (params.slug.startsWith("di--")) {
-    const service = (await getServiceDI(params.slug.slice(4))) as Service;
+    const service = (await getServiceDI(
+      params.slug.slice(4),
+      fetch // on passe l'implémentation Svelte de fetch pour éviter de dupliquer la requête
+    )) as Service;
     if (!service) {
       error(404, "Page Not Found");
     }

--- a/front/src/routes/(modeles-services)/services/[slug]/orienter/demande/+page.svelte
+++ b/front/src/routes/(modeles-services)/services/[slug]/orienter/demande/+page.svelte
@@ -4,7 +4,7 @@
   import Button from "$lib/components/display/button.svelte";
   import LinkButton from "$lib/components/display/link-button.svelte";
   import StickyFormSubmissionRow from "$lib/components/forms/sticky-form-submission-row.svelte";
-  import { getApiURL } from "$lib/utils/api";
+  import { API_URL } from "$lib/env";
   import { token } from "$lib/utils/auth";
   import Layout from "../orientation-layout.svelte";
   import type { PageData } from "./$types";
@@ -48,7 +48,7 @@
       validatedData.attachments
     ).flat();
 
-    return fetch(`${getApiURL()}/orientations/`, {
+    return fetch(`${API_URL}/orientations/`, {
       method: "POST",
       headers: {
         Accept: "application/json; version=1.0",

--- a/front/src/routes/(modeles-services)/services/[slug]/service-feedback-modal.svelte
+++ b/front/src/routes/(modeles-services)/services/[slug]/service-feedback-modal.svelte
@@ -12,7 +12,7 @@
   import Modal from "$lib/components/hoc/modal.svelte";
 
   import type { Service } from "$lib/types";
-  import { getApiURL } from "$lib/utils/api";
+  import { API_URL } from "$lib/env";
   import { userInfo } from "$lib/utils/auth";
   import * as v from "$lib/validation/schema-utils";
   import { validate } from "$lib/validation/validation";
@@ -163,7 +163,7 @@
   }
 
   function handleSubmit() {
-    const url = `${getApiURL()}/services${isDI ? "-di" : ""}/${
+    const url = `${API_URL}/services${isDI ? "-di" : ""}/${
       service.slug
     }/feedback/`;
 

--- a/front/src/routes/admin/structures/+page.ts
+++ b/front/src/routes/admin/structures/+page.ts
@@ -3,12 +3,12 @@ import { getStructuresOptions } from "$lib/requests/structures";
 import type { PageLoad } from "./$types";
 import { userInfo } from "$lib/utils/auth";
 import { get } from "svelte/store";
-import { getApiURL } from "$lib/utils/api";
+import { API_URL } from "$lib/env";
 import type { GeoApiValue } from "$lib/types";
 import { error } from "@sveltejs/kit";
 
 async function getDepartments(departmentCodes) {
-  const url = `${getApiURL()}/admin-division-departments/?dept_codes=${encodeURIComponent(
+  const url = `${API_URL}/admin-division-departments/?dept_codes=${encodeURIComponent(
     departmentCodes.join(",")
   )}`;
   const response = await fetch(url);

--- a/front/src/routes/admin/structures/creer/+page.svelte
+++ b/front/src/routes/admin/structures/creer/+page.svelte
@@ -10,7 +10,7 @@
   import EnsureLoggedIn from "$lib/components/hoc/ensure-logged-in.svelte";
   import StructureSearch from "$lib/components/specialized/establishment-search/search.svelte";
   import { siretWasAlreadyClaimed } from "$lib/requests/structures";
-  import { getApiURL } from "$lib/utils/api";
+  import { API_URL } from "$lib/env";
   import * as v from "$lib/validation/schema-utils";
   import { structureSchema } from "$lib/validation/schemas/structure";
   import { formErrors } from "$lib/validation/validation";
@@ -57,7 +57,7 @@
   function handleChange(_validatedData) {}
 
   function handleSubmit(validatedData) {
-    const url = `${getApiURL()}/auth/invite-first-admin/`;
+    const url = `${API_URL}/auth/invite-first-admin/`;
     const method = "POST";
 
     return fetch(url, {

--- a/front/src/routes/auth/connexion/send-magic-link.svelte
+++ b/front/src/routes/auth/connexion/send-magic-link.svelte
@@ -8,7 +8,7 @@
   import Notice from "$lib/components/display/notice.svelte";
   import FormErrors from "$lib/components/forms/form-errors.svelte";
   import Modal from "$lib/components/hoc/modal.svelte";
-  import { getApiURL } from "$lib/utils/api";
+  import { API_URL } from "$lib/env";
 
   const schema: v.Schema = {
     email: {
@@ -28,7 +28,7 @@
   let requesting = false;
 
   async function handleSubmit(validatedData) {
-    const url = `${getApiURL()}/auth/send-link/`;
+    const url = `${API_URL}/auth/send-link/`;
     const method = "POST";
     const result = await fetch(url, {
       method,

--- a/front/src/routes/auth/invitation/+page.svelte
+++ b/front/src/routes/auth/invitation/+page.svelte
@@ -5,19 +5,20 @@
   import Notice from "$lib/components/display/notice.svelte";
   import CheckboxMark from "$lib/components/display/checkbox-mark.svelte";
   import EnsureLoggedIn from "$lib/components/hoc/ensure-logged-in.svelte";
-  import { defaultAcceptHeader, getApiURL } from "$lib/utils/api";
+  import { defaultAcceptHeader } from "$lib/utils/api";
   import { token, validateCredsAndFillUserInfo } from "$lib/utils/auth";
   import { get } from "svelte/store";
   import AuthLayout from "../auth-layout.svelte";
   import type { PageData } from "./$types";
   import { CGU_VERSION } from "../../(static)/cgu/version";
+  import { API_URL } from "$lib/env";
 
   export let data: PageData;
   let cguAccepted = false;
   let joinError = "";
 
   async function handleJoin() {
-    const targetUrl = `${getApiURL()}/auth/join-structure/`;
+    const targetUrl = `${API_URL}/auth/join-structure/`;
 
     const response = await fetch(targetUrl, {
       method: "POST",

--- a/front/src/routes/auth/pc-logout/+page.ts
+++ b/front/src/routes/auth/pc-logout/+page.ts
@@ -1,8 +1,8 @@
-import { getApiURL } from "$lib/utils/api";
+import { API_URL } from "$lib/env";
 import { disconnect } from "$lib/utils/auth";
 import { redirect } from "@sveltejs/kit";
 
 export const load = () => {
   disconnect();
-  redirect(302, getApiURL() + "/oidc/pre_logout/");
+  redirect(302, API_URL + "/oidc/pre_logout/");
 };

--- a/front/src/routes/auth/rattachement/+page.svelte
+++ b/front/src/routes/auth/rattachement/+page.svelte
@@ -3,7 +3,7 @@
   import Button from "$lib/components/display/button.svelte";
   import EnsureLoggedIn from "$lib/components/hoc/ensure-logged-in.svelte";
   import StructureSearch from "$lib/components/specialized/establishment-search/search.svelte";
-  import { defaultAcceptHeader, getApiURL } from "$lib/utils/api";
+  import { defaultAcceptHeader } from "$lib/utils/api";
   import { token, userInfo, refreshUserInfo } from "$lib/utils/auth";
   import { get } from "svelte/store";
   import AuthLayout from "../auth-layout.svelte";
@@ -12,6 +12,7 @@
   import loopImg from "$lib/assets/icons/loop.svg";
   import Notice from "$lib/components/display/notice.svelte";
   import CheckboxMark from "$lib/components/display/checkbox-mark.svelte";
+  import { API_URL } from "$lib/env";
 
   export let data: PageData;
 
@@ -22,7 +23,7 @@
   let joinError = "";
 
   async function handleJoin() {
-    const targetUrl = `${getApiURL()}/auth/join-structure/`;
+    const targetUrl = `${API_URL}/auth/join-structure/`;
     const response = await fetch(targetUrl, {
       method: "POST",
       headers: {

--- a/front/src/routes/auth/rattachement/+page.ts
+++ b/front/src/routes/auth/rattachement/+page.ts
@@ -1,11 +1,11 @@
 import type { Establishment } from "$lib/types";
-import { getApiURL } from "$lib/utils/api";
+import { API_URL } from "$lib/env";
 import type { PageLoad } from "./$types";
 import { userInfo } from "$lib/utils/auth";
 import { get } from "svelte/store";
 
 function siretSearch(siret: string) {
-  const url = `${getApiURL()}/search-siret/?siret=${encodeURIComponent(siret)}`;
+  const url = `${API_URL}/search-siret/?siret=${encodeURIComponent(siret)}`;
 
   return fetch(url, {
     headers: {
@@ -16,7 +16,7 @@ function siretSearch(siret: string) {
 }
 
 function safirSearch(safir: string) {
-  const url = `${getApiURL()}/search-safir/?safir=${encodeURIComponent(safir)}`;
+  const url = `${API_URL}/search-safir/?safir=${encodeURIComponent(safir)}`;
 
   return fetch(url, {
     headers: {

--- a/front/src/routes/mes-alertes/+page.svelte
+++ b/front/src/routes/mes-alertes/+page.svelte
@@ -7,7 +7,7 @@
   import CenteredGrid from "$lib/components/display/centered-grid.svelte";
   import EnsureLoggedIn from "$lib/components/hoc/ensure-logged-in.svelte";
   import type { SavedSearch } from "$lib/types";
-  import { getApiURL } from "$lib/utils/api";
+  import { API_URL } from "$lib/env";
   import { refreshUserInfo, userInfo } from "$lib/utils/auth";
   import { fetchData } from "$lib/utils/misc";
   import { onMount } from "svelte";
@@ -16,7 +16,7 @@
   let savedSearches: SavedSearch[] | undefined = undefined;
 
   async function getSavedSearches() {
-    const url = `${getApiURL()}/saved-searches/`;
+    const url = `${API_URL}/saved-searches/`;
     const result = await fetchData(url);
     if (result.ok) {
       return result.data as Array<SavedSearch>;

--- a/front/src/routes/recherche/+page.ts
+++ b/front/src/routes/recherche/+page.ts
@@ -1,6 +1,6 @@
 import { getServicesOptions } from "$lib/requests/services";
 import type { SearchQuery, ServiceSearchResult } from "$lib/types";
-import { getApiURL } from "$lib/utils/api";
+import { API_URL } from "$lib/env";
 import { trackSearch } from "$lib/utils/stats";
 import { getQueryString, storeLastSearchCity } from "$lib/utils/service-search";
 import type { PageLoad } from "./$types";
@@ -39,7 +39,7 @@ async function getResults({
     lat,
     lon,
   });
-  const url = `${getApiURL()}/search/?${querystring}`;
+  const url = `${API_URL}/search/?${querystring}`;
 
   const res = await fetch(url, {
     headers: { Accept: "application/json; version=1.0" },

--- a/front/src/routes/structures/[slug]/collaborateurs/modal-add-user.svelte
+++ b/front/src/routes/structures/[slug]/collaborateurs/modal-add-user.svelte
@@ -2,7 +2,7 @@
   import Button from "$lib/components/display/button.svelte";
   import Form from "$lib/components/forms/form.svelte";
   import Modal from "$lib/components/hoc/modal.svelte";
-  import { getApiURL } from "$lib/utils/api";
+  import { API_URL } from "$lib/env";
   import { token } from "$lib/utils/auth";
   import { addUserSchema } from "$lib/validation/schemas/dashboard";
   import { get } from "svelte/store";
@@ -50,7 +50,7 @@
         }),
       };
     }
-    const url = `${getApiURL()}/structure-putative-members/?structure=${
+    const url = `${API_URL}/structure-putative-members/?structure=${
       structure.slug
     }`;
     return fetch(url, {

--- a/front/src/routes/structures/[slug]/collaborateurs/modal-change-user.svelte
+++ b/front/src/routes/structures/[slug]/collaborateurs/modal-change-user.svelte
@@ -3,7 +3,7 @@
   import Fieldset from "$lib/components/display/fieldset.svelte";
   import Form from "$lib/components/forms/form.svelte";
   import Modal from "$lib/components/hoc/modal.svelte";
-  import { getApiURL } from "$lib/utils/api";
+  import { API_URL } from "$lib/env";
   import { token } from "$lib/utils/auth";
   import { modifyUserSchema } from "$lib/validation/schemas/dashboard";
   import { get } from "svelte/store";
@@ -28,7 +28,7 @@
   let level = member.isAdmin ? "admin" : "user";
 
   function handleSubmit(validatedData) {
-    const url = `${getApiURL()}/structure-members/${member.id}/`;
+    const url = `${API_URL}/structure-members/${member.id}/`;
     return fetch(url, {
       method: "PATCH",
       body: JSON.stringify({


### PR DESCRIPTION
`getApiURL()` retourne la variable d'environnement `API_URL` ou `INTERNAL_API_URL`. Cette dernière n'est jamais utilisée, dans aucun environnement.  Par conséquent, j'ai supprimé son utilisation ainsi que `getApiURL()` afin d'utiliser `API_URL` directement.

Ajout de la possibilité d'utiliser l'implémentation Svelte de `fetch()` dans les requêtes à l'API. Cela permet de dédupliquer les requêtes quand la page est accédée directement, car dans ce cas `load()` est appelé côté client et serveur.

Utilisation de cette possibilité pour l'appel de `getServiceDI()` afin de moins fausser les stats de DI.

TODO : utiliser ça pour tous les autres appels API initiés dans les fonctions `load()`. Voir si on peut mieux mutualiser le code d'appels à l'API et permettre l'utilisation de l'implémentation Svelte de `fetch()` aux requêtes authentifiées.