### PR TITLE
feat(data): import des données de partage de fiche service depuis matomo

### DIFF
--- a/analytics/cron.json
+++ b/analytics/cron.json
@@ -3,6 +3,10 @@
     {
       "command": "0 7,13,18 * * * ./sync-analytics.sh",
       "size": "2XL"
+    },
+    {
+      "command": "0 23 * * * python sync-matomo.py",
+      "size": "2XL"
     }
   ]
 }

--- a/analytics/models/_sources.yml
+++ b/analytics/models/_sources.yml
@@ -31,5 +31,9 @@ sources:
       - name: structures_structureputativemember
       - name: structures_structuretypology
       - name: users_user
+  - name: matomo
+    schema: public
+    tables:
+      - name: mtm_share_service_tracking
 
 

--- a/analytics/sync-matomo.py
+++ b/analytics/sync-matomo.py
@@ -1,0 +1,94 @@
+from datetime import datetime, timedelta
+from sqlalchemy import create_engine
+from dotenv import load_dotenv
+import pandas as pd
+import json
+import requests
+import os
+
+load_dotenv()
+
+def get_share_services_actions(matomo_base_url, token):
+
+    start_date = datetime.strptime("2025-05-01", "%Y-%m-%d")
+    end_date = datetime.today()
+    current_date = start_date
+
+    segment = "eventCategory==Page Service;eventAction==Clic Bouton Envoyer la Fiche,eventCategory==Page Service;eventAction==Clic Bouton Partager cette Fiche,eventCategory==Page Service;eventAction==Clic Bouton Profil Professionnel"
+    actions = []
+
+    while current_date <= end_date:
+        print(f"\t> {current_date}")
+        date_str = current_date.strftime("%Y-%m-%d")
+
+        url = (
+            f"{matomo_base_url}"
+            "?module=API"
+            "&method=Live.getLastVisitsDetails"
+            f"&idSite=211"
+            "&expanded=1"
+            "&period=day"
+            f"&date={date_str}"
+            "&format=json"
+            f"&token_auth={token}"
+            f"&segment={segment}"
+        )
+
+        response = requests.get(url, headers={"Accept": "application/json"})
+        try:
+            data = response.json()
+        except json.JSONDecodeError:
+            continue
+    
+        event_actions = ("Clic Bouton Envoyer la Fiche",
+                         "Clic Bouton Partager cette Fiche",
+                         "Clic Bouton Profil Professionnel")
+        changement_profil_pro = 0
+
+        for visit in data:
+            for event in visit["actionDetails"]:
+                if event['type'] == "event" and event["eventCategory"] == "Page Service" and event["eventAction"] in event_actions:
+                    if event["eventAction"] == "Clic Bouton Partager cette Fiche":
+                        actions.append({'visitId': visit['idVisit'],
+                        'visitorId': visit['visitorId'],
+                        'slug': event['eventName'].split(" ")[0],
+                        'envoi_fiche': None,
+                        'partage_fiche': 1,
+                        'profil_pro': None,
+                        'serverdate' : event['serverTimePretty'],
+                        'date' : date_str
+                        })
+                    elif event["eventAction"] == "Clic Bouton Profil Professionnel":
+                        changement_profil_pro += 1
+                    elif event["eventAction"] == "Clic Bouton Envoyer la Fiche":
+                        actions.append({'visitId': visit['idVisit'],
+                        'visitorId': visit['visitorId'],
+                        'slug': event['eventName'].split(" ")[0],
+                        'envoi_fiche': 1,
+                        'partage_fiche': None,
+                        'profil_pro': "Bénéficiaire" if changement_profil_pro%2==0 else "Pro",
+                        'date' : date_str,
+                        'serverdate' : event['serverTimePretty']
+                        })
+                        changement_profil_pro = 0
+        current_date += timedelta(days=1)
+
+    return pd.DataFrame(actions)
+
+def push_to_db():
+
+    matomo_base_url = os.getenv("MATOMO_BASE_URL")
+    matomo_token = os.getenv("MATOMO_TOKEN")
+    database_url = os.getenv("DATABASE_URL")
+
+    engine = create_engine(database_url)
+    print("🔄 Loading data from matomo..")
+
+    table = get_share_services_actions(matomo_base_url, matomo_token)
+    print("🔄 Pushing data to database")
+
+    table.to_sql("mtm_share_service_tracking", engine, if_exists='replace', index=False)
+    print("✅ Data ready")
+
+
+push_to_db()

--- a/analytics/sync-matomo.py
+++ b/analytics/sync-matomo.py
@@ -8,8 +8,8 @@ import os
 
 load_dotenv()
 
-def get_share_services_actions(matomo_base_url, token):
 
+def get_share_services_actions(matomo_base_url, token):
     start_date = datetime.strptime("2025-05-01", "%Y-%m-%d")
     end_date = datetime.today()
     current_date = start_date
