### PR TITLE
feat(profils): remplacement de l'aide de la section Publics du formulaire d'édition de service par une Notice avec texte mis à jour

### DIFF
--- a/front/src/lib/components/specialized/services/fields-publics.svelte
+++ b/front/src/lib/components/specialized/services/fields-publics.svelte
@@ -4,6 +4,7 @@
   import type { Model, Service, ServicesOptions } from "$lib/types";
   import { getModelInputProps } from "$lib/utils/forms";
   import FieldModel from "$lib/components/specialized/services/field-model.svelte";
+  import Notice from "$lib/components/display/notice.svelte";
 
   export let servicesOptions: ServicesOptions;
   export let service: Service;
@@ -27,25 +28,24 @@
 </script>
 
 <FieldSet title="Publics" {showModel}>
-  <div slot="help">
-    <p class="text-f14">
-      Publics auxquels le service s’adresse. Si votre service est ouvert à tous,
-      sans critère ou prérequis, laissez les champs avec les options par défaut.
+  <Notice type="info">
+    <p class="text-f16 leading-s24 text-gray-dark mb-s0">
+      Indiquer ici les profils de publics à qui s’adresse votre service. Si
+      votre service est ouvert à toutes et tous, il n’est pas nécessaire de
+      sélectionner des profils.
     </p>
-    <ul class="text-f14 font-bold">
-      <li>
-        <a
-          href="https://aide.dora.inclusion.beta.gouv.fr/fr/article/definir-les-publics-et-criteres-dacces-a-votre-service-tos25n/"
-          class="text-magenta-cta"
-          target="_blank"
-          title="Ouverture dans une nouvelle fenêtre"
-          rel="noopener"
-        >
-          Définir les publics et critères d’accès à votre service
-        </a>
-      </li>
-    </ul>
-  </div>
+    <p class="text-f16 leading-s24 text-gray-dark mb-s0">
+      <a
+        href="https://aide.dora.inclusion.beta.gouv.fr/fr/article/definir-les-publics-et-criteres-dacces-a-votre-service-tos25n/"
+        class="text-magenta-cta font-bold"
+        target="_blank"
+        title="Ouverture dans une nouvelle fenêtre"
+        rel="noopener"
+      >
+        Définir les publics et critères d’accès à votre service
+      </a>
+    </p>
+  </Notice>
 
   {#if servicesOptions.concernedPublic.length}
     <FieldModel {...fieldModelProps.concernedPublic ?? {}} type="array">


### PR DESCRIPTION
- Suppression de l'aide (avec bouton Aide)
- Ajout d'un composant Notice
- Copie mise à jour du text

Avant : ![image](https://github.com/user-attachments/assets/c1615dd2-6499-4dd5-925a-668a9dd94135)

Après : ![image](https://github.com/user-attachments/assets/a266e477-6f34-4a9e-b9a3-5f79af19f3f5)
