### PR TITLE
feat(sécu): traçage de la connexion des utilisateurs

### DIFF
--- a/back/dora/logs/__init__.py
+++ b/back/dora/logs/__init__.py
@@ -1,0 +1,4 @@
+import logging
+
+# Raccourci et side effect
+logger = logging.getLogger("dora.logs.core")

--- a/back/dora/logs/admin.py
+++ b/back/dora/logs/admin.py
@@ -23,7 +23,7 @@ class ActionLogAdmin(admin.ModelAdmin):
     list_display = ("id", "created_at", "log_level", "legal")
     list_filter = (LogLevelFilter, "legal")
     # voir modèle : pour l'instant pas de recherche sur le message du log
-    search_fields = ("id",)
+    search_fields = ("id", "msg")
     readonly_fields = ("id", "created_at", "log_level", "legal", "msg", "payload")
     ordering = ("-created_at",)
 

--- a/back/dora/oidc/backends.py
+++ b/back/dora/oidc/backends.py
@@ -137,7 +137,6 @@ class OIDCAuthenticationBackend(MozillaOIDCAuthenticationBackend):
                 "Connexion utilisateur via ProConnect",
                 {
                     "legal": True,
-                    "userEmail": user.email,
                     "userId": user.pk,
                     "isManager": user.is_manager,
                     "isAdmin": user.membership.filter(is_admin=True).exists(),

--- a/back/dora/oidc/backends.py
+++ b/back/dora/oidc/backends.py
@@ -7,6 +7,8 @@ from mozilla_django_oidc.auth import (
 )
 from rest_framework.authtoken.models import Token
 
+from dora.logs import logger as core_logger
+
 logger = getLogger(__name__)
 
 
@@ -131,6 +133,14 @@ class OIDCAuthenticationBackend(MozillaOIDCAuthenticationBackend):
         # simplement surchargé pour ajout du token DRF
         # note: DRF devrait être déprécié pour utiliser un autre type d'identification entre front et back.
         if user := super().get_user(user_id):
+            core_logger.info(
+                "Connexion utilisateur via ProConnect",
+                {
+                    "legal": True,
+                    "userEmail": user.email,
+                    "userId": user.pk,
+                },
+            )
             self.get_or_create_drf_token(user)
             return user
         return None

--- a/back/dora/oidc/backends.py
+++ b/back/dora/oidc/backends.py
@@ -139,6 +139,7 @@ class OIDCAuthenticationBackend(MozillaOIDCAuthenticationBackend):
                     "legal": True,
                     "userEmail": user.email,
                     "userId": user.pk,
+                    "isManager": user.is_manager,
                 },
             )
             self.get_or_create_drf_token(user)

--- a/back/dora/oidc/backends.py
+++ b/back/dora/oidc/backends.py
@@ -140,6 +140,7 @@ class OIDCAuthenticationBackend(MozillaOIDCAuthenticationBackend):
                     "userEmail": user.email,
                     "userId": user.pk,
                     "isManager": user.is_manager,
+                    "isAdmin": user.membership.filter(is_admin=True).exists(),
                 },
             )
             self.get_or_create_drf_token(user)


### PR DESCRIPTION
- En base de données via un logger spécifique,
- à chaque connexion ProConnect 
- on sait si l'utilisateur est un gestionnaire de territoire
- et si il est administrateur de structure *sans plus de précision*

---

- **fix: accès plus simple au logger**
- **fix: recherche par le message du log**
- **feat: logging de la connexion ProConnect des utilisateurs**
- **fix: traçage de la connexion des managers**
