### PR TITLE
feat(sécu): suppression des pièces-jointes d'une orientation

### DIFF
--- a/back/dora/core/views.py
+++ b/back/dora/core/views.py
@@ -32,7 +32,7 @@ def upload(request, filename, structure_slug):
     file_obj = request.data["file"]
     _validate_upload(file_obj)
     clean_filename = (
-        f"{settings.ENVIRONMENT}/{structure.id}/{get_valid_filename(filename)}"
+        f"{settings.ENVIRONMENT}/{structure.pk}/{get_valid_filename(filename)}"
     )
     result = default_storage.save(clean_filename, file_obj)
     return Response({"key": result}, status=201)

--- a/back/dora/orientations/management/commands/delete_orientation_attachments.py
+++ b/back/dora/orientations/management/commands/delete_orientation_attachments.py
@@ -1,0 +1,42 @@
+from django.core.management.base import BaseCommand
+
+from dora.orientations.models import Orientation
+
+
+class Command(BaseCommand):
+    help = "Supprime les pièces-jointes d'une orientation via son identifiant"
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "orientation_id", type=int, help="Identifiant de l'orientation"
+        )
+
+    def handle(self, *args, **options):
+        orientation_id = options["orientation_id"]
+        try:
+            orientation = Orientation.objects.get(id=orientation_id)
+            results = orientation.delete_attachments()
+            if all(results.values()):
+                self.stdout.write(
+                    self.style.SUCCESS(
+                        f"Les pièces-jointes de l'orientation #{orientation_id} ont été supprimées avec succès."
+                    )
+                )
+            else:
+                self.stdout.write(
+                    self.style.WARNING(
+                        "Certaines pièces-jointes de l'orientation n'ont pas pu être supprimées :"
+                    )
+                )
+                for path, result in results.items():
+                    if not result:
+                        self.stdout.write(self.style.WARNING(f" > {path} : KO"))
+                    else:
+                        self.stdout.write(self.style.SUCCESS(f" > {path} : OK"))
+
+        except Orientation.DoesNotExist:
+            self.stdout.write(
+                self.style.ERROR(
+                    f"L'orientation avec l'identifiant #{orientation_id} n'existe pas."
+                )
+            )

--- a/back/dora/orientations/models.py
+++ b/back/dora/orientations/models.py
@@ -334,19 +334,19 @@ class Orientation(models.Model):
                 },
             )
 
-    def delete_attachment(self, attachment: str) -> bool:
+    def delete_attachment(self, attachment: str) -> (str, bool):
         # Détruit une pièce-jointe de l'orientation, *si elle existe*.
         if default_storage.exists(attachment):
             default_storage.delete(attachment)
             logger.info("deleteOrientationAttachment", {"path": attachment})
             self.beneficiary_attachments.remove(attachment)
             self.save()
-            return True
+            return attachment, True
         else:
             logger.warning("deleteOrientationAttachment", {"pathNotFound": attachment})
-            return False
+            return attachment, False
 
-    def delete_attachments(self) -> bool:
+    def delete_attachments(self) -> dict[str, bool]:
         # Cette méthode effectue des appels synchrones via `django-storages` pour la destruction
         # des pièces-jointes de l'orientation concernée.
         # Elle ne devrait idéalement être utilisée que via des management-commands ou en shell.

