### PR TITLE
feat: ajouter un message pour clarifier que les avertissements sont à titre informatif quand il y a des erreurs bloquantes

### DIFF
--- a/back/dora/services/admin.py
+++ b/back/dora/services/admin.py
@@ -300,11 +300,13 @@ class ServiceAdmin(admin.GISModelAdmin):
             and is_wet_run
             and (duplicated_services or geo_data_missing or draft_services_created)
         ):
-            messages.warning(
+            messages.add_message(
                 request,
+                messages.INFO,
                 mark_safe(
                     "<b>D'autres irrégularités non bloquantes ont été détectées :</b>"
                 ),
+                extra_tags="plain",
             )
 
         title_prefix = ""

--- a/back/dora/services/admin.py
+++ b/back/dora/services/admin.py
@@ -279,7 +279,7 @@ class ServiceAdmin(admin.GISModelAdmin):
             message_text = (
                 "Aucun service n’a été importé, car le fichier comporte des erreurs."
                 if is_wet_run
-                else "Le fichier contient des erreurs qui empêchent l'import."
+                else "Le fichier contient des erreurs qui empêcheront l'import."
             )
             messages.error(
                 request,
@@ -294,6 +294,18 @@ class ServiceAdmin(admin.GISModelAdmin):
         geo_data_missing = result.get("geo_data_missing_lines", [])
         draft_services_created = result.get("draft_services_created", [])
         errors = result.get("errors", [])
+
+        if (
+            errors
+            and is_wet_run
+            and (duplicated_services or geo_data_missing or draft_services_created)
+        ):
+            messages.error(
+                request,
+                mark_safe(
+                    "<b>Les avertissements ci-dessous sont uniquement à titre informatif. Aucune opération décrite n'a été effectuée dans la base de données.</b>"
+                ),
+            )
 
         title_prefix = ""
         if not errors and is_wet_run:

--- a/back/dora/services/admin.py
+++ b/back/dora/services/admin.py
@@ -300,10 +300,10 @@ class ServiceAdmin(admin.GISModelAdmin):
             and is_wet_run
             and (duplicated_services or geo_data_missing or draft_services_created)
         ):
-            messages.error(
+            messages.warning(
                 request,
                 mark_safe(
-                    "<b>Les avertissements ci-dessous sont uniquement à titre informatif. Aucune opération décrite n'a été effectuée dans la base de données.</b>"
+                    "<b>D'autres irrégularités non bloquantes ont été détectées :</b>"
                 ),
             )
 
@@ -345,9 +345,13 @@ class ServiceAdmin(admin.GISModelAdmin):
                 for service in draft_services_created
             )
 
-            wet_run_message = f"<b>{title_prefix}Services importés en brouillon</b><br/>{len(draft_services_created)} services ont été importés en brouillon. Contactez les structures pour compléter ces éléments avant publication"
-            test_run_message = f"<b>{title_prefix}Services incomplets</b><br/>{len(draft_services_created)} services seront passés en brouillon en cas d'import. Contactez les structures pour compléter ces éléments avant importation"
-            message = wet_run_message if is_wet_run else test_run_message
+            if errors and is_wet_run:
+                message = "<b>Informations manquantes</b><br/> Contactez les structures pour compléter ces éléments avant importation"
+            if not errors and is_wet_run:
+                message = f"<b>{title_prefix}Services importés en brouillon</b><br/>{len(draft_services_created)} services ont été importés en brouillon. Contactez les structures pour compléter ces éléments avant publication"
+            if not is_wet_run:
+                message = f"<b>{title_prefix}Services incomplets</b><br/>{len(draft_services_created)} services seront passés en brouillon en cas d'import. Contactez les structures pour compléter ces éléments avant importation"
+
             messages.warning(
                 request,
                 mark_safe(message + f" :<br/>{draft_list}"),

--- a/back/dora/services/tests/test_admin_import_view.py
+++ b/back/dora/services/tests/test_admin_import_view.py
@@ -578,10 +578,10 @@ class ImportServicesViewTestCase(APITestCase):
         self.assertIsInstance(response, HttpResponseRedirect)
         self.assertEqual(response.url, ".")
 
-        mock_messages.error.assert_any_call(
+        mock_messages.warning.assert_any_call(
             request,
             mark_safe(
-                "<b>Les avertissements ci-dessous sont uniquement à titre informatif. Aucune opération décrite n'a été effectuée dans la base de données.</b>"
+                "<b>D'autres irrégularités non bloquantes ont été détectées :</b>"
             ),
         )
 
@@ -604,7 +604,7 @@ class ImportServicesViewTestCase(APITestCase):
         mock_messages.warning.assert_any_call(
             request,
             mark_safe(
-                '<b>Services importés en brouillon</b><br/>1 services ont été importés en brouillon. Contactez les structures pour compléter ces éléments avant publication :<br/>• [1] Service "Service Test" - Manque : contact email, lieu de déroulement'
+                '<b>Informations manquantes</b><br/> Contactez les structures pour compléter ces éléments avant importation :<br/>• [1] Service "Service Test" - Manque : contact email, lieu de déroulement'
             ),
         )
 

--- a/back/dora/services/tests/test_admin_import_view.py
+++ b/back/dora/services/tests/test_admin_import_view.py
@@ -578,11 +578,9 @@ class ImportServicesViewTestCase(APITestCase):
         self.assertIsInstance(response, HttpResponseRedirect)
         self.assertEqual(response.url, ".")
 
-        mock_messages.warning.assert_any_call(
-            request,
-            mark_safe(
-                "<b>D'autres irrégularités non bloquantes ont été détectées :</b>"
-            ),
+        self.assertEqual(
+            mock_messages.add_message.call_args[0][2],
+            "<b>D'autres irrégularités non bloquantes ont été détectées :</b>",
         )
 
         mock_messages.warning.assert_any_call(
@@ -655,7 +653,7 @@ class ImportServicesViewTestCase(APITestCase):
         self.assertIsInstance(response, HttpResponseRedirect)
         self.assertEqual(response.url, "..")
 
-        mock_messages.error.assert_not_called()
+        mock_messages.add_message.assert_not_called()
 
         mock_messages.warning.assert_any_call(
             request,

--- a/back/dora/services/tests/test_admin_import_view.py
+++ b/back/dora/services/tests/test_admin_import_view.py
@@ -345,7 +345,7 @@ class ImportServicesViewTestCase(APITestCase):
         mock_messages.error.assert_called_once_with(
             request,
             mark_safe(
-                "<b>Test terminé - Erreurs à corriger</b><br/>Le fichier contient des erreurs qui empêchent l'import. Veuillez corriger les éléments suivants :<br/>"
+                "<b>Test terminé - Erreurs à corriger</b><br/>Le fichier contient des erreurs qui empêcheront l'import. Veuillez corriger les éléments suivants :<br/>"
                 "• [2] SIRET manquant.<br/>"
                 "• [3] Structure introuvable."
             ),
@@ -578,6 +578,13 @@ class ImportServicesViewTestCase(APITestCase):
         self.assertIsInstance(response, HttpResponseRedirect)
         self.assertEqual(response.url, ".")
 
+        mock_messages.error.assert_any_call(
+            request,
+            mark_safe(
+                "<b>Les avertissements ci-dessous sont uniquement à titre informatif. Aucune opération décrite n'a été effectuée dans la base de données.</b>"
+            ),
+        )
+
         mock_messages.warning.assert_any_call(
             request,
             mark_safe(
@@ -647,6 +654,8 @@ class ImportServicesViewTestCase(APITestCase):
 
         self.assertIsInstance(response, HttpResponseRedirect)
         self.assertEqual(response.url, "..")
+
+        mock_messages.error.assert_not_called()
 
         mock_messages.warning.assert_any_call(
             request,

--- a/back/dora/static/admin/css/import_form.css
+++ b/back/dora/static/admin/css/import_form.css
@@ -207,6 +207,10 @@
     background-color: #5a6268;
 }
 
+.messagelist .plain {
+    background: none;
+}
+
 @media (max-width: 768px) {
     .form-container {
         margin: 0 10px;


### PR DESCRIPTION
Pour que les utilisateurs sachent que les avertissements sont uniquement pour montrer ce que l'import donnerait, j'ai ajouté un nouveau message montré ci-dessous. Ce message ne s'affiche que quand c'est un vrai import et il y a des erreurs bloquantes et il y a des avertissements 

En plus, on change l'avertissements des services qui seront créés en brouillon quand c'est un vrai import et il y a des erreurs bloquants. 

<img width="1440" alt="Screenshot 2025-07-03 at 12 23 36" src="https://github.com/user-attachments/assets/1ad2a5cc-e6ca-418c-b4bc-74a9bf61c451" />


