### PR TITLE
fix: acceptation d'une orientation vers un service DI

### DIFF
--- a/back/dora/core/test_utils.py
+++ b/back/dora/core/test_utils.py
@@ -131,3 +131,65 @@ def make_orientation(**kwargs):
         **kwargs,
     )
     return orientation
+
+
+def make_di_orientation(**kwargs):
+    di_service_id = (
+        kwargs.pop("di_service_id") if "di_service_id" in kwargs else "di_service_id"
+    )
+    di_service_name = (
+        kwargs.pop("di_service_name")
+        if "di_service_name" in kwargs
+        else "di_service_name"
+    )
+    di_service_address_line = (
+        kwargs.pop("di_service_address_line")
+        if "di_service_address_line" in kwargs
+        else "di_service_address_line"
+    )
+    di_contact_email = (
+        kwargs.pop("di_contact_email")
+        if "di_contact_email" in kwargs
+        else "di_contact_email"
+    )
+    di_contact_name = (
+        kwargs.pop("di_contact_name")
+        if "di_contact_name" in kwargs
+        else "di_contact_name"
+    )
+    di_contact_phone = (
+        kwargs.pop("di_contact_phone")
+        if "di_contact_phone" in kwargs
+        else "di_contact_phone"
+    )
+    di_structure_name = (
+        kwargs.pop("di_structure_name")
+        if "di_structure_name" in kwargs
+        else "di_structure_name"
+    )
+    prescriber_structure = (
+        kwargs.pop("prescriber_structure")
+        if "prescriber_structure" in kwargs
+        else make_structure()
+    )
+    prescriber = (
+        kwargs.pop("prescriber")
+        if "prescriber" in kwargs
+        else make_user(structure=prescriber_structure)
+    )
+
+    orientation = baker.make(
+        "Orientation",
+        prescriber=prescriber,
+        prescriber_structure=prescriber_structure,
+        service=None,
+        di_service_id=di_service_id,
+        di_service_name=di_service_name,
+        di_service_address_line=di_service_address_line,
+        di_contact_email=di_contact_email,
+        di_contact_name=di_contact_name,
+        di_contact_phone=di_contact_phone,
+        di_structure_name=di_structure_name,
+        **kwargs,
+    )
+    return orientation

--- a/back/dora/orientations/tests/conftest.py
+++ b/back/dora/orientations/tests/conftest.py
@@ -1,7 +1,7 @@
 import pytest
 from model_bakery.random_gen import gen_email
 
-from dora.core.test_utils import make_orientation
+from dora.core.test_utils import make_di_orientation, make_orientation
 
 from ..models import Orientation
 
@@ -11,3 +11,10 @@ def orientation() -> Orientation:
     # l'e-mail bénéficiaire est optionel dans la génération,
     # mais on veut vérifier l'envoi d'e-mail vers tous les destinataires
     return make_orientation(beneficiary_email=gen_email)
+
+
+@pytest.fixture
+def di_orientation() -> Orientation:
+    # l'e-mail bénéficiaire est optionel dans la génération,
+    # mais on veut vérifier l'envoi d'e-mail vers tous les destinataires
+    return make_di_orientation(beneficiary_email=gen_email)

--- a/back/dora/orientations/views.py
+++ b/back/dora/orientations/views.py
@@ -85,8 +85,12 @@ class OrientationViewSet(
         orientation = self.get_object()
         prescriber_message = self.request.data.get("message")
         beneficiary_message = self.request.data.get("beneficiary_message")
-        orientation.duration_weekly_hours = orientation.service.duration_weekly_hours
-        orientation.duration_weeks = orientation.service.duration_weeks
+        if orientation.service:
+            # L'objet service et les durées n'existent pas dans le cas des services DI
+            orientation.duration_weekly_hours = (
+                orientation.service.duration_weekly_hours
+            )
+            orientation.duration_weeks = orientation.service.duration_weeks
         orientation.processing_date = timezone.now()
         orientation.status = OrientationStatus.ACCEPTED
         orientation.save()


### PR DESCRIPTION
Lors de l'acceptation d'une orientation, l'objet service associé à l'orientation est accédé. Or, il n'existe pas pour les services DI, provoquant une erreur. Ce correctif vérifie son existence avant d'y accéder. Un test a été ajouté.