### PR TITLE
fix: ajouter une date de publication si le service importé est publié

### DIFF
--- a/back/dora/services/csv_import.py
+++ b/back/dora/services/csv_import.py
@@ -5,6 +5,7 @@ from typing import Any, Dict, List, Optional, Union
 
 from django.db import IntegrityError, transaction
 from django.db.models import QuerySet
+from django.utils import timezone
 
 from dora.admin_express.models import AdminDivisionType
 from dora.core.utils import get_geo_data
@@ -292,6 +293,7 @@ class ImportServicesHelper:
 
         if service.is_eligible_for_publishing():
             service.status = ServiceStatus.PUBLISHED
+            service.publication_date = timezone.now()
         else:
             missing_fields = service.get_missing_properties_for_publishing()
             self.draft_services_created.append(

--- a/back/dora/services/tests/test_import_services.py
+++ b/back/dora/services/tests/test_import_services.py
@@ -4,6 +4,7 @@ from unittest import TestCase
 from unittest.mock import patch
 
 from django.contrib.gis.geos import Point
+from freezegun import freeze_time
 from model_bakery import baker
 
 from dora.core.utils import GeoData
@@ -370,6 +371,7 @@ class ImportServicesTestCase(TestCase):
         self.assertEqual(result["created_count"], 0)
         self.assertEqual(len(result["errors"]), 1)
 
+    @freeze_time("2022-01-01")
     def test_publish_eligible_remote_service(self):
         csv_content = (
             f"{self.csv_headers}\n"
@@ -388,7 +390,11 @@ class ImportServicesTestCase(TestCase):
         self.assertEqual(result["created_count"], 1)
         self.assertEqual(result["errors"], [])
         self.assertEqual(created_service.status, ServiceStatus.PUBLISHED)
+        self.assertEqual(
+            str(created_service.publication_date), "2022-01-01 00:00:00+00:00"
+        )
 
+    @freeze_time("2022-01-01")
     def test_publish_eligible_in_person_service(self):
         csv_content = (
             f"{self.csv_headers}\n"
@@ -407,6 +413,9 @@ class ImportServicesTestCase(TestCase):
         self.assertEqual(result["created_count"], 1)
         self.assertEqual(result["errors"], [])
         self.assertEqual(created_service.status, ServiceStatus.PUBLISHED)
+        self.assertEqual(
+            str(created_service.publication_date), "2022-01-01 00:00:00+00:00"
+        )
 
     def test_keep_in_person_service_in_draft_when_ineligible(self):
         csv_content = (
@@ -426,6 +435,7 @@ class ImportServicesTestCase(TestCase):
         self.assertEqual(result["created_count"], 1)
         self.assertEqual(result["errors"], [])
         self.assertEqual(created_service.status, ServiceStatus.DRAFT)
+        self.assertIsNone(created_service.publication_date)
 
     def test_keep_service_in_draft_when_ineligible(self):
         csv_content = (
@@ -445,6 +455,7 @@ class ImportServicesTestCase(TestCase):
         self.assertEqual(result["created_count"], 1)
         self.assertEqual(result["errors"], [])
         self.assertEqual(created_service.status, ServiceStatus.DRAFT)
+        self.assertIsNone(created_service.publication_date)
 
     def test_make_contact_info_public(self):
         csv_content = (


### PR DESCRIPTION
Si un service qui est importé est éligible d'être publié, il faut que la valeur de la date de publication soit pas `null`. 

Ce PR fait en sorte que la date de publication soit correcte mais que les services en brouillon n'aient pas de date de publication