### PR TITLE
fix: réduit l'espace au-dessus du CTA des mails d'orientation rejetée

### DIFF
--- a/back/dora/orientations/templates/orientation-rejected-prescriber.mjml
+++ b/back/dora/orientations/templates/orientation-rejected-prescriber.mjml
@@ -42,7 +42,6 @@
 {% endblock %}
 
 {% block cta %}
-  <mj-spacer height="24px"/>
   <mj-button mj-class="cta" href="{% frontend_url %}">
     Relancer la recherche
   </mj-button>

--- a/back/dora/orientations/templates/orientation-rejected-structure.mjml
+++ b/back/dora/orientations/templates/orientation-rejected-structure.mjml
@@ -55,7 +55,6 @@
 {% endblock %}
 
 {% block cta %}
-  <mj-spacer height="24px"/>
   <mj-button mj-class="cta" href="{{ data.get_magic_link }}">
     Visualiser le récapitulatif de la demande
   </mj-button>


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/538fba1a-2bb9-4fce-b2be-2fdf851d7d9b)
![image](https://github.com/user-attachments/assets/7fa08d67-49bc-4499-bec7-2db0d613eb5f)
