### PR TITLE
fix: utiliser value de diffusion_zone_type au lieu de label

### DIFF
--- a/back/dora/services/management/commands/import_services.py
+++ b/back/dora/services/management/commands/import_services.py
@@ -64,7 +64,7 @@ def _extract_diffusion_zone_type_from_line(line):
         return ""
 
     for choice in AdminDivisionType:
-        if diffusion_zone_type_raw == choice.label:
+        if diffusion_zone_type_raw == choice.value:
             return choice
 
     raise ValueError(

--- a/back/dora/services/tests/test_import_services.py
+++ b/back/dora/services/tests/test_import_services.py
@@ -34,7 +34,7 @@ class ImportServicesTestCase(TestCase):
     def test_import_services_wet_run(self):
         csv_content = (
             f"{self.csv_headers}\n"
-            f"{self.service_model.slug},{self.structure.siret},referent@email.com,{self.funding_label.value},Test Person,0123456789,,,,,,Commune,"
+            f"{self.service_model.slug},{self.structure.siret},referent@email.com,{self.funding_label.value},Test Person,0123456789,,,,,,city,"
         )
         reader = csv.reader(io.StringIO(csv_content))
 
@@ -338,7 +338,7 @@ class ImportServicesTestCase(TestCase):
         csv_content = (
             f"{self.csv_headers}\n"
             f"{self.service_model.slug},{self.structure.siret},referent@email.com,"
-            f"{self.funding_label.value},Test Person,0123456789,a-distance,,,,,Commune,"
+            f"{self.funding_label.value},Test Person,0123456789,a-distance,,,,,city,"
         )
 
         reader = csv.reader(io.StringIO(csv_content))
@@ -355,7 +355,7 @@ class ImportServicesTestCase(TestCase):
         csv_content = (
             f"{self.csv_headers}\n"
             f"{self.service_model.slug},{self.structure.siret},referent@email.com,"
-            f"{self.funding_label.value},Test Person,0123456789,en-presentiel,Paris,1 rue de test,,75020,Commune,"
+            f"{self.funding_label.value},Test Person,0123456789,en-presentiel,Paris,1 rue de test,,75020,city,"
         )
 
         reader = csv.reader(io.StringIO(csv_content))


### PR DESCRIPTION
le csv template pour l'import des nouveaux services utilisent les `values` des `AdminDivisionType` (`city`, `epci`, etc) mais le script actuel vérifie les label (`Commune`, etc). Ce PR fait en sorte que le script vérifie la `value` au lieu du `label`. 