### PR TITLE
fix(boto3): désactivation checksum pour compatibilité CleverCloud

### DIFF
--- a/back/config/settings/base.py
+++ b/back/config/settings/base.py
@@ -12,6 +12,7 @@ https://docs.djangoproject.com/en/3.2/ref/settings/
 
 import os
 
+from botocore.config import Config
 from corsheaders.defaults import default_headers
 
 from . import BASE_DIR
@@ -186,7 +187,13 @@ STATIC_ROOT = os.path.join(BASE_DIR, "staticfiles")
 
 STORAGES = {
     "default": {
-        "BACKEND": "storages.backends.s3boto3.S3Boto3Storage",
+        "BACKEND": "storages.backends.s3.S3Storage",
+        "OPTIONS": {
+            "client_config": Config(
+                request_checksum_calculation="when_required",
+                response_checksum_validation="when_required",
+            ),
+        },
     },
     "staticfiles": {
         "BACKEND": "django.contrib.staticfiles.storage.StaticFilesStorage",


### PR DESCRIPTION
Avec les versions de boto3 supérieures à 35.99, une vérification de somme de contrôle est faite qui n'est pas compatible avec l'implémentation S3 de CleverCloud (et d'autres).

La désactivation de cette vérification permet de mettre à jour boto3 sans casser l'upload de fichiers avec CleverCloud.

**Test :** il ne sera possible de tester qu'une fois déployé sur staging.

Sources :
- https://github.com/boto/boto3/issues/4398#issuecomment-2619946229
- https://github.com/jschneier/django-storages/issues/1498