### PR TITLE
mettre à jour toutes les colonnes pertinentes pour les structures modifiées

### DIFF
--- a/back/dora/structures/csv_import.py
+++ b/back/dora/structures/csv_import.py
@@ -3,6 +3,7 @@ from pprint import pformat
 from typing import Dict, List, Union
 
 from django.db import IntegrityError
+from django.utils import timezone
 from rest_framework import serializers
 
 from dora.core.models import ModerationStatus
@@ -275,7 +276,11 @@ class ImportStructuresHelper:
         # les champs optionnels (comme le téléphone et l'adresse mail) peuvent être mis à jour s'ils contiennent une valeur
         to_update = dict({(k, v) for k, v in kwargs.items() if v})
         print(f" > mise à jour des champs : {to_update}")
-        Structure.objects.filter(pk=structure.pk).update(**to_update)
+        Structure.objects.filter(pk=structure.pk).update(
+            **to_update,
+            modification_date=timezone.now(),
+            last_editor=self.importing_user,
+        )
         self.edited_structures_count += 1
 
     def _to_string_array(self, strings_list: str) -> List[str]:

--- a/back/dora/structures/tests/test_import_structures.py
+++ b/back/dora/structures/tests/test_import_structures.py
@@ -3,6 +3,7 @@ import io
 from urllib.parse import quote
 
 from django.core import mail
+from freezegun import freeze_time
 from model_bakery import baker
 from rest_framework.test import APITestCase
 
@@ -716,6 +717,7 @@ class StructuresImportTestCase(APITestCase):
 
         self.assertEqual(structure.email, "email@structure.com")
 
+    @freeze_time("2022-01-01")
     def test_modify_phone_of_existing_structure(self):
         structure = make_structure(siret="12345678900000", phone="0123456789")
 
@@ -729,7 +731,10 @@ class StructuresImportTestCase(APITestCase):
 
         structure.refresh_from_db()
         self.assertEqual(structure.phone, "0234567891")
+        self.assertEqual(structure.last_editor, self.importing_user)
+        self.assertEqual(str(structure.modification_date), "2022-01-01 00:00:00+00:00")
 
+    @freeze_time("2022-01-01")
     def test_modify_email_of_existing_structure(self):
         structure = make_structure(siret="12345678900000", email="old@email.com")
 
@@ -745,6 +750,8 @@ class StructuresImportTestCase(APITestCase):
 
         structure.refresh_from_db()
         self.assertEqual(structure.email, "email1@structure.com")
+        self.assertEqual(structure.last_editor, self.importing_user)
+        self.assertEqual(str(structure.modification_date), "2022-01-01 00:00:00+00:00")
 
     def test_add_email_to_new_structure_with_parent(self):
         parent = make_structure(siret="21345678900000", email="old@email.com")


### PR DESCRIPTION
Quand une structure existante est modifié, la valeur de `modification_date` doit être `timezone.now()` et `last_editor` doit être la personne qui a fait l'import