@@ -39,44 +39,58 @@ def get_share_services_actions(matomo_base_url, token):
             data = response.json()
         except json.JSONDecodeError:
             continue
-    
-        event_actions = ("Clic Bouton Envoyer la Fiche",
-                         "Clic Bouton Partager cette Fiche",
-                         "Clic Bouton Profil Professionnel")
+
+        event_actions = (
+            "Clic Bouton Envoyer la Fiche",
+            "Clic Bouton Partager cette Fiche",
+            "Clic Bouton Profil Professionnel",
+        )
         changement_profil_pro = 0
 
         for visit in data:
             for event in visit["actionDetails"]:
-                if event['type'] == "event" and event["eventCategory"] == "Page Service" and event["eventAction"] in event_actions:
+                if (
+                    event["type"] == "event"
+                    and event["eventCategory"] == "Page Service"
+                    and event["eventAction"] in event_actions
+                ):
                     if event["eventAction"] == "Clic Bouton Partager cette Fiche":
-                        actions.append({'visitId': visit['idVisit'],
-                        'visitorId': visit['visitorId'],
-                        'slug': event['eventName'].split(" ")[0],
-                        'envoi_fiche': None,
-                        'partage_fiche': 1,
-                        'profil_pro': None,
-                        'serverdate' : event['serverTimePretty'],
-                        'date' : date_str
-                        })
+                        actions.append(
+                            {
+                                "visitId": visit["idVisit"],
+                                "visitorId": visit["visitorId"],
+                                "slug": event["eventName"].split(" ")[0],
+                                "envoi_fiche": None,
+                                "partage_fiche": 1,
+                                "profil_pro": None,
+                                "serverdate": event["serverTimePretty"],
+                                "date": date_str,
+                            }
+                        )
                     elif event["eventAction"] == "Clic Bouton Profil Professionnel":
                         changement_profil_pro += 1
                     elif event["eventAction"] == "Clic Bouton Envoyer la Fiche":
-                        actions.append({'visitId': visit['idVisit'],
-                        'visitorId': visit['visitorId'],
-                        'slug': event['eventName'].split(" ")[0],
-                        'envoi_fiche': 1,
-                        'partage_fiche': None,
-                        'profil_pro': "Bénéficiaire" if changement_profil_pro%2==0 else "Pro",
-                        'date' : date_str,
-                        'serverdate' : event['serverTimePretty']
-                        })
+                        actions.append(
+                            {
+                                "visitId": visit["idVisit"],
+                                "visitorId": visit["visitorId"],
+                                "slug": event["eventName"].split(" ")[0],
+                                "envoi_fiche": 1,
+                                "partage_fiche": None,
+                                "profil_pro": "Bénéficiaire"
+                                if changement_profil_pro % 2 == 0
+                                else "Pro",
+                                "date": date_str,
+                                "serverdate": event["serverTimePretty"],
+                            }
+                        )
                         changement_profil_pro = 0
         current_date += timedelta(days=1)
 
     return pd.DataFrame(actions)
 
-def push_to_db():
 
+def push_to_db():
     matomo_base_url = os.getenv("MATOMO_BASE_URL")
     matomo_token = os.getenv("MATOMO_TOKEN")
     database_url = os.getenv("DATABASE_URL")
@@ -87,7 +101,7 @@ def push_to_db():
     table = get_share_services_actions(matomo_base_url, matomo_token)
     print("🔄 Pushing data to database")
 
-    table.to_sql("mtm_share_service_tracking", engine, if_exists='replace', index=False)
+    table.to_sql("mtm_share_service_tracking", engine, if_exists="replace", index=False)
     print("✅ Data ready")
 
 


### PR DESCRIPTION
🌼 Objectif

Récupérer les événements de clic sur partage de la fiche service afin de suivre l'usage sur metabase.

🌸 Comment

Création d'un modèle python dans dbt dont le but est de récupérer ces infos via l'API Matomo.
On récupère tous les événements de type souhaité (catégorie "PageService" et action "Clic Bouton Envoyer la Fiche" ou "Clic Bouton Partager cette Fiche" ou "Clic Bouton Profil Professionnel". 

Les événements de clic partage et d'envoi de fiche sont conservés, et le clic bouton professionnel est comptabilisé pour enregistrer lors de l'envoi de la fiche, si c'est envoyé à un pro (nombre impair de clics) ou à un bénéficiaire (nombre pair) 
-> tricky mais matomo ne permet pas de suivre quel bouton a été cliqué, donc obligé de passer par un compteur. Un cas à la marge n'est pas traité avec cette méthode, c'est si l'utilisateur clique deux fois sur le même bouton, mais on s'autorise à supposer que ce sera suffisamment marginal voir inexistant