### PR TITLE
fix(recherche unifiée): correction de bugs introduits par la recherche unifiée

### DIFF
--- a/back/dora/data_inclusion/mappings.py
+++ b/back/dora/data_inclusion/mappings.py
@@ -98,6 +98,7 @@ def map_search_result(result: dict, supported_service_kinds: list[str]) -> dict:
         "coordinates": (result["service"]["longitude"], result["service"]["latitude"])
         if result["service"]["longitude"] and result["service"]["latitude"]
         else None,
+        "publication_date": None,
     }
 
 

--- a/front/src/lib/env.ts
+++ b/front/src/lib/env.ts
@@ -8,3 +8,5 @@ export const WARNING_BANNER = import.meta.env.VITE_WARNING_BANNER;
 export const OIDC_AUTH_BACKEND =
   import.meta.env.VITE_OIDC_AUTH_BACKEND || "proconnect";
 export const GOOGLE_CSE_ID = import.meta.env.VITE_GOOGLE_CSE_ID;
+export const DI_DORA_UNIFIED_SEARCH_ENABLED =
+  import.meta.env.VITE_DI_DORA_UNIFIED_SEARCH_ENABLED !== "false";

--- a/front/src/routes/(modeles-services)/components/service-body/service-body.svelte
+++ b/front/src/routes/(modeles-services)/components/service-body/service-body.svelte
@@ -4,6 +4,7 @@
   import CenteredGrid from "$lib/components/display/centered-grid.svelte";
   import Notice from "$lib/components/display/notice.svelte";
   import OrientationVideo from "$lib/components/specialized/orientation-video.svelte";
+  import { DI_DORA_UNIFIED_SEARCH_ENABLED } from "$lib/env";
   import type { Model, Service, ServicesOptions } from "$lib/types";
   import { token, userInfo } from "$lib/utils/auth";
   import { isLessThanOneHourAgo } from "$lib/utils/date";
@@ -13,6 +14,7 @@
   import ServiceMobilisation from "./service-mobilisation.svelte";
   import ServicePresentation from "./service-presentation/service-presentation.svelte";
   import ServiceIndividual from "./service-individual.svelte";
+
   export let service: Service | Model;
   export let servicesOptions: ServicesOptions;
   export let onFeedbackButtonClick: () => void;
@@ -31,7 +33,9 @@
     : false;
 
   $: showServiceWillBeVisibleSoonNotice =
-    service.canWrite && isLessThanOneHourAgo(service.creationDate);
+    DI_DORA_UNIFIED_SEARCH_ENABLED &&
+    service.canWrite &&
+    isLessThanOneHourAgo(service.creationDate);
 
   // Utilisé pour prévenir le tracking multiple
   let mobilisationTracked = false;

--- a/front/src/routes/(modeles-services)/services/service-edition-form.svelte
+++ b/front/src/routes/(modeles-services)/services/service-edition-form.svelte
@@ -20,6 +20,7 @@
   import FieldsPublics from "$lib/components/specialized/services/fields-publics.svelte";
   import FieldsStructure from "../_common/fields-structure.svelte";
   import FieldsTypology from "$lib/components/specialized/services/fields-typology.svelte";
+  import { DI_DORA_UNIFIED_SEARCH_ENABLED } from "$lib/env";
   import { createOrModifyService } from "$lib/requests/services";
   import type {
     Model,
@@ -93,8 +94,12 @@
     }
   }
 
-  function handleSuccess() {
-    goto("/services/creer/succès");
+  function handleSuccess(result) {
+    if (DI_DORA_UNIFIED_SEARCH_ENABLED) {
+      goto("/services/creer/succès");
+    } else {
+      goto(`/services/${result.slug}`);
+    }
   }
 
   function handleValidate(data, kind: "draft" | "publish") {


### PR DESCRIPTION
## Affichage du message sur la visibilité du service et redirection après création du service

Prise en compte d'une nouvelle variable d'environnement côté front `VITE_DI_DORA_UNIFIED_SEARCH_ENABLED` permettant de désactiver l'affichage des messages d'information sur la visibilité du service après création. À utiliser lorsque la recherche unifiée est désactivée côté back.

## Recherches sauvegardées (alertes)

Il manquait le champ `publication_date` dans la fonction de mapping des résultats de recherche DI, occasionnant le non-affichage des recherches sauvegardées.