### PR TITLE
feat: envoi du user agent et du user hash à DI lors de la récupération d'un service

### DIFF
--- a/back/dora/data_inclusion/client.py
+++ b/back/dora/data_inclusion/client.py
@@ -100,10 +100,10 @@ class DataInclusionClient:
         url = url / "services" / source / id
 
         if user_agent is not None:
-            url.args["user_agent"] = user_agent
+            self.session.headers.update({"User-Agent": user_agent})
 
         if user_hash is not None:
-            url.args["user_hash"] = user_hash
+            self.session.headers.update({"Anonymous-User-Hash": user_hash})
 
         try:
             response = self._get(url)

--- a/back/dora/data_inclusion/client.py
+++ b/back/dora/data_inclusion/client.py
@@ -89,9 +89,21 @@ class DataInclusionClient:
             return None
 
     @log_conn_error
-    def retrieve_service(self, source: str, id: str) -> Optional[dict]:
+    def retrieve_service(
+        self,
+        source: str,
+        id: str,
+        user_agent: Optional[str] = None,
+        user_hash: Optional[str] = None,
+    ) -> Optional[dict]:
         url = self.base_url.copy()
         url = url / "services" / source / id
+
+        if user_agent is not None:
+            url.args["user_agent"] = user_agent
+
+        if user_hash is not None:
+            url.args["user_hash"] = user_hash
 
         try:
             response = self._get(url)

--- a/back/dora/data_inclusion/test_utils.py
+++ b/back/dora/data_inclusion/test_utils.py
@@ -83,7 +83,13 @@ class FakeDataInclusionClient:
     def list_services(self, source: Optional[str] = None) -> Optional[list[dict]]:
         raise NotImplementedError()
 
-    def retrieve_service(self, source: str, id: str) -> Optional[dict]:
+    def retrieve_service(
+        self,
+        source: str,
+        id: str,
+        user_agent: Optional[str] = None,
+        user_hash: Optional[str] = None,
+    ) -> Optional[dict]:
         return next(
             (s for s in self.services if s["source"] == source and s["id"] == id), None
         )

--- a/back/dora/services/tests/test_services.py
+++ b/back/dora/services/tests/test_services.py
@@ -1848,6 +1848,25 @@ class DataInclusionSearchTestCase(APITestCase):
         assert response.status_code == 200
         assert len(response.data["services"]) == 2
 
+    def test_service_di_user_agent_user_hash(self):
+        service_data = self.make_di_service()
+        di_id = self.get_di_id(service_data)
+        with mock.patch.object(
+            FakeDataInclusionClient, "retrieve_service", return_value=service_data
+        ) as mock_retrieve_service:
+            request = self.factory.get(
+                f"/services-di/{di_id}/?user_hash=1234567890",
+                HTTP_USER_AGENT="test-agent",
+            )
+            response = self.service_di(request, di_id=di_id)
+            self.assertEqual(response.status_code, 200)
+            mock_retrieve_service.assert_called_once_with(
+                source=service_data["source"],
+                id=service_data["id"],
+                user_agent="test-agent",
+                user_hash="1234567890",
+            )
+
 
 class ServiceSearchTestCase(APITestCase):
     def setUp(self):

--- a/back/dora/services/tests/test_services.py
+++ b/back/dora/services/tests/test_services.py
@@ -1855,8 +1855,9 @@ class DataInclusionSearchTestCase(APITestCase):
             FakeDataInclusionClient, "retrieve_service", return_value=service_data
         ) as mock_retrieve_service:
             request = self.factory.get(
-                f"/services-di/{di_id}/?user_hash=1234567890",
+                f"/services-di/{di_id}/",
                 HTTP_USER_AGENT="test-agent",
+                HTTP_ANONYMOUS_USER_HASH="1234567890",
             )
             response = self.service_di(request, di_id=di_id)
             self.assertEqual(response.status_code, 200)

--- a/back/dora/services/views.py
+++ b/back/dora/services/views.py
@@ -772,10 +772,18 @@ def service_di(request, di_id: str):
     di_id = unquote(di_id)
     source_di, di_service_id = di_id.split("--")
 
