### PR TITLE
docs: ajouter des consignes manquantes au ReadMe

### DIFF
--- a/.talismanrc
+++ b/.talismanrc
@@ -2,5 +2,5 @@ fileignoreconfig:
   - filename: back/dora/services/migrations/0110_remove_service_fee_pass_numerique.py
     checksum: 8d45217f8fc80d3ffb37ca6040b04a9aa99a37c1eb82f4ae0939b91f6989850d
   - filename: back/README.md
-    checksum: cb06ebd13607002b081a9028b2baa3682554d482d193c43c12d25e6ceb0c3009
+    checksum: 0f0095589eeccad4a4447a8495ce9e2e0339c3ab5aa287eeee32e159a7bf2f7f
 version: ""

--- a/.talismanrc
+++ b/.talismanrc
@@ -1,0 +1,6 @@
+fileignoreconfig:
+  - filename: back/dora/services/migrations/0110_remove_service_fee_pass_numerique.py
+    checksum: 8d45217f8fc80d3ffb37ca6040b04a9aa99a37c1eb82f4ae0939b91f6989850d
+  - filename: back/README.md
+    checksum: be32ef778546615e1efde355bde2091a2640416c5dfcc60d1eb089d8d4d91a4b
+version: ""

--- a/.talismanrc
+++ b/.talismanrc
@@ -2,5 +2,5 @@ fileignoreconfig:
   - filename: back/dora/services/migrations/0110_remove_service_fee_pass_numerique.py
     checksum: 8d45217f8fc80d3ffb37ca6040b04a9aa99a37c1eb82f4ae0939b91f6989850d
   - filename: back/README.md
-    checksum: be32ef778546615e1efde355bde2091a2640416c5dfcc60d1eb089d8d4d91a4b
+    checksum: cb06ebd13607002b081a9028b2baa3682554d482d193c43c12d25e6ceb0c3009
 version: ""

--- a/back/.talismanrc
+++ b/back/.talismanrc
@@ -1,4 +1,0 @@
-fileignoreconfig:
-  - filename: dora/services/migrations/0110_remove_service_fee_pass_numerique.py
-    checksum: 8d45217f8fc80d3ffb37ca6040b04a9aa99a37c1eb82f4ae0939b91f6989850d
-version: ""

--- a/back/README.md
+++ b/back/README.md
@@ -76,6 +76,19 @@ Pour que l’application soit utilisable, il faut _a minima_ importer les donné
 
 Mais pour avoir un jeu de données complet, il est plus simple d’importer la base de _staging_ entière.
 
+# Configurer le téléchargement de documents en local
+Vous devez créer un bucket dans Minio pour les téléchargements de documents.
+
+1. Allez sur http://localhost:9001/ et connectez-vous avec les identifiants par défaut que vous trouverez ici :
+  - Nom d'utilisateur : minio
+  - Mot de passe : miniosecret
+2. Créez un bucket nommé `dora`.
+3. Créez une clé d'accès et copiez la clé d'accès et la clé secrète.
+4. Dans `envs/secrets.env`, définissez les variables suivantes :
+    - AWS_ACCESS_KEY_ID=<votre_clé_d'accès>
+    - AWS_SECRET_ACCESS_KEY=<votre_clé_secrète>
+
+
 ## Problèmes avec GeoDjango
 
 GeoDjango a besoin des _packages_ `GEOS` et `GDAL` pour fonctionner.