--- a/back/dora/orientations/tests/test_orientation_attachments.py
+++ b/back/dora/orientations/tests/test_orientation_attachments.py
@@ -1,0 +1,102 @@
+from unittest.mock import patch
+
+import pytest
+from django.core.files.base import ContentFile
+from django.core.files.storage import default_storage
+
+from dora.core.test_utils import make_published_service
+from dora.orientations.models import Orientation
+
+
+@pytest.fixture
+def orientation():
+    service = make_published_service(
+        address1="6 Boulevard St Denis",
+        address2="Plateforme de l'inclusion",
+        postal_code="75010",
+    )
+    return Orientation.objects.create(
+        service=service,
+        beneficiary_last_name="Doe",
+        beneficiary_first_name="John",
+        referent_last_name="Smith",
+        referent_first_name="Jane",
+        referent_email="jane.smith@example.com",
+    )
+
+
+def test_delete_attachment_existing(orientation):
+    # Créer une pièce jointe factice
+    attachment_path = "test_attachment.txt"
+    default_storage.save(attachment_path, ContentFile("Test content"))
+
+    # Ajouter la pièce jointe à l'orientation
+    orientation.beneficiary_attachments.append(attachment_path)
+    orientation.save()
+
+    # Vérifier que la pièce jointe existe avant la suppression
+    assert default_storage.exists(attachment_path)
+
+    # Supprimer la pièce jointe
+    deleted_path, success = orientation.delete_attachment(attachment_path)
+
+    # Vérifier que la pièce jointe a été supprimée
+    assert not default_storage.exists(attachment_path)
+    assert deleted_path == attachment_path
+    assert success
+
+
+def test_delete_attachment_non_existing(orientation):
+    # Essayer de supprimer une pièce jointe qui n'existe pas
+    non_existing_path = "non_existing_attachment.txt"
+    deleted_path, success = orientation.delete_attachment(non_existing_path)
+
+    # Vérifier que la suppression a échoué
+    assert deleted_path == non_existing_path
+    assert not success
+
+
+def test_delete_attachments(orientation):
+    # Créer plusieurs pièces jointes factices
+    attachment_paths = ["test_attachment1.txt", "test_attachment2.txt"]
+    for path in attachment_paths:
+        default_storage.save(path, ContentFile("Test content"))
+
+    # Ajouter les pièces jointes à l'orientation
+    orientation.beneficiary_attachments.extend(attachment_paths)
+    orientation.save()
+
+    # Vérifier que les pièces jointes existent avant la suppression
+    for path in attachment_paths:
+        assert default_storage.exists(path)
+
+    # Supprimer toutes les pièces jointes
+    print("attn:", orientation.beneficiary_attachments)
+    results = orientation.delete_attachments()
+    print("results:", results)
+    print("attn:", orientation.beneficiary_attachments)
+
+    # Vérifier que toutes les pièces jointes ont été supprimées
+    for path in attachment_paths:
+        assert not default_storage.exists(path)
+        assert results[path]
+
+
+@patch("dora.orientations.models.default_storage.exists")
+@patch("dora.orientations.models.default_storage.delete")
+def test_delete_attachments_with_mock(mock_delete, mock_exists, orientation):
+    # Configurer le mock pour simuler l'existence des pièces jointes
+    mock_exists.return_value = True
+
+    # Ajouter des pièces jointes factices à l'orientation
+    attachment_paths = ["test_attachment1.txt", "test_attachment2.txt"]
+    orientation.beneficiary_attachments.extend(attachment_paths)
+    orientation.save()
+
+    # Supprimer toutes les pièces jointes
+    results = orientation.delete_attachments()
+
+    # Vérifier que les méthodes de stockage ont été appelées correctement
+    for path in attachment_paths:
+        mock_delete.assert_any_call(path)
+        assert results[path]

--- a/back/dora/orientations/tests/test_orientation_attachments.py
+++ b/back/dora/orientations/tests/test_orientation_attachments.py
@@ -1,3 +1,4 @@
+import os
 from unittest.mock import patch
 
 import pytest
@@ -6,6 +7,15 @@ from django.core.files.storage import default_storage
 
 from dora.core.test_utils import make_published_service
 from dora.orientations.models import Orientation
+
+
+def only_dev_env(test_func):
+    def wrapper(*args, **kwargs):
+        if os.getenv("ENVIRONMENT") != "local":
+            pytest.skip("Test uniquement exécuté dans l'environnement de développement")
+        return test_func(*args, **kwargs)
+
+    return wrapper
 
 
 @pytest.fixture
