### PR TITLE
feat: changer le lien pour le kit de déploiement

### DIFF
--- a/.talismanrc
+++ b/.talismanrc
@@ -9,4 +9,6 @@ fileignoreconfig:
     checksum: f65ff95262da014ae116d2c2f81e6438787e27d71ffcd6642773e803c78f8fbd
   - filename: back/envs-example/dev.env
     checksum: 09b186afff65d138433589b78cee86675d8118e18f61610248649ec0f33a1d81
+  - filename: front/src/routes/_index/sub-menu.svelte
+    checksum: 86a32003f7024fbc9fce4a66043aa3c1099f0d4dd02a49be740dfbb87459ff36
 version: ""

--- a/front/src/routes/_index/sub-menu-dropdown.svelte
+++ b/front/src/routes/_index/sub-menu-dropdown.svelte
@@ -13,7 +13,8 @@
     : "text-f14 text-gray-text p-s16";
 
   export let label: string;
-  export let links: { href: string; label: string }[] = [];
+  export let links: { href: string; label: string; openInNewTab?: boolean }[] =
+    [];
   let isOpen = false;
   let dropdownButton;
   const id = `sub-dropdown-menu-${randomId()}`;
@@ -68,11 +69,11 @@
     class="{mobileDesign ? '' : 'top-[100%)] absolute'} z-10 bg-white"
     class:hidden={!isOpen}
   >
-    {#each links as link, index}
-      {@const currentPage = $page.url.pathname === link.href}
+    {#each links as { href, label: linkLabel, openInNewTab }, index}
+      {@const currentPage = $page.url.pathname === href}
       <li class="text-f14 hover:bg-magenta-10 whitespace-nowrap">
         <a
-          href={link.href}
+          {href}
           class="py-s16 pl-s16 pr-s32 inline-block w-full
           {currentPage
             ? 'border-magenta-cta text-magenta-cta'
@@ -80,8 +81,10 @@
           {index === links.length - 1 || mobileDesign
             ? 'border-b-none'
             : 'border-b'}"
+          target={openInNewTab ? "_blank" : undefined}
+          rel={openInNewTab ? "noopener noreferrer" : undefined}
         >
-          {link.label}
+          {linkLabel}
         </a>
       </li>
     {/each}

--- a/front/src/routes/_index/sub-menu.svelte
+++ b/front/src/routes/_index/sub-menu.svelte
@@ -48,14 +48,16 @@
           {
             href: "https://www.youtube.com/channel/UCadIsy9gfHgLmLkutRGC5ew/playlists",
             label: "Tutoriels vidéo",
+            openInNewTab: true,
           },
           {
             href: "https://aide.dora.inclusion.beta.gouv.fr/fr/article/participer-a-un-webinaire-dora-h3n747/",
             label: "Webinaires",
           },
           {
-            href: "https://aide.dora.inclusion.beta.gouv.fr/fr/article/deployer-la-plateforme-dora-sur-votre-territoire-qb9ner/",
+            href: "https://docs.google.com/presentation/d/e/2PACX-1vQ1xdf83eiY7CVTcWLpOg9cE8Zjd_9oEVe4RCeia9FNNB7FnTYXX6S21nbsMV3es6zgIwhwgKODI8dk/pub?start=false&loop=false&delayms=3000",
             label: "Kit de déploiement",
+            openInNewTab: true,
           },
           {
             href: "https://aide.dora.inclusion.beta.gouv.fr/fr/article/kit-de-communication-1x9t4kj/",


### PR DESCRIPTION
Le lien attaché à `Kit de déploiement` dans le menu déroulant `Ressources` est cassé. On va diriger l'utilisateur vers un google doc.

Ce PR change le lien comme indiqué et pour les liens externes comme celui-ci, on les ouvre dans un nouvel onglet.