### PR TITLE
fix: les structures obsolètes doivent être exclues des notifications de modération

### DIFF
--- a/back/dora/notifications/tasks/users.py
+++ b/back/dora/notifications/tasks/users.py
@@ -178,6 +178,7 @@ class ManagerStructureModerationTask(Task):
             # un ou plusieurs des départements du gestionnaire
             # contiennent des structures en attente de modération (overlap = PgSQL `&&`)
             departments__overlap=Structure.objects.awaiting_moderation()
+            .exclude(is_obsolete=True)
             .distinct("department")
             .values_list("department", flat=True)
         )

--- a/back/dora/users/emails.py
+++ b/back/dora/users/emails.py
@@ -103,8 +103,10 @@ def send_structure_awaiting_moderation(manager):
 
     # pas de dépendances/import entre modèles sauf si indispensable
     structures = apps.get_model("structures.Structure").objects
-    to_moderate = structures.awaiting_moderation().filter(
-        department__in=manager.departments
+    to_moderate = (
+        structures.awaiting_moderation()
+        .exclude(is_obsolete=True)
+        .filter(department__in=manager.departments)
     )
 
     cta_link = furl(settings.FRONTEND_URL) / "admin" / "structures"


### PR DESCRIPTION
Les structures obsolètes ne doivent pas être prises en compte pour les notifications aux gestionnaires de territoire.

_Ni pour quoi que ce soit, d'ailleurs._

Elles sont désormais filtrées dans le cadre des notifications (uniquement).
