### PR TITLE
feat: changer les messages d'erreur/avertissement

### DIFF
--- a/back/dora/services/tests/test_admin_import_view.py
+++ b/back/dora/services/tests/test_admin_import_view.py
@@ -45,31 +45,6 @@ class ImportServicesViewTestCase(APITestCase):
             "geo_data_missing_lines": [],
             "draft_services_created": [],
         }
-        self.mock_warning_result = {
-            "created_count": 3,
-            "errors": [],
-            "duplicated_services": [
-                {
-                    "idx": 2,
-                    "siret": "1234",
-                    "name": "Service A",
-                    "model_slug": "slug_1",
-                    "contact_email": "a@a.com",
-                },
-                {
-                    "idx": 3,
-                    "siret": "3456",
-                    "name": "Service B",
-                    "model_slug": "slug_2",
-                    "contact_email": "b@b.com",
-                },
-            ],
-            "geo_data_missing_lines": [
-                {"idx": 1, "address": "123 Main St", "city": "Paris"},
-                {"idx": 3, "address": "456 Oak Ave", "city": "Lyon"},
-            ],
-            "draft_services_created": [],
-        }
 
     def create_csv_file(self, content, filename="test.csv"):
         return SimpleUploadedFile(
@@ -340,7 +315,7 @@ class ImportServicesViewTestCase(APITestCase):
         mock_messages.error.assert_called_once_with(
             request,
             mark_safe(
-                "<b>Échec de l'import - Erreurs à corriger</b><br/>Le fichier contient des erreurs qui empêchent l'import. Veuillez corriger les éléments suivants :<br/>"
+                "<b>Échec de l'import</b><br/>Aucun service n’a été importé, car le fichier comporte des erreurs. Veuillez corriger les éléments suivants :<br/>"
                 "• [2] SIRET manquant.<br/>"
                 "• [3] Structure introuvable."
             ),
@@ -426,7 +401,7 @@ class ImportServicesViewTestCase(APITestCase):
         mock_messages.error.assert_called_once_with(
             request,
             mark_safe(
-                "<b>Échec de l'import - Erreurs à corriger</b><br/>Le fichier contient des erreurs qui empêchent l'import. Veuillez corriger les éléments suivants :<br/>"
+                "<b>Échec de l'import</b><br/>Aucun service n’a été importé, car le fichier comporte des erreurs. Veuillez corriger les éléments suivants :<br/>"
                 "• [2] SIRET manquant.<br/>"
                 "• [3] Structure introuvable."
             ),
@@ -554,8 +529,110 @@ class ImportServicesViewTestCase(APITestCase):
             ),
         )
 
-    def test_combined_warnings(self, mock_import, mock_messages):
-        mock_import.return_value = self.mock_warning_result
+    def test_combined_warnings_when_wet_run_with_errors(
+        self, mock_import, mock_messages
+    ):
+        mock_import.return_value = {
+            "created_count": 3,
+            "errors": ["[2] Siret manquant"],
+            "duplicated_services": [
+                {
+                    "idx": 2,
+                    "siret": "1234",
+                    "name": "Service A",
+                    "model_slug": "slug_1",
+                    "contact_email": "a@a.com",
+                },
+                {
+                    "idx": 3,
+                    "siret": "3456",
+                    "name": "Service B",
+                    "model_slug": "slug_2",
+                    "contact_email": "b@b.com",
+                },
+            ],
+            "geo_data_missing_lines": [
+                {"idx": 1, "address": "123 Main St", "city": "Paris"},
+                {"idx": 3, "address": "456 Oak Ave", "city": "Lyon"},
+            ],
+            "draft_services_created": [
+                {
+                    "idx": 1,
+                    "name": "Service Test",
+                    "missing_fields": ["contact email", "lieu de déroulement"],
+                }
+            ],
+        }
+
+        csv_content = "header1,header2\nvalue1,value2"
+        csv_file = self.create_csv_file(csv_content)
+
+        request = self.factory.post(
+            "/admin/services/service/import-services/",
+            {"csv_file": csv_file, "test_run": "off"},
+        )
+        request.user = self.user
+
+        response = self.service_admin.import_services_view(request)
+
+        self.assertIsInstance(response, HttpResponseRedirect)
+        self.assertEqual(response.url, ".")
+
+        mock_messages.warning.assert_any_call(
+            request,
+            mark_safe(
+                "<b>Doublons potentiels détectés</b><br/>Nous avons détecté des similitudes avec des services existants. Nous vous recommandons de vérifier :<br/>"
+                '• [2] SIRET 1234 - il existe déjà un service avec le modèle slug_1 et le courriel "a@a.com"<br/>'
+                '• [3] SIRET 3456 - il existe déjà un service avec le modèle slug_2 et le courriel "b@b.com"'
+            ),
+        )
+        mock_messages.warning.assert_any_call(
+            request,
+            mark_safe(
+                "<b>Géolocalisation incomplète</b><br/>Certaines adresses n'ont pas pu être géolocalisées correctement et risquent de ne pas apparaître dans les résultats de recherche :<br/>"
+                "• [1] 123 Main St  Paris<br/>"
+                "• [3] 456 Oak Ave  Lyon"
+            ),
+        )
+        mock_messages.warning.assert_any_call(
+            request,
+            mark_safe(
+                '<b>Services importés en brouillon</b><br/>1 services ont été importés en brouillon. Contactez les structures pour compléter ces éléments avant publication :<br/>• [1] Service "Service Test" - Manque : contact email, lieu de déroulement'
+            ),
+        )
+
+    def test_combined_warnings_when_wet_run_no_errors(self, mock_import, mock_messages):
+        mock_import.return_value = {
+            "created_count": 3,
+            "errors": [],
+            "duplicated_services": [
+                {
+                    "idx": 2,
+                    "siret": "1234",
+                    "name": "Service A",
+                    "model_slug": "slug_1",
+                    "contact_email": "a@a.com",
+                },
+                {
+                    "idx": 3,
+                    "siret": "3456",
+                    "name": "Service B",
+                    "model_slug": "slug_2",
+                    "contact_email": "b@b.com",
+                },
+            ],
+            "geo_data_missing_lines": [
+                {"idx": 1, "address": "123 Main St", "city": "Paris"},
+                {"idx": 3, "address": "456 Oak Ave", "city": "Lyon"},
+            ],
+            "draft_services_created": [
+                {
+                    "idx": 1,
+                    "name": "Service Test",
+                    "missing_fields": ["contact email", "lieu de déroulement"],
+                }
+            ],
+        }
 
         csv_content = "header1,header2\nvalue1,value2"
         csv_file = self.create_csv_file(csv_content)
@@ -585,6 +662,12 @@ class ImportServicesViewTestCase(APITestCase):
                 "<b>Import réalisé - Géolocalisation incomplète</b><br/>Certaines adresses n'ont pas pu être géolocalisées correctement et risquent de ne pas apparaître dans les résultats de recherche :<br/>"
                 "• [1] 123 Main St  Paris<br/>"
                 "• [3] 456 Oak Ave  Lyon"
+            ),
+        )
+        mock_messages.warning.assert_any_call(
+            request,
+            mark_safe(
+                '<b>Import réalisé - Services importés en brouillon</b><br/>1 services ont été importés en brouillon. Contactez les structures pour compléter ces éléments avant publication :<br/>• [1] Service "Service Test" - Manque : contact email, lieu de déroulement'
             ),
         )
 


### PR DESCRIPTION
Pour l'import des services dans l'admin, on affiche ce message d'erreur quand il y a des erreurs bloquantes et c'est un vrai import : 
![Screenshot 2025-07-02 at 12 24 22](https://github.com/user-attachments/assets/99e84583-db05-4a59-9598-caf6d4a09a08)

Quand il y a des avertissements pendant un vrai import et il y a des erreurs bloquantes, on supprime `Import réalisé` dans le titre comme ici :
![Screenshot 2025-07-02 at 12 24 32](https://github.com/user-attachments/assets/b5ce6f54-5ddb-4423-b7f2-7f4c4d1d8cc3)