@@ -125,6 +138,32 @@ Vous pouvez corriger ce souci en ajoutant les variables d'environnement suivante
 ```
 export PATH="/opt/homebrew/opt/openssl@3/bin:$PATH"
 export LIBRARY_PATH=$LIBRARY_PATH:/opt/homebrew/opt/openssl@3/lib/
+```
+
+### Erreur avec Minio
+Si vous rencontrez une erreur avec Minio où vous voyez des dizaines de logs comme celui-ci :
+
+```
+Adding local Minio host to 'mc' configuration...
+```
+Suivi par :
+```
+INFO  ==> MinIO is already stopped...
+```
+
+Essayez de supprimer le containeur `s3` :
+* Note : la commande suivante supprimera tous les containeurs et leurs volumes y compris le db.
+
+```bash
+docker compose down -v
+```
+
+Utilisez une version spécifique de l'image au lieu de `bitnami/minio@latest` comme par exemple : `bitnami/minio:2024.5.1`
+La liste de toutes les versions disponibles est [ici](https://hub.docker.com/r/bitnami/minio/tags).
+
+Pour refaire les containeur :
+```bash
+docker compose up --build
 ```
 
 ## Développement

--- a/back/README.md
+++ b/back/README.md
@@ -152,7 +152,7 @@ Suivi par :
 INFO  ==> MinIO is already stopped...
 ```
 
-Supprimer le containeur `s3` :
+Supprimer le conteneur `s3` :
 
 ```bash
 docker compose stop s3

--- a/back/README.md
+++ b/back/README.md
@@ -162,7 +162,7 @@ docker compose rm -v s3
 Utilisez une version spécifique de l'image au lieu de `bitnami/minio@latest` comme par exemple : `bitnami/minio:2024.5.1`
 La liste de toutes les versions disponibles est [ici](https://hub.docker.com/r/bitnami/minio/tags).
 
-Pour recréer les containeurs :
+Pour recréer les conteneurs :
 ```bash
 docker compose up --build
 ```

--- a/back/README.md
+++ b/back/README.md
@@ -6,6 +6,12 @@
 - PostgreSQL avec l'extension [PostGIS](https://postgis.net/).
 - [GDAL](https://gdal.org/).
 
+### Setup des variables d'environnement
+ 
+- Copier le dossier `envs-example` et renommer le `envs`
+- Dans le fichier `envs/dev.env`, compléter la variable `POSTGRES_USER`.
+- Dans le fichier `envs/secrets.env`, compléter les variables `POSTGRES_PASSWORD` et `DJANGO_SECRET_KEY`.
+
 ### Docker Compose
 
 PostgreSQL, PostGIS, Minio et Redis peuvent être installés simplement avec Docker Compose.
@@ -13,11 +19,6 @@ PostgreSQL, PostGIS, Minio et Redis peuvent être installés simplement avec Doc
 Copier `docker-compose.yml.template` en `docker-compose.yml`.
 
 Vous pouvez modifier `docker-compose.yml` à votre guise (ports, volumes, etc.).
-
-Le fichier `docker-compose.yml` a besoin des valeurs stockées dans les fichiers `.env`. Pour les remplir : 
-- Copier le dossier `envs-example` et renommer le `envs`
-- Dans le fichier `envs/dev.env`, compléter la variable `POSTGRES_USER`.
-- Dans le fichier `envs/secrets.env`, compléter les variables `POSTGRES_PASSWORD` et `DJANGO_SECRET_KEY`.
 
 Créer et démarrer les conteneurs :
 
@@ -151,17 +152,17 @@ Suivi par :
 INFO  ==> MinIO is already stopped...
 ```
 
-Essayez de supprimer le containeur `s3` :
-* Note : la commande suivante supprimera tous les containeurs et leurs volumes y compris le db.
+Supprimer le containeur `s3` :
 
 ```bash
-docker compose down -v
+docker compose stop s3
+docker compose rm -v s3
 ```
 
 Utilisez une version spécifique de l'image au lieu de `bitnami/minio@latest` comme par exemple : `bitnami/minio:2024.5.1`
 La liste de toutes les versions disponibles est [ici](https://hub.docker.com/r/bitnami/minio/tags).
 
-Pour refaire les containeur :
+Pour recréer les containeurs :
 ```bash
 docker compose up --build
 ```

--- a/back/README.md
+++ b/back/README.md
@@ -14,6 +14,11 @@ Copier `docker-compose.yml.template` en `docker-compose.yml`.
 
 Vous pouvez modifier `docker-compose.yml` à votre guise (ports, volumes, etc.).
 
+Le fichier `docker-compose.yml` a besoin des valeurs stockées dans les fichiers `.env`. Pour les remplir : 
+- Copier le dossier `envs-example` et renommer le `envs`
+- Dans le fichier `envs/dev.env`, compléter la variable `POSTGRES_USER`.
+- Dans le fichier `envs/secrets.env`, compléter les variables `POSTGRES_PASSWORD` et `DJANGO_SECRET_KEY`.
+
 Créer et démarrer les conteneurs :
 
 ```bash
@@ -36,19 +41,30 @@ Accéder à pgAdmin 4 via http://localhost:8888/ en utilisant l'adresse e-mail e
 
 ## Installation
 
-- Créer une base de données PostgresQL `dora`.
-- Copier le dossier `envs-example` et renommer le `envs`
-- Dans le fichier `envs/dev.env`, compléter la variable `POSTGRES_USER`.
-- Dans le fichier `envs/secrets.env`, compléter les variables `POSTGRES_PASSWORD` et `DJANGO_SECRET_KEY`.
 
+# Installer graphviz
+Pour Mac:
 ```bash
+brew install graphviz
+```
+Pour Linux:
+```bash
+sudo apt install graphviz
+```
+Les consignes d'installation sont [ici](https://graphviz.org/download/).'
+
 # Installer les dépendances
+```bash
 pip install -r requirements/dev.txt
+```
 
 # Vérifier que tout fonctionne
+```bash
 ./manage.py check
+```
 
 # Créer les tables de la base de données
+```bash
 ./manage.py migrate
 ```
 
@@ -66,6 +82,13 @@ GeoDjango a besoin des _packages_ `GEOS` et `GDAL` pour fonctionner.
 
 Si Django n'arrive pas à trouver les librairies nécessaires, vous pourrez ajouter les variables d'environnement suivante
 à votre shell
+
+C'est possible que vous ayez besoin d'installer `gdal`.
+Pour Mac:
+```bash
+brew install gdal
+```
+Les consignes d'installation sont [ici](https://gdal.org/en/stable/download.html).
 
 ```bash
 export GDAL_LIBRARY_PATH=

--- a/back/docker-compose.yml.template
+++ b/back/docker-compose.yml.template
@@ -1,6 +1,6 @@
 services:
   db:
-    image: postgis/postgis:14-3.4-alpine
+    image: postgis/postgis:16-3.4-alpine
     env_file:
       - envs/dev.env
       - envs/secrets.env
@@ -32,3 +32,4 @@ volumes:
   pgdata:
   pgconf:
   miniodata:
+  pgadmin-data:


### PR DESCRIPTION
Après avoir installé le projet, j'ai remarqué que quelques consignes sont manquantes. Ce PR les ajoute.

À noter :
- il fallait aussi ajouter/modifier deux choses dans `docker-compose.yml` donc j'ai fait ça aussi
- j'ai eu besoin de mettre `.tailsmanrc` à la racine du projet pour faire un commit