+    user_agent = request.META.get("HTTP_USER_AGENT")
+    user_hash = request.GET.get("user_hash")
+
     di_client = data_inclusion.di_client_factory()
 
     try:
-        raw_service = di_client.retrieve_service(source=source_di, id=di_service_id)
+        raw_service = di_client.retrieve_service(
+            source=source_di,
+            id=di_service_id,
+            user_agent=user_agent,
+            user_hash=user_hash,
+        )
     except requests.ConnectionError:
         return Response(status=status.HTTP_502_BAD_GATEWAY)
 

--- a/back/dora/services/views.py
+++ b/back/dora/services/views.py
@@ -773,7 +773,7 @@ def service_di(request, di_id: str):
     source_di, di_service_id = di_id.split("--")
 
     user_agent = request.META.get("HTTP_USER_AGENT")
-    user_hash = request.GET.get("user_hash")
+    user_hash = request.META.get("HTTP_ANONYMOUS_USER_HASH")
 
     di_client = data_inclusion.di_client_factory()
 

--- a/front/src/lib/requests/services.ts
+++ b/front/src/lib/requests/services.ts
@@ -10,6 +10,7 @@ import type {
   ShortService,
   StructureService,
 } from "$lib/types";
+import { getAnalyticsId } from "$lib/utils/stats";
 import { logException } from "$lib/utils/logger";
 
 function serviceToBack(service) {
@@ -47,8 +48,12 @@ export async function getService(slug): Promise<Service> {
 }
 
 export async function getServiceDI(diId): Promise<Service> {
-  const url = `${getApiURL()}/services-di/${diId}/`;
-  const response = await fetchData<Service>(url);
+  const userHash = getAnalyticsId();
+  const url = new URL(`/services-di/${diId}/`, getApiURL());
+  if (userHash) {
+    url.searchParams.append("user_hash", userHash);
+  }
+  const response = await fetchData<Service>(url.toString());
 
   if (!response.data) {
     return null;

--- a/front/src/lib/requests/services.ts
+++ b/front/src/lib/requests/services.ts
@@ -50,10 +50,15 @@ export async function getService(slug): Promise<Service> {
 export async function getServiceDI(diId): Promise<Service> {
   const userHash = getAnalyticsId();
   const url = new URL(`/services-di/${diId}/`, getApiURL());
-  if (userHash) {
-    url.searchParams.append("user_hash", userHash);
-  }
-  const response = await fetchData<Service>(url.toString());
+
+  const response = await fetchData<Service>(
+    url.toString(),
+    userHash
+      ? {
+          "Anonymous-User-Hash": userHash,
+        }
+      : {}
+  );
 
   if (!response.data) {
     return null;

--- a/front/src/lib/utils/misc.ts
+++ b/front/src/lib/utils/misc.ts
@@ -39,8 +39,11 @@ export function htmlToMarkdown(html: string) {
   return "";
 }
 
-export async function fetchData<T>(url: string) {
-  const headers = { Accept: defaultAcceptHeader };
+export async function fetchData<T>(
+  url: string,
+  customHeaders: Record<string, string> = {}
+) {
+  const headers = { Accept: defaultAcceptHeader, ...customHeaders };
   const currentToken = get(token);
 
   if (currentToken) {

--- a/front/src/lib/utils/stats.ts
+++ b/front/src/lib/utils/stats.ts
@@ -7,7 +7,10 @@ import type { Service, Structure } from "$lib/types";
 
 const analyticsIdKey = "userHash";
 
-function getAnalyticsId() {
+export function getAnalyticsId() {
+  if (!browser) {
+    return null;
+  }
   let analyticsId = localStorage.getItem(analyticsIdKey);
   if (!analyticsId) {
     analyticsId = hexoid(32)();


### PR DESCRIPTION
Afin de permettre à DI de reconnaître les lectures de service faites par des robots, on passe le User-Agent et le _user hash_ (utilisé pour identifier un utilisateur anonyme) en par headers HTTP à la route `/api/v0/services/{source}/{id}`.

Ces informations ne sont accessibles que lorsque l'appel est fait depuis le client et pas depuis le serveur en mode SSR.