### PR TITLE
feat: créer des services en brouillon quand certaines infos sont manquantes

### DIFF
--- a/back/dora/services/management/commands/import_services.py
+++ b/back/dora/services/management/commands/import_services.py
@@ -117,6 +117,12 @@ def _edit_and_save_service(
     service.location_kinds.set(data.location_kinds)
     service.diffusion_zone_type = data.diffusion_zone_type
 
+    if service.is_eligible_for_publishing():
+        service.status = ServiceStatus.PUBLISHED
+
+    if not service.diffusion_zone_type:
+        service.diffusion_zone_type = AdminDivisionType.CITY
+
     if service.address1 and service.city and service.postal_code:
         geo_data = get_geo_data(
             service.address1, city=service.city, postal_code=service.postal_code
@@ -134,9 +140,6 @@ def _edit_and_save_service(
                     "postal_code": service.postal_code,
                 }
             )
-
-    if service.is_eligible_for_publishing():
-        service.status = ServiceStatus.PUBLISHED
 
     if wet_run:
         service.funding_labels.add(*data.funding_labels)

--- a/back/dora/services/management/commands/import_services.py
+++ b/back/dora/services/management/commands/import_services.py
@@ -135,29 +135,13 @@ def _edit_and_save_service(
                 }
             )
 
-    if _is_service_eligible_for_publishing(service):
+    if service.is_eligible_for_publishing():
         service.status = ServiceStatus.PUBLISHED
 
     if wet_run:
         service.funding_labels.add(*data.funding_labels)
 
         service.save()
