### PR TITLE
fix: ajout des ids structure et services à la table int_service_structure_labels

### DIFF
--- a/analytics/models/intermediate/int_service_structure_labels.sql
+++ b/analytics/models/intermediate/int_service_structure_labels.sql
@@ -8,8 +8,8 @@ structure AS (
 
 final AS (
     SELECT
-        {{ dbt_utils.star(relation_alias='services', from=ref("stg_service"), prefix='service_', except=['id']) }},
-        {{ dbt_utils.star(relation_alias='structure', from=ref("int_structure_national_labels"), prefix='structure_', except=['id']) }}
+        {{ dbt_utils.star(relation_alias='services', from=ref("stg_service"), prefix='service_') }},
+        {{ dbt_utils.star(relation_alias='structure', from=ref("int_structure_national_labels"), prefix='structure_') }}
     FROM services
     INNER JOIN structure ON services.structure_id = structure.structure_id
 )


### PR DESCRIPTION
Ces variables étaient ignorées ce qui ne permet pas de réaliser une simple jointure sur metabase pour le calcul des thématiques.