### PR TITLE
feat: affiche le bouton et la modale de signalement pour tout le monde sauf pour les membres et membres potentiels de la structure du service

### DIFF
--- a/front/src/lib/utils/current-structure.ts
+++ b/front/src/lib/utils/current-structure.ts
@@ -16,3 +16,16 @@ export function getCurrentlySelectedStructure(
       )
     : userStructures[0];
 }
+
+export function isMemberOrPotentialMemberOfStructure(
+  userInfo: UserInfo | null,
+  structureSlug: string
+): boolean {
+  if (!userInfo) {
+    return false;
+  }
+  return (
+    userInfo.structures.some(({ slug }) => slug === structureSlug) ||
+    userInfo.pendingStructures.some(({ slug }) => slug === structureSlug)
+  );
+}

--- a/front/src/routes/(modeles-services)/components/service-body/service-presentation/service-key-informations/service-key-informations.svelte
+++ b/front/src/routes/(modeles-services)/components/service-body/service-presentation/service-key-informations/service-key-informations.svelte
@@ -191,7 +191,7 @@
       </ServiceKeyInformationSection>
       {#if !hasLabelSection}
         <div class="mt-s32">
-          <ServiceFeedbackButton {service} on:click={onFeedbackButtonClick} />
+          <ServiceFeedbackButton on:click={onFeedbackButtonClick} />
         </div>
       {/if}
     </div>
@@ -216,7 +216,7 @@
           {/if}
         </div>
         <div class="mt-s32">
-          <ServiceFeedbackButton {service} on:click={onFeedbackButtonClick} />
+          <ServiceFeedbackButton on:click={onFeedbackButtonClick} />
         </div>
       </div>
     {/if}

--- a/front/src/routes/(modeles-services)/components/service-body/service-presentation/service-presentation.svelte
+++ b/front/src/routes/(modeles-services)/components/service-body/service-presentation/service-presentation.svelte
@@ -27,5 +27,5 @@
 
   <ServiceDiIdentification {service} />
 
-  <ServiceFeedbackButton {service} on:click={onFeedbackButtonClick} />
+  <ServiceFeedbackButton on:click={onFeedbackButtonClick} />
 </div>

--- a/front/src/routes/(modeles-services)/services/[slug]/+page.svelte
+++ b/front/src/routes/(modeles-services)/services/[slug]/+page.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { onMount } from "svelte";
+  import { onMount, setContext } from "svelte";
 
   import { browser } from "$app/environment";
   import { page } from "$app/stores";
@@ -10,6 +10,8 @@
   import { TallyFormId } from "$lib/consts";
   import { getService } from "$lib/requests/services";
   import type { Service } from "$lib/types";
+  import { userInfo } from "$lib/utils/auth";
+  import { isMemberOrPotentialMemberOfStructure } from "$lib/utils/current-structure";
   import { trackService } from "$lib/utils/stats";
 
   import ServiceBody from "../../components/service-body/service-body.svelte";
@@ -21,6 +23,13 @@
   export let data: PageData;
 
   let isServiceFeedbackModalOpen = false;
+
+  $: showFeedbackModal =
+    browser &&
+    data.service &&
+    !isMemberOrPotentialMemberOfStructure($userInfo, data.service.structure);
+
+  $: setContext("showFeedbackModal", showFeedbackModal);
 
   onMount(() => {
     const searchId = $page.url.searchParams.get("searchId");
@@ -67,7 +76,7 @@
     onFeedbackButtonClick={() => (isServiceFeedbackModalOpen = true)}
   />
 
-  {#if browser && !data.service.canWrite}
+  {#if browser && showFeedbackModal}
     <ServiceFeedbackModal
       bind:isOpen={isServiceFeedbackModalOpen}
       service={data.service}

--- a/front/src/routes/(modeles-services)/services/[slug]/+page.svelte
+++ b/front/src/routes/(modeles-services)/services/[slug]/+page.svelte
@@ -76,7 +76,7 @@
     onFeedbackButtonClick={() => (isServiceFeedbackModalOpen = true)}
   />
 
-  {#if browser && showFeedbackModal}
+  {#if showFeedbackModal}
     <ServiceFeedbackModal
       bind:isOpen={isServiceFeedbackModalOpen}
       service={data.service}

--- a/front/src/routes/(modeles-services)/services/[slug]/service-feedback-button.svelte
+++ b/front/src/routes/(modeles-services)/services/[slug]/service-feedback-button.svelte
@@ -1,10 +1,10 @@
 <script lang="ts">
-  import type { Model, Service } from "$lib/types";
+  import { getContext } from "svelte";
 
-  export let service: Service | Model;
+  const showFeedbackModal = getContext("showFeedbackModal");
 </script>
 
-{#if !service.canWrite}
+{#if showFeedbackModal}
   <div>
     <button class="text-gray-text underline" on:click
       >Signalez-nous toute erreur ou suggestion de modification.</button

--- a/front/src/routes/(modeles-services)/services/[slug]/service-update-date.svelte
+++ b/front/src/routes/(modeles-services)/services/[slug]/service-update-date.svelte
@@ -19,5 +19,5 @@
       bold
     />
   </div>
-  <ServiceFeedbackButton {service} on:click={onFeedbackButtonClick} />
+  <ServiceFeedbackButton on:click={onFeedbackButtonClick} />
 </div>


### PR DESCRIPTION
Sur une fiche service, le bouton est situé à 3 endroits différents de la page.

![image](https://github.com/user-attachments/assets/fe70f56f-8a22-40b0-bf73-7280f8948316)

- Ajout d'une fonction utilitaire `isMemberOrPotentielMemberOfStructure()` ;
- Utilisation de _setContext()_ et _getContext()_ pour transmettre le statut d'affichage à tous les boutons en évitant le _prop drilling_ ;
- Affichage du bouton et de la modale pour tout le monde sauf pour les membres et membres potentiels de la structure du service.