@@ -25,6 +35,7 @@ def orientation():
     )
 
 
+@only_dev_env
 def test_delete_attachment_existing(orientation):
     # Créer une pièce jointe factice
     attachment_path = "test_attachment.txt"
@@ -46,6 +57,7 @@ def test_delete_attachment_existing(orientation):
     assert success
 
 
+@only_dev_env
 def test_delete_attachment_non_existing(orientation):
     # Essayer de supprimer une pièce jointe qui n'existe pas
     non_existing_path = "non_existing_attachment.txt"
@@ -56,6 +68,7 @@ def test_delete_attachment_non_existing(orientation):
     assert not success
 
 
+@only_dev_env
 def test_delete_attachments(orientation):
     # Créer plusieurs pièces jointes factices
     attachment_paths = ["test_attachment1.txt", "test_attachment2.txt"]
@@ -82,6 +95,7 @@ def test_delete_attachments(orientation):
         assert results[path]
 
 
+@only_dev_env
 @patch("dora.orientations.models.default_storage.exists")
 @patch("dora.orientations.models.default_storage.delete")
 def test_delete_attachments_with_mock(mock_delete, mock_exists, orientation):

--- a/back/dora/orientations/tests/test_orientation_attachments.py
+++ b/back/dora/orientations/tests/test_orientation_attachments.py
@@ -8,14 +8,10 @@ from django.core.files.storage import default_storage
 from dora.core.test_utils import make_published_service
 from dora.orientations.models import Orientation
 
-
-def only_dev_env(test_func):
-    def wrapper(*args, **kwargs):
-        if os.getenv("ENVIRONMENT") != "local":
-            pytest.skip("Test uniquement exécuté dans l'environnement de développement")
-        return test_func(*args, **kwargs)
-
-    return wrapper
+only_local = pytest.mark.skipif(
+    os.getenv("ENVIRONMENT") != "local",
+    reason="Test uniquement exécuté dans l'environnement de développement",
+)
 
 
 @pytest.fixture
@@ -35,7 +31,7 @@ def orientation():
     )
 
 
-@only_dev_env
+@only_local
 def test_delete_attachment_existing(orientation):
     # Créer une pièce jointe factice
     attachment_path = "test_attachment.txt"
@@ -57,7 +53,7 @@ def test_delete_attachment_existing(orientation):
     assert success
 
 
-@only_dev_env
+@only_local
 def test_delete_attachment_non_existing(orientation):
     # Essayer de supprimer une pièce jointe qui n'existe pas
     non_existing_path = "non_existing_attachment.txt"
@@ -68,7 +64,7 @@ def test_delete_attachment_non_existing(orientation):
     assert not success
 
 
-@only_dev_env
+@only_local
 def test_delete_attachments(orientation):
     # Créer plusieurs pièces jointes factices
     attachment_paths = ["test_attachment1.txt", "test_attachment2.txt"]
@@ -95,7 +91,7 @@ def test_delete_attachments(orientation):
         assert results[path]
 
 
-@only_dev_env
+@only_local
 @patch("dora.orientations.models.default_storage.exists")
 @patch("dora.orientations.models.default_storage.delete")
 def test_delete_attachments_with_mock(mock_delete, mock_exists, orientation):


### PR DESCRIPTION
## Destruction des pièces-jointes d'une orientation

Ajoute des éléments au modèle `Orientation` pour permettre la destruction des pièces-jointes attachées (stockées sur un S3 Clevercloud) :
- directement lors de la suppression de l'orientation,
- via une management-command `delete_orientation_attachments` prenant la pk de l'orientation en paramètre (si on ne souhaite pas supprimer l'orientation).

## Note

Les tests unitaires sont "skippés"  pour la CI car elle ne dispose pas de S3 pour des tests e2e.
Ils sont utilisables sur un environnement de dev avec un S3 local (Minio)