-
-
-def _is_service_eligible_for_publishing(service):
-    if (
-        not service.contact_name
-        or not service.contact_phone
-        or not service.diffusion_zone_type
-        or service.location_kinds.count() == 0
-    ):
-        return False
-
-    if service.location_kinds.filter(value="en-presentiel").exists():
-        if not service.city or not service.postal_code or not service.address1:
-            return False
-
-    return True
 
 
 def import_services(

--- a/back/dora/services/management/commands/import_services.py
+++ b/back/dora/services/management/commands/import_services.py
@@ -61,7 +61,7 @@ def _extract_multiple_values_from_line(line, header_name, model, category_label)
 def _extract_diffusion_zone_type_from_line(line):
     diffusion_zone_type_raw = line.get("diffusion_zone_type", "").strip()
     if not diffusion_zone_type_raw:
-        return None
+        return ""
 
     for choice in AdminDivisionType:
         if diffusion_zone_type_raw == choice.label:
@@ -206,26 +206,6 @@ def import_services(
                         model = ServiceModel.objects.get(slug=data.modele_slug)
                     except ServiceModel.DoesNotExist:
                         error_msg = f"Erreur : Modèle de service avec le slug {data.modele_slug} introuvable. Ligne {idx} ignorée."
-                        print(
-                            f"❌ {error_msg}",
-                            file=sys.stderr,
-                        )
-                        errors.append(error_msg)
-                        continue
-
-                    # Vérification du type de zone de diffusion (contrainte d'intégrité sur la table Services)
-                    if not data.diffusion_zone_type:
-                        error_msg = f"Erreur : Type de zone de diffusion manquant. Ligne {idx} ignorée."
-                        print(
-                            f"❌ {error_msg}",
-                            file=sys.stderr,
-                        )
-                        errors.append(error_msg)
-                        continue
-
-                    # Vérification du type de zone de diffusion (contrainte d'intégrité sur la table Services)
-                    if not data.diffusion_zone_type:
-                        error_msg = f"Erreur : Type de zone de diffusion manquant. Ligne {idx} ignorée."
                         print(
                             f"❌ {error_msg}",
                             file=sys.stderr,

--- a/back/dora/services/management/commands/import_services.py
+++ b/back/dora/services/management/commands/import_services.py
@@ -114,7 +114,6 @@ def _edit_and_save_service(
     service.address2 = data.location_complement
     service.city = data.location_city
     service.postal_code = data.location_postal_code
-    service.status = ServiceStatus.PUBLISHED
     service.location_kinds.set(data.location_kinds)
     service.diffusion_zone_type = data.diffusion_zone_type
 
@@ -136,10 +135,29 @@ def _edit_and_save_service(
                 }
             )
 
+    if _is_service_eligible_for_publishing(service):
+        service.status = ServiceStatus.PUBLISHED
+
     if wet_run:
         service.funding_labels.add(*data.funding_labels)
 
         service.save()
+
+
+def _is_service_eligible_for_publishing(service):
+    if (
+        not service.contact_name
+        or not service.contact_phone
+        or not service.diffusion_zone_type
+        or service.location_kinds.count() == 0
+    ):
+        return False
+
+    if service.location_kinds.filter(value="en-presentiel").exists():
+        if not service.city or not service.postal_code or not service.address1:
+            return False
+
+    return True
 
 
 def import_services(

--- a/back/dora/services/management/commands/import_services.py
+++ b/back/dora/services/management/commands/import_services.py
@@ -22,7 +22,7 @@ class Command(BaseCommand):
         parser.add_argument(
             "--wet-run",
             help="Exécuter l'import en vrai (modifie la base de données)",
-            default=False,
+            action="store_true",
         )
 
     def handle(self, *args, **kwargs):

--- a/back/dora/services/management/commands/import_services.py
+++ b/back/dora/services/management/commands/import_services.py
@@ -89,6 +89,7 @@ def _extract_data_from_line(line):
         funding_labels=_extract_multiple_values_from_line(
             line, "labels_financement", FundingLabel, "labels de financement"
         ),
+        is_contact_info_public=line.get("is_contact_info_public", "").strip(),
         diffusion_zone_type=_extract_diffusion_zone_type_from_line(line),
     )
     return data
@@ -116,6 +117,7 @@ def _edit_and_save_service(
     service.postal_code = data.location_postal_code
     service.location_kinds.set(data.location_kinds)
     service.diffusion_zone_type = data.diffusion_zone_type
+    service.is_contact_info_public = data.is_contact_info_public.lower() == "oui"
 
     if service.address1 and service.city and service.postal_code:
         geo_data = get_geo_data(

--- a/back/dora/services/models.py
+++ b/back/dora/services/models.py
@@ -660,6 +660,21 @@ class Service(ModerationMixin, models.Model):
         # voir FranceTravailOrientableService
         return bool(self.orientable_ft_services.count())
 
+    def is_eligible_for_publishing(self) -> bool:
+        if (
+            not self.contact_name
+            or not self.contact_phone
+            or not self.diffusion_zone_type
+            or self.location_kinds.count() == 0
+        ):
+            return False
+
+        if self.location_kinds.filter(value="en-presentiel").exists():
+            if not self.city or not self.postal_code or not self.address1:
+                return False
+
+        return True
+
 
 class ServiceModelManager(models.Manager):
     def get_queryset(self):

--- a/back/dora/services/tests/test_import_services.py
+++ b/back/dora/services/tests/test_import_services.py
@@ -34,7 +34,7 @@ class ImportServicesTestCase(TestCase):
     def test_import_services_wet_run(self):
         csv_content = (
             f"{self.csv_headers}\n"
-            f"{self.service_model.slug},{self.structure.siret},referent@email.com,{self.funding_label.value},Test Person,0123456789,,,,,,Commune,,"
+            f"{self.service_model.slug},{self.structure.siret},referent@email.com,{self.funding_label.value},Test Person,0123456789,,,,,,Commune,"
         )
         reader = csv.reader(io.StringIO(csv_content))
 
@@ -63,7 +63,7 @@ class ImportServicesTestCase(TestCase):
     def test_import_services_dry_run(self):
         csv_content = (
             f"{self.csv_headers}\n"
-            f"{self.service_model.slug},{self.structure.siret},referent@email.com,{self.funding_label.value},,,,,,,,,,"
+            f"{self.service_model.slug},{self.structure.siret},referent@email.com,{self.funding_label.value},,,,,,,,"
         )
 
         reader = csv.reader(io.StringIO(csv_content))
@@ -81,7 +81,7 @@ class ImportServicesTestCase(TestCase):
     def test_missing_siret(self):
         csv_content = (
             f"{self.csv_headers}\n"
-            f"{self.service_model.slug},,referent@email.com,{self.funding_label.value},,,,,,,,,,"
+            f"{self.service_model.slug},,referent@email.com,{self.funding_label.value},,,,,,,,"
         )
 
         reader = csv.reader(io.StringIO(csv_content))
@@ -96,7 +96,7 @@ class ImportServicesTestCase(TestCase):
     def test_invalid_structure_siret(self):
         csv_content = (
             f"{self.csv_headers}\n"
-            f"{self.service_model.slug},'invalid-siret',referent@email.com,{self.funding_label.value},,,,,,,,,,"
+            f"{self.service_model.slug},'invalid-siret',referent@email.com,{self.funding_label.value},,,,,,,,"
         )
 
         reader = csv.reader(io.StringIO(csv_content))
@@ -112,7 +112,7 @@ class ImportServicesTestCase(TestCase):
     def test_invalid_service_model_slug(self):
         csv_content = (
             f"{self.csv_headers}\n"
-            f"invalid-slug,{self.structure.siret},referent@email.com,{self.funding_label.value},,,,,,,,,,"
+            f"invalid-slug,{self.structure.siret},referent@email.com,{self.funding_label.value},,,,,,,,"
         )
 
         reader = csv.reader(io.StringIO(csv_content))
@@ -127,28 +127,27 @@ class ImportServicesTestCase(TestCase):
         )
 
     def test_missing_diffusion_zone_type(self):
-        def test_publish_eligible_remote_service(self):
-            csv_content = (
-                f"{self.csv_headers}\n"
-                f"{self.service_model.slug},{self.structure.siret},referent@email.com,"
-                f"{self.funding_label.value},Test Person,0123456789,a-distance,,,,,,"
-            )
+        csv_content = (
+            f"{self.csv_headers}\n"
+            f"{self.service_model.slug},{self.structure.siret},referent@email.com,"
+            f"{self.funding_label.value},Test Person,0123456789,a-distance,,,,,,"
+        )
 
-            reader = csv.reader(io.StringIO(csv_content))
+        reader = csv.reader(io.StringIO(csv_content))
 
-            result = import_services(reader, self.importing_user, wet_run=True)
+        result = import_services(reader, self.importing_user, wet_run=True)
 
-            created_service = Service.objects.filter(creator=self.importing_user).last()
+        created_service = Service.objects.filter(creator=self.importing_user).last()
 
-            self.assertEqual(result["created_count"], 1)
-            self.assertEqual(result["errors"], [])
-            self.assertEqual(created_service.status, ServiceStatus.DRAFT)
-            self.assertEqual(created_service.diffusion_zone_type, "")
+        self.assertEqual(result["created_count"], 1)
+        self.assertEqual(result["errors"], [])
+        self.assertEqual(created_service.status, ServiceStatus.DRAFT)
+        self.assertEqual(created_service.diffusion_zone_type, "")
 
     def test_invalid_diffusion_zone_type(self):
         csv_content = (
             f"{self.csv_headers}\n"
-            f"{self.service_model.slug},'invalid-siret',referent@email.com,{self.funding_label.value},,,,,,,,invalid_zone_type,,"
+            f"{self.service_model.slug},'invalid-siret',referent@email.com,{self.funding_label.value},,,,,,,,invalid_zone_type,"
         )
 
         reader = csv.reader(io.StringIO(csv_content))
@@ -164,7 +163,7 @@ class ImportServicesTestCase(TestCase):
     def test_invalid_funding_label(self):
         csv_content = (
             f"{self.csv_headers}\n"
-            f"{self.service_model.slug},{self.structure.siret},referent@email.com,invalid-funding-label,,,,,,,,,,"
+            f"{self.service_model.slug},{self.structure.siret},referent@email.com,invalid-funding-label,,,,,,,,"
         )
 
         reader = csv.reader(io.StringIO(csv_content))
@@ -185,7 +184,7 @@ class ImportServicesTestCase(TestCase):
     def test_missing_geo_data(self, mock_geo_data):
         csv_content = (
             f"{self.csv_headers}\n"
-            f"{self.service_model.slug},{self.structure.siret},referent@email.com,{self.funding_label.value},,,,Paris,1 rue de test,,75020,,,"
+            f"{self.service_model.slug},{self.structure.siret},referent@email.com,{self.funding_label.value},,,,Paris,1 rue de test,,75020,,"
         )
 
         reader = csv.reader(io.StringIO(csv_content))
@@ -220,7 +219,7 @@ class ImportServicesTestCase(TestCase):
     def test_valid_geo_data(self, mock_geo_data):
         csv_content = (
             f"{self.csv_headers}\n"
-            f"{self.service_model.slug},{self.structure.siret},referent@email.com,{self.funding_label.value},,,,Paris,1 rue de test,,75020,,,"
+            f"{self.service_model.slug},{self.structure.siret},referent@email.com,{self.funding_label.value},,,,Paris,1 rue de test,,75020,,"
         )
 
         reader = csv.reader(io.StringIO(csv_content))
@@ -241,7 +240,7 @@ class ImportServicesTestCase(TestCase):
     def test_location_kinds(self):
         csv_content = (
             f"{self.csv_headers}\n"
-            f'{self.service_model.slug},{self.structure.siret},referent@email.com,{self.funding_label.value},,,"a-distance,en-presentiel",,,,,,,'
+            f'{self.service_model.slug},{self.structure.siret},referent@email.com,{self.funding_label.value},,,"a-distance,en-presentiel",,,,,'
         )
 
         reader = csv.reader(io.StringIO(csv_content))
@@ -262,7 +261,7 @@ class ImportServicesTestCase(TestCase):
     def test_invalid_location_kinds(self):
         csv_content = (
             f"{self.csv_headers}\n"
-            f"{self.service_model.slug},{self.structure.siret},referent@email.com,{self.funding_label.value},,,invalid_kind,,,,,,,"
+            f"{self.service_model.slug},{self.structure.siret},referent@email.com,{self.funding_label.value},,,invalid_kind,,,,,,"
         )
 
         reader = csv.reader(io.StringIO(csv_content))
@@ -283,7 +282,7 @@ class ImportServicesTestCase(TestCase):
 
         csv_content = (
             f"{self.csv_headers}\n"
-            f'{self.service_model.slug},{self.structure.siret},referent@email.com,"{self.funding_label.value},{other_funding_label.value}",,,,,,,,,'
+            f'{self.service_model.slug},{self.structure.siret},referent@email.com,"{self.funding_label.value},{other_funding_label.value}",,,,,,,,'
         )
 
         reader = csv.reader(io.StringIO(csv_content))
@@ -308,7 +307,7 @@ class ImportServicesTestCase(TestCase):
     def test_duplicated_financing_labels(self):
         csv_content = (
             f"{self.csv_headers}\n"
-            f'{self.service_model.slug},{self.structure.siret},referent@email.com,"{self.funding_label.value},{self.funding_label.value}",,,,,,,,,'
+            f'{self.service_model.slug},{self.structure.siret},referent@email.com,"{self.funding_label.value},{self.funding_label.value}",,,,,,,,'
         )
 
         reader = csv.reader(io.StringIO(csv_content))
@@ -324,8 +323,8 @@ class ImportServicesTestCase(TestCase):
     def test_handle_one_invalid_line(self):
         csv_content = (
             f"{self.csv_headers}\n"
-            f"invalid,{self.structure.siret},referent@email.com,{self.funding_label.value},,,,,,,,,,,\n"
-            f"{self.service_model.slug},{self.structure.siret},referent@email.com,{self.funding_label.value},,,,,,,,,,"
+            f"invalid,{self.structure.siret},referent@email.com,{self.funding_label.value},,,,,,,,,\n"
+            f"{self.service_model.slug},{self.structure.siret},referent@email.com,{self.funding_label.value},,,,,,,,"
         )
 
         reader = csv.reader(io.StringIO(csv_content))
@@ -356,7 +355,7 @@ class ImportServicesTestCase(TestCase):
         csv_content = (
             f"{self.csv_headers}\n"
             f"{self.service_model.slug},{self.structure.siret},referent@email.com,"
-            f"{self.funding_label.value},Test Person,0123456789,en-presentiel,Paris,1 rue de test,,75020,Commune,,"
+            f"{self.funding_label.value},Test Person,0123456789,en-presentiel,Paris,1 rue de test,,75020,Commune,"
         )
 
         reader = csv.reader(io.StringIO(csv_content))

--- a/back/dora/services/tests/test_import_services.py
+++ b/back/dora/services/tests/test_import_services.py
@@ -399,21 +399,3 @@ class ImportServicesTestCase(TestCase):
         self.assertEqual(result["created_count"], 1)
         self.assertEqual(result["errors"], [])
         self.assertEqual(created_service.status, ServiceStatus.DRAFT)
-
-    def test_keep_service_without_diffusion_zone_in_draft_and_apply_default(self):
-        csv_content = (
-            f"{self.csv_headers}\n"
-            f"{self.service_model.slug},{self.structure.siret},referent@email.com,"
-            f"{self.funding_label.value},Test Person,,À distance,,,,,"
-        )
-
-        reader = csv.reader(io.StringIO(csv_content))
-
-        result = import_services(reader, self.importing_user, wet_run=True)
-
-        created_service = Service.objects.filter(creator=self.importing_user).last()
-
-        self.assertEqual(result["created_count"], 1)
-        self.assertEqual(result["errors"], [])
-        self.assertEqual(created_service.status, ServiceStatus.DRAFT)
-        self.assertEqual(created_service.diffusion_zone_type, "city")

--- a/back/dora/services/tests/test_import_services.py
+++ b/back/dora/services/tests/test_import_services.py
@@ -218,7 +218,7 @@ class ImportServicesTestCase(TestCase):
     def test_valid_geo_data(self, mock_geo_data):
         csv_content = (
             f"{self.csv_headers}\n"
-            f"{self.service_model.slug},{self.structure.siret},referent@email.com,Commune,{self.funding_label.value},,,,Paris,1 rue de test,,75020,,"
+            f"{self.service_model.slug},{self.structure.siret},referent@email.com,Commune,{self.funding_label.value},,,,Paris,1 rue de test,,75020,"
         )
 
         reader = csv.reader(io.StringIO(csv_content))
@@ -336,8 +336,8 @@ class ImportServicesTestCase(TestCase):
     def test_publish_eligible_remote_service(self):
         csv_content = (
             f"{self.csv_headers}\n"
-            f"{self.service_model.slug},{self.structure.siret},referent@email.com,"
-            f"{self.funding_label.value},Test Person,0123456789,À distance,,,,,Commune,"
+            f"{self.service_model.slug},{self.structure.siret},referent@email.com,Commune,"
+            f"{self.funding_label.value},Test Person,0123456789,a-distance,,,,,,,"
         )
 
         reader = csv.reader(io.StringIO(csv_content))
@@ -353,8 +353,8 @@ class ImportServicesTestCase(TestCase):
     def test_publish_eligible_in_person_service(self):
         csv_content = (
             f"{self.csv_headers}\n"
-            f"{self.service_model.slug},{self.structure.siret},referent@email.com,"
-            f"{self.funding_label.value},Test Person,0123456789,En présentiel,Paris,1 rue de test,,75020,Commune,"
+            f"{self.service_model.slug},{self.structure.siret},referent@email.com,Commune,"
+            f"{self.funding_label.value},Test Person,0123456789,en-presentiel,Paris,1 rue de test,,75020,"
         )
 
         reader = csv.reader(io.StringIO(csv_content))
@@ -370,8 +370,8 @@ class ImportServicesTestCase(TestCase):
     def test_keep_in_person_service_in_draft_when_ineligible(self):
         csv_content = (
             f"{self.csv_headers}\n"
-            f"{self.service_model.slug},{self.structure.siret},referent@email.com,"
-            f"{self.funding_label.value},Test Person,0123456789,En présentiel,Paris,1 rue de test,,,Commune,"
+            f"{self.service_model.slug},{self.structure.siret},referent@email.com,Commune,"
+            f"{self.funding_label.value},Test Person,0123456789,en-presentiel,Paris,1 rue de test,,,,,"
         )
 
         reader = csv.reader(io.StringIO(csv_content))
@@ -387,8 +387,8 @@ class ImportServicesTestCase(TestCase):
     def test_keep_service_in_draft_when_ineligible(self):
         csv_content = (
             f"{self.csv_headers}\n"
-            f"{self.service_model.slug},{self.structure.siret},referent@email.com,"
-            f"{self.funding_label.value},Test Person,,À distance,,,,,Commune,"
+            f"{self.service_model.slug},{self.structure.siret},referent@email.com,Commune,"
+            f"{self.funding_label.value},Test Person,,a-distance,,,,,,,"
         )
 
         reader = csv.reader(io.StringIO(csv_content))
@@ -404,8 +404,8 @@ class ImportServicesTestCase(TestCase):
     def test_make_contact_info_public(self):
         csv_content = (
             f"{self.csv_headers}\n"
-            f"{self.service_model.slug},{self.structure.siret},referent@email.com,"
-            f"{self.funding_label.value},Test Person,,À distance,,,,,Commune,oui"
+            f"{self.service_model.slug},{self.structure.siret},referent@email.com,Commune,"
+            f"{self.funding_label.value},Test Person,,a-distance,,,,,oui"
         )
 
         reader = csv.reader(io.StringIO(csv_content))

--- a/back/dora/services/tests/test_import_services.py
+++ b/back/dora/services/tests/test_import_services.py
@@ -399,3 +399,21 @@ class ImportServicesTestCase(TestCase):
         self.assertEqual(result["created_count"], 1)
         self.assertEqual(result["errors"], [])
         self.assertEqual(created_service.status, ServiceStatus.DRAFT)
+
+    def test_keep_service_without_diffusion_zone_in_draft_and_apply_default(self):
+        csv_content = (
+            f"{self.csv_headers}\n"
+            f"{self.service_model.slug},{self.structure.siret},referent@email.com,"
+            f"{self.funding_label.value},Test Person,,À distance,,,,,"
+        )
+
+        reader = csv.reader(io.StringIO(csv_content))
+
+        result = import_services(reader, self.importing_user, wet_run=True)
+
+        created_service = Service.objects.filter(creator=self.importing_user).last()
+
+        self.assertEqual(result["created_count"], 1)
+        self.assertEqual(result["errors"], [])
+        self.assertEqual(created_service.status, ServiceStatus.DRAFT)
+        self.assertEqual(created_service.diffusion_zone_type, "city")

--- a/back/dora/services/tests/test_import_services.py
+++ b/back/dora/services/tests/test_import_services.py
@@ -63,7 +63,7 @@ class ImportServicesTestCase(TestCase):
     def test_import_services_dry_run(self):
         csv_content = (
             f"{self.csv_headers}\n"
-            f"{self.service_model.slug},{self.structure.siret},referent@email.com,{self.funding_label.value},,,,,,,,Commune,,"
+            f"{self.service_model.slug},{self.structure.siret},referent@email.com,{self.funding_label.value},,,,,,,,,,"
         )
 
         reader = csv.reader(io.StringIO(csv_content))
@@ -81,7 +81,7 @@ class ImportServicesTestCase(TestCase):
     def test_missing_siret(self):
         csv_content = (
             f"{self.csv_headers}\n"
-            f"{self.service_model.slug},,referent@email.com,{self.funding_label.value},,,,,,,,Commune,,"
+            f"{self.service_model.slug},,referent@email.com,{self.funding_label.value},,,,,,,,,,"
         )
 
         reader = csv.reader(io.StringIO(csv_content))
@@ -96,7 +96,7 @@ class ImportServicesTestCase(TestCase):
     def test_invalid_structure_siret(self):
         csv_content = (
             f"{self.csv_headers}\n"
-            f"{self.service_model.slug},'invalid-siret',referent@email.com,{self.funding_label.value},,,,,,,,Commune,,"
+            f"{self.service_model.slug},'invalid-siret',referent@email.com,{self.funding_label.value},,,,,,,,,,"
         )
 
         reader = csv.reader(io.StringIO(csv_content))
@@ -112,7 +112,7 @@ class ImportServicesTestCase(TestCase):
     def test_invalid_service_model_slug(self):
         csv_content = (
             f"{self.csv_headers}\n"
-            f"invalid-slug,{self.structure.siret},referent@email.com,{self.funding_label.value},,,,,,,,Commune,,"
+            f"invalid-slug,{self.structure.siret},referent@email.com,{self.funding_label.value},,,,,,,,,,"
         )
 
         reader = csv.reader(io.StringIO(csv_content))
@@ -127,21 +127,23 @@ class ImportServicesTestCase(TestCase):
         )
 
     def test_missing_diffusion_zone_type(self):
-        csv_content = (
-            f"{self.csv_headers}\n"
-            f"{self.service_model.slug},{self.structure.siret},referent@email.com,,{self.funding_label.value},,,,,,,,,"
-        )
+        def test_publish_eligible_remote_service(self):
+            csv_content = (
+                f"{self.csv_headers}\n"
+                f"{self.service_model.slug},{self.structure.siret},referent@email.com,"
+                f"{self.funding_label.value},Test Person,0123456789,a-distance,,,,,,"
+            )
 
-        reader = csv.reader(io.StringIO(csv_content))
+            reader = csv.reader(io.StringIO(csv_content))
 
-        result = import_services(reader, self.importing_user, wet_run=True)
+            result = import_services(reader, self.importing_user, wet_run=True)
 
-        self.assertEqual(result["created_count"], 0)
+            created_service = Service.objects.filter(creator=self.importing_user).last()
 
-        self.assertEqual(
-            result["errors"][0],
-            "Erreur : Type de zone de diffusion manquant. Ligne 1 ignorée.",
-        )
+            self.assertEqual(result["created_count"], 1)
+            self.assertEqual(result["errors"], [])
+            self.assertEqual(created_service.status, ServiceStatus.DRAFT)
+            self.assertEqual(created_service.diffusion_zone_type, "")
 
     def test_invalid_diffusion_zone_type(self):
         csv_content = (
@@ -162,7 +164,7 @@ class ImportServicesTestCase(TestCase):
     def test_invalid_funding_label(self):
         csv_content = (
             f"{self.csv_headers}\n"
-            f"{self.service_model.slug},{self.structure.siret},referent@email.com,invalid-funding-label,,,,,,,,Commune,,"
+            f"{self.service_model.slug},{self.structure.siret},referent@email.com,invalid-funding-label,,,,,,,,,,"
         )
 
         reader = csv.reader(io.StringIO(csv_content))
@@ -183,7 +185,7 @@ class ImportServicesTestCase(TestCase):
     def test_missing_geo_data(self, mock_geo_data):
         csv_content = (
             f"{self.csv_headers}\n"
-            f"{self.service_model.slug},{self.structure.siret},referent@email.com,{self.funding_label.value},,,,Paris,1 rue de test,,75020,Commune,,"
+            f"{self.service_model.slug},{self.structure.siret},referent@email.com,{self.funding_label.value},,,,Paris,1 rue de test,,75020,,,"
         )
 
         reader = csv.reader(io.StringIO(csv_content))
@@ -218,7 +220,7 @@ class ImportServicesTestCase(TestCase):
     def test_valid_geo_data(self, mock_geo_data):
         csv_content = (
             f"{self.csv_headers}\n"
-            f"{self.service_model.slug},{self.structure.siret},referent@email.com,{self.funding_label.value},,,,Paris,1 rue de test,,75020,Commune,,"
+            f"{self.service_model.slug},{self.structure.siret},referent@email.com,{self.funding_label.value},,,,Paris,1 rue de test,,75020,,,"
         )
 
         reader = csv.reader(io.StringIO(csv_content))
@@ -239,7 +241,7 @@ class ImportServicesTestCase(TestCase):
     def test_location_kinds(self):
         csv_content = (
             f"{self.csv_headers}\n"
-            f'{self.service_model.slug},{self.structure.siret},referent@email.com,{self.funding_label.value},,,"a-distance,en-presentiel",,,,,Commune,,'
+            f'{self.service_model.slug},{self.structure.siret},referent@email.com,{self.funding_label.value},,,"a-distance,en-presentiel",,,,,,,'
         )
 
         reader = csv.reader(io.StringIO(csv_content))
@@ -260,7 +262,7 @@ class ImportServicesTestCase(TestCase):
     def test_invalid_location_kinds(self):
         csv_content = (
             f"{self.csv_headers}\n"
-            f"{self.service_model.slug},{self.structure.siret},referent@email.com,{self.funding_label.value},,,invalid_kind,,,,,Commune,,"
+            f"{self.service_model.slug},{self.structure.siret},referent@email.com,{self.funding_label.value},,,invalid_kind,,,,,,,"
         )
 
         reader = csv.reader(io.StringIO(csv_content))
@@ -281,7 +283,7 @@ class ImportServicesTestCase(TestCase):
 
         csv_content = (
             f"{self.csv_headers}\n"
-            f'{self.service_model.slug},{self.structure.siret},referent@email.com,"{self.funding_label.value},{other_funding_label.value}",,,,,,,,Commune,'
+            f'{self.service_model.slug},{self.structure.siret},referent@email.com,"{self.funding_label.value},{other_funding_label.value}",,,,,,,,,'
         )
 
         reader = csv.reader(io.StringIO(csv_content))
@@ -306,7 +308,7 @@ class ImportServicesTestCase(TestCase):
     def test_duplicated_financing_labels(self):
         csv_content = (
             f"{self.csv_headers}\n"
-            f'{self.service_model.slug},{self.structure.siret},referent@email.com,"{self.funding_label.value},{self.funding_label.value}",,,,,,,Commune,,'
+            f'{self.service_model.slug},{self.structure.siret},referent@email.com,"{self.funding_label.value},{self.funding_label.value}",,,,,,,,,'
         )
 
         reader = csv.reader(io.StringIO(csv_content))
@@ -322,8 +324,8 @@ class ImportServicesTestCase(TestCase):
     def test_handle_one_invalid_line(self):
         csv_content = (
             f"{self.csv_headers}\n"
-            f"invalid,{self.structure.siret},referent@email.com,{self.funding_label.value},,,,,,,,,Commune,,\n"
-            f"{self.service_model.slug},{self.structure.siret},referent@email.com,{self.funding_label.value},,,,,,,,Commune,,"
+            f"invalid,{self.structure.siret},referent@email.com,{self.funding_label.value},,,,,,,,,,,\n"
+            f"{self.service_model.slug},{self.structure.siret},referent@email.com,{self.funding_label.value},,,,,,,,,,"
         )
 
         reader = csv.reader(io.StringIO(csv_content))
@@ -371,7 +373,7 @@ class ImportServicesTestCase(TestCase):
         csv_content = (
             f"{self.csv_headers}\n"
             f"{self.service_model.slug},{self.structure.siret},referent@email.com,"
-            f"{self.funding_label.value},Test Person,0123456789,en-presentiel,Paris,1 rue de test,,,Commune,"
+            f"{self.funding_label.value},Test Person,0123456789,en-presentiel,Paris,1 rue de test,,,,"
         )
 
         reader = csv.reader(io.StringIO(csv_content))
@@ -388,7 +390,7 @@ class ImportServicesTestCase(TestCase):
         csv_content = (
             f"{self.csv_headers}\n"
             f"{self.service_model.slug},{self.structure.siret},referent@email.com,"
-            f"{self.funding_label.value},Test Person,,a-distance,,,,,Commune,"
+            f"{self.funding_label.value},Test Person,,a-distance,,,,,,"
         )
 
         reader = csv.reader(io.StringIO(csv_content))
@@ -405,7 +407,7 @@ class ImportServicesTestCase(TestCase):
         csv_content = (
             f"{self.csv_headers}\n"
             f"{self.service_model.slug},{self.structure.siret},referent@email.com,"
-            f"{self.funding_label.value},Test Person,,a-distance,,,,,Commune,oui"
+            f"{self.funding_label.value},Test Person,,a-distance,,,,,,oui"
         )
 
         reader = csv.reader(io.StringIO(csv_content))

--- a/back/dora/services/tests/test_import_services.py
+++ b/back/dora/services/tests/test_import_services.py
@@ -8,6 +8,7 @@ from model_bakery import baker
 
 from dora.core.utils import GeoData
 from dora.service_suggestions.tests import DUMMY_SUGGESTION
+from dora.services.enums import ServiceStatus
 from dora.services.management.commands.import_services import import_services
 from dora.services.models import Service
 
@@ -330,3 +331,71 @@ class ImportServicesTestCase(TestCase):
 
         self.assertEqual(result["created_count"], 1)
         self.assertEqual(len(result["errors"]), 1)
+
+    def test_publish_eligible_remote_service(self):
+        csv_content = (
+            f"{self.csv_headers}\n"
+            f"{self.service_model.slug},{self.structure.siret},referent@email.com,"
+            f"{self.funding_label.value},Test Person,0123456789,À distance,,,,,Commune"
+        )
+
+        reader = csv.reader(io.StringIO(csv_content))
+
+        result = import_services(reader, self.importing_user, wet_run=True)
+
+        created_service = Service.objects.filter(creator=self.importing_user).last()
+
+        self.assertEqual(result["created_count"], 1)
+        self.assertEqual(result["errors"], [])
+        self.assertEqual(created_service.status, ServiceStatus.PUBLISHED)
+
+    def test_publish_eligible_in_person_service(self):
+        csv_content = (
+            f"{self.csv_headers}\n"
+            f"{self.service_model.slug},{self.structure.siret},referent@email.com,"
+            f"{self.funding_label.value},Test Person,0123456789,En présentiel,Paris,1 rue de test,,75020,Commune"
+        )
+
+        reader = csv.reader(io.StringIO(csv_content))
+
+        result = import_services(reader, self.importing_user, wet_run=True)
+
+        created_service = Service.objects.filter(creator=self.importing_user).last()
+
+        self.assertEqual(result["created_count"], 1)
+        self.assertEqual(result["errors"], [])
+        self.assertEqual(created_service.status, ServiceStatus.PUBLISHED)
+
+    def test_keep_in_person_service_in_draft_when_ineligible(self):
+        csv_content = (
+            f"{self.csv_headers}\n"
+            f"{self.service_model.slug},{self.structure.siret},referent@email.com,"
+            f"{self.funding_label.value},Test Person,0123456789,En présentiel,Paris,1 rue de test,,,Commune"
+        )
+
+        reader = csv.reader(io.StringIO(csv_content))
+
+        result = import_services(reader, self.importing_user, wet_run=True)
+
+        created_service = Service.objects.filter(creator=self.importing_user).last()
+
+        self.assertEqual(result["created_count"], 1)
+        self.assertEqual(result["errors"], [])
+        self.assertEqual(created_service.status, ServiceStatus.DRAFT)
+
+    def test_keep_service_in_draft_when_ineligible(self):
+        csv_content = (
+            f"{self.csv_headers}\n"
+            f"{self.service_model.slug},{self.structure.siret},referent@email.com,"
+            f"{self.funding_label.value},Test Person,,À distance,,,,,Commune"
+        )
+
+        reader = csv.reader(io.StringIO(csv_content))
+
+        result = import_services(reader, self.importing_user, wet_run=True)
+
+        created_service = Service.objects.filter(creator=self.importing_user).last()
+
+        self.assertEqual(result["created_count"], 1)
+        self.assertEqual(result["errors"], [])
+        self.assertEqual(created_service.status, ServiceStatus.DRAFT)

--- a/back/dora/services/tests/test_import_services.py
+++ b/back/dora/services/tests/test_import_services.py
@@ -16,7 +16,7 @@ from dora.services.models import Service
 class ImportServicesTestCase(TestCase):
     def setUp(self):
         self.importing_user = baker.make("users.User")
-        self.csv_headers = "modele_slug,structure_siret,contact_email,diffusion_zone_type,labels_financement,contact_name,contact_phone,location_kinds,location_city,location_address,location_complement,location_postal_code,is_contact_info_public"
+        self.csv_headers = "modele_slug,structure_siret,contact_email,labels_financement,contact_name,contact_phone,location_kinds,location_city,location_address,location_complement,location_postal_code,diffusion_zone_type,is_contact_info_public"
         self.structure = baker.make("Structure", siret=DUMMY_SUGGESTION["siret"])
 
         self.service_model = baker.make(
@@ -34,7 +34,7 @@ class ImportServicesTestCase(TestCase):
     def test_import_services_wet_run(self):
         csv_content = (
             f"{self.csv_headers}\n"
-            f"{self.service_model.slug},{self.structure.siret},referent@email.com,Commune,{self.funding_label.value},Test Person,0123456789,,,,,,,"
+            f"{self.service_model.slug},{self.structure.siret},referent@email.com,{self.funding_label.value},Test Person,0123456789,,,,,,Commune,,"
         )
         reader = csv.reader(io.StringIO(csv_content))
 
@@ -63,7 +63,7 @@ class ImportServicesTestCase(TestCase):
     def test_import_services_dry_run(self):
         csv_content = (
             f"{self.csv_headers}\n"
-            f"{self.service_model.slug},{self.structure.siret},referent@email.com,Commune,{self.funding_label.value},,,,,,,,,"
+            f"{self.service_model.slug},{self.structure.siret},referent@email.com,{self.funding_label.value},,,,,,,,Commune,,"
         )
 
         reader = csv.reader(io.StringIO(csv_content))
@@ -81,7 +81,7 @@ class ImportServicesTestCase(TestCase):
     def test_missing_siret(self):
         csv_content = (
             f"{self.csv_headers}\n"
-            f"{self.service_model.slug},,referent@email.com,Commune,{self.funding_label.value},,,,,,,,,"
+            f"{self.service_model.slug},,referent@email.com,{self.funding_label.value},,,,,,,,Commune,,"
         )
 
         reader = csv.reader(io.StringIO(csv_content))
@@ -96,7 +96,7 @@ class ImportServicesTestCase(TestCase):
     def test_invalid_structure_siret(self):
         csv_content = (
             f"{self.csv_headers}\n"
-            f"{self.service_model.slug},'invalid-siret',referent@email.com,Commune,{self.funding_label.value},,,,,,,,,"
+            f"{self.service_model.slug},'invalid-siret',referent@email.com,{self.funding_label.value},,,,,,,,Commune,,"
         )
 
         reader = csv.reader(io.StringIO(csv_content))
@@ -112,7 +112,7 @@ class ImportServicesTestCase(TestCase):
     def test_invalid_service_model_slug(self):
         csv_content = (
             f"{self.csv_headers}\n"
-            f"invalid-slug,{self.structure.siret},referent@email.com,Commune,{self.funding_label.value},,,,,,,,,"
+            f"invalid-slug,{self.structure.siret},referent@email.com,{self.funding_label.value},,,,,,,,Commune,,"
         )
 
         reader = csv.reader(io.StringIO(csv_content))
@@ -146,7 +146,7 @@ class ImportServicesTestCase(TestCase):
     def test_invalid_diffusion_zone_type(self):
         csv_content = (
             f"{self.csv_headers}\n"
-            f"{self.service_model.slug},'invalid-siret',referent@email.com,invalid_zone_type,{self.funding_label.value},,,,,,,,,"
+            f"{self.service_model.slug},'invalid-siret',referent@email.com,{self.funding_label.value},,,,,,,,invalid_zone_type,,"
         )
 
         reader = csv.reader(io.StringIO(csv_content))
@@ -162,7 +162,7 @@ class ImportServicesTestCase(TestCase):
     def test_invalid_funding_label(self):
         csv_content = (
             f"{self.csv_headers}\n"
-            f"{self.service_model.slug},{self.structure.siret},referent@email.com,Commune,invalid-funding-label,,,,,,,,,"
+            f"{self.service_model.slug},{self.structure.siret},referent@email.com,invalid-funding-label,,,,,,,,Commune,,"
         )
 
         reader = csv.reader(io.StringIO(csv_content))
@@ -183,7 +183,7 @@ class ImportServicesTestCase(TestCase):
     def test_missing_geo_data(self, mock_geo_data):
         csv_content = (
             f"{self.csv_headers}\n"
-            f"{self.service_model.slug},{self.structure.siret},referent@email.com,Commune,{self.funding_label.value},,,,Paris,1 rue de test,,75020,,"
+            f"{self.service_model.slug},{self.structure.siret},referent@email.com,{self.funding_label.value},,,,Paris,1 rue de test,,75020,Commune,,"
         )
 
         reader = csv.reader(io.StringIO(csv_content))
@@ -218,7 +218,7 @@ class ImportServicesTestCase(TestCase):
     def test_valid_geo_data(self, mock_geo_data):
         csv_content = (
             f"{self.csv_headers}\n"
-            f"{self.service_model.slug},{self.structure.siret},referent@email.com,Commune,{self.funding_label.value},,,,Paris,1 rue de test,,75020,"
+            f"{self.service_model.slug},{self.structure.siret},referent@email.com,{self.funding_label.value},,,,Paris,1 rue de test,,75020,Commune,,"
         )
 
         reader = csv.reader(io.StringIO(csv_content))
@@ -239,7 +239,7 @@ class ImportServicesTestCase(TestCase):
     def test_location_kinds(self):
         csv_content = (
             f"{self.csv_headers}\n"
-            f'{self.service_model.slug},{self.structure.siret},referent@email.com,Commune,{self.funding_label.value},,,"a-distance,en-presentiel",,,,,,'
+            f'{self.service_model.slug},{self.structure.siret},referent@email.com,{self.funding_label.value},,,"a-distance,en-presentiel",,,,,Commune,,'
         )
 
         reader = csv.reader(io.StringIO(csv_content))
@@ -260,7 +260,7 @@ class ImportServicesTestCase(TestCase):
     def test_invalid_location_kinds(self):
         csv_content = (
             f"{self.csv_headers}\n"
-            f"{self.service_model.slug},{self.structure.siret},referent@email.com,Commune,{self.funding_label.value},,,invalid_kind,,,,,,"
+            f"{self.service_model.slug},{self.structure.siret},referent@email.com,{self.funding_label.value},,,invalid_kind,,,,,Commune,,"
         )
 
         reader = csv.reader(io.StringIO(csv_content))
@@ -281,7 +281,7 @@ class ImportServicesTestCase(TestCase):
 
         csv_content = (
             f"{self.csv_headers}\n"
-            f'{self.service_model.slug},{self.structure.siret},referent@email.com,Commune,"{self.funding_label.value},{other_funding_label.value}",,,,,,,,'
+            f'{self.service_model.slug},{self.structure.siret},referent@email.com,"{self.funding_label.value},{other_funding_label.value}",,,,,,,,Commune,'
         )
 
         reader = csv.reader(io.StringIO(csv_content))
@@ -306,7 +306,7 @@ class ImportServicesTestCase(TestCase):
     def test_duplicated_financing_labels(self):
         csv_content = (
             f"{self.csv_headers}\n"
-            f'{self.service_model.slug},{self.structure.siret},referent@email.com,Commune,"{self.funding_label.value},{self.funding_label.value}",,,,,,,,'
+            f'{self.service_model.slug},{self.structure.siret},referent@email.com,"{self.funding_label.value},{self.funding_label.value}",,,,,,,Commune,,'
         )
 
         reader = csv.reader(io.StringIO(csv_content))
@@ -322,8 +322,8 @@ class ImportServicesTestCase(TestCase):
     def test_handle_one_invalid_line(self):
         csv_content = (
             f"{self.csv_headers}\n"
-            f"invalid,{self.structure.siret},referent@email.com,Commune,{self.funding_label.value},,,,,,,,,\n"
-            f"{self.service_model.slug},{self.structure.siret},referent@email.com,Commune,{self.funding_label.value},,,,,,,,,"
+            f"invalid,{self.structure.siret},referent@email.com,{self.funding_label.value},,,,,,,,,Commune,,\n"
+            f"{self.service_model.slug},{self.structure.siret},referent@email.com,{self.funding_label.value},,,,,,,,Commune,,"
         )
 
         reader = csv.reader(io.StringIO(csv_content))
@@ -336,8 +336,8 @@ class ImportServicesTestCase(TestCase):
     def test_publish_eligible_remote_service(self):
         csv_content = (
             f"{self.csv_headers}\n"
-            f"{self.service_model.slug},{self.structure.siret},referent@email.com,Commune,"
-            f"{self.funding_label.value},Test Person,0123456789,a-distance,,,,,,,"
+            f"{self.service_model.slug},{self.structure.siret},referent@email.com,"
+            f"{self.funding_label.value},Test Person,0123456789,a-distance,,,,,Commune,"
         )
 
         reader = csv.reader(io.StringIO(csv_content))
@@ -353,8 +353,8 @@ class ImportServicesTestCase(TestCase):
     def test_publish_eligible_in_person_service(self):
         csv_content = (
             f"{self.csv_headers}\n"
-            f"{self.service_model.slug},{self.structure.siret},referent@email.com,Commune,"
-            f"{self.funding_label.value},Test Person,0123456789,en-presentiel,Paris,1 rue de test,,75020,"
+            f"{self.service_model.slug},{self.structure.siret},referent@email.com,"
+            f"{self.funding_label.value},Test Person,0123456789,en-presentiel,Paris,1 rue de test,,75020,Commune,,"
         )
 
         reader = csv.reader(io.StringIO(csv_content))
@@ -370,8 +370,8 @@ class ImportServicesTestCase(TestCase):
     def test_keep_in_person_service_in_draft_when_ineligible(self):
         csv_content = (
             f"{self.csv_headers}\n"
-            f"{self.service_model.slug},{self.structure.siret},referent@email.com,Commune,"
-            f"{self.funding_label.value},Test Person,0123456789,en-presentiel,Paris,1 rue de test,,,,,"
+            f"{self.service_model.slug},{self.structure.siret},referent@email.com,"
+            f"{self.funding_label.value},Test Person,0123456789,en-presentiel,Paris,1 rue de test,,,Commune,"
         )
 
         reader = csv.reader(io.StringIO(csv_content))
@@ -387,8 +387,8 @@ class ImportServicesTestCase(TestCase):
     def test_keep_service_in_draft_when_ineligible(self):
         csv_content = (
             f"{self.csv_headers}\n"
-            f"{self.service_model.slug},{self.structure.siret},referent@email.com,Commune,"
-            f"{self.funding_label.value},Test Person,,a-distance,,,,,,,"
+            f"{self.service_model.slug},{self.structure.siret},referent@email.com,"
+            f"{self.funding_label.value},Test Person,,a-distance,,,,,Commune,"
         )
 
         reader = csv.reader(io.StringIO(csv_content))
@@ -404,8 +404,8 @@ class ImportServicesTestCase(TestCase):
     def test_make_contact_info_public(self):
         csv_content = (
             f"{self.csv_headers}\n"
-            f"{self.service_model.slug},{self.structure.siret},referent@email.com,Commune,"
-            f"{self.funding_label.value},Test Person,,a-distance,,,,,oui"
+            f"{self.service_model.slug},{self.structure.siret},referent@email.com,"
+            f"{self.funding_label.value},Test Person,,a-distance,,,,,Commune,oui"
         )
 
         reader = csv.reader(io.StringIO(csv_content))

--- a/back/dora/services/utils.py
+++ b/back/dora/services/utils.py
@@ -80,7 +80,6 @@ def instantiate_model(model, structure, user):
         service.geom = None
 
     # Metadata
-    service.is_draft = True
     service.is_model = False
     service.creator = model.creator
     service.last_editor = user


### PR DESCRIPTION
[Ticket](https://www.notion.so/gip-inclusion/Cr-ation-de-services-par-import-services-sont-en-brouillon-si-certaines-infos-sont-manquantes-2095f321b6048033b69ec6837ce52abe?source=copy_link)

Quand certaines colonnes optionnelles du csv d'import sont manquantes, les services peuvent être crées mais ils sont mis en brouillon. (Les conditions sont dans le ticket au-dessus)

* Pour que la colonne `diffusion_zone_type` soit optionnelle, il faut mettre `""` comme valeur si cette colonne n'est pas remplie dans le csv. j'ai supprimé la verification d'une valeur manquante pour cette colonne.
* Ajout d'une colonne `is_contact_info_public` (le défaut est `False`)

* la colonne `is_draft` a été supprimée dans une migration précédente donc j'ai enlevé l'un des vestiges de cette propriété dans ce PR aussi
