### PR TITLE
fix: correction des iMER manquantes 🌸

### DIFF
--- a/analytics/models/intermediate/int_orientation_user_service.sql
+++ b/analytics/models/intermediate/int_orientation_user_service.sql
@@ -3,7 +3,11 @@ SELECT
     {{ dbt_utils.star(relation_alias='users', from=ref('stg_user'), prefix='user_') }},
     {{ dbt_utils.star(relation_alias='services', from=ref('int_service_structure')) }}
 FROM {{ ref('stg_orientation') }} AS orientations
-INNER JOIN {{ ref('stg_user') }} AS users
+-- left join pour considérer les orientations faites par des users supprimés
+LEFT JOIN {{ ref('stg_user') }} AS users
     ON orientations.prescriber_id = users.id
-INNER JOIN {{ ref('int_service_structure') }} AS services
+-- left join pour considérer les cas suivants : 
+-- orientations faites sur des services sans service_id (ont un di_service_id)
+-- orientations faites sur des services non rattachés à une structure
+LEFT JOIN {{ ref('int_service_structure') }} AS services
     ON orientations.service_id = services.service_id

--- a/analytics/models/staging/stg_mobilisationevent.sql
+++ b/analytics/models/staging/stg_mobilisationevent.sql
@@ -56,7 +56,7 @@ final AS (
     UNION
     SELECT *
     FROM di_events
-    WHERE date >= '2024-07-01'
+    WHERE date >= '2024-01-01'
 )
 
 SELECT * FROM final

--- a/analytics/models/staging/stg_orientation.sql
+++ b/analytics/models/staging/stg_orientation.sql
@@ -5,7 +5,7 @@ WITH orientations AS (
 final AS (
     SELECT * FROM orientations
     -- date discutée avec Chloé pour limiter la taille de la table
-    WHERE CAST(creation_date AS DATE) >= '2024-07-01'
+    WHERE CAST(creation_date AS DATE) >= '2024-01-01'
 )
 
 SELECT * FROM final

--- a/analytics/models/staging/stg_pageview.sql
+++ b/analytics/models/staging/stg_pageview.sql
@@ -6,7 +6,7 @@ final AS (
     SELECT * FROM events
     WHERE
         -- date discutée avec Chloé pour limiter la taille de la table
-        CAST(date AS DATE) >= '2024-07-01'
+        CAST(date AS DATE) >= '2024-01-01'
         AND is_staff IS FALSE
 )
 

--- a/analytics/models/staging/stg_searchview.sql
+++ b/analytics/models/staging/stg_searchview.sql
@@ -5,7 +5,7 @@ WITH events AS (
 final AS (
     SELECT * FROM events
     WHERE
-        CAST(date AS DATE) >= '2024-07-01'
+        CAST(date AS DATE) >= '2024-01-01'
         AND is_staff IS FALSE
 )
 

--- a/analytics/models/staging/stg_serviceview.sql
+++ b/analytics/models/staging/stg_serviceview.sql
@@ -59,7 +59,7 @@ final AS (
     UNION
     SELECT * FROM di_service_view
     WHERE
-        CAST(date AS DATE) >= '2024-07-01'
+        CAST(date AS DATE) >= '2024-01-01'
         AND is_staff IS FALSE
 )
 


### PR DESCRIPTION
Certaines iMER n'étaient pas ajoutées à la table iMER pour plusieurs raisons :
- `prescriber_id` inexistant : sans doute des utilisateurs supprimés (marginal, mais gardons les :))
- `service_id` inexistant : correspond aux services importés de d·i, qui ont un `di_service_id` (majorité des cas!)
- `service_id` inexistant dans la table `int_service_structure` : services non rattachés à une structure (marginal mais gardons les !)


Modification de la jointure en conséquence, afin de garder toutes les orientations (commit [878b1f2](https://github.com/gip-inclusion/dora/pull/455/commits/878b1f22d5209311a09c36db9cf2651793d36cc0))
La table sera incomplète pour les informations de user ou de structure pour les services concernés, ce qui n'est pas problématique et sera géré sur metabase.


J'en profite pour étendre la contrainte de date afin d'avoir tous les événements de l'année 2024. (commit [31f0d1c](https://github.com/gip-inclusion/dora/pull/455/commits/31f0d1ccdc04181ea9b6f694ccb37fda5276148a))