### PR TITLE
feat: ajout du package segno pour la génération du code QR de configuration du OTP

### DIFF
--- a/back/requirements/base.txt
+++ b/back/requirements/base.txt
@@ -22,6 +22,7 @@ psycopg==3.2.9
 PyJWT==2.10.1 # conflit avec ggshield sur versions supérieures
 redis==6.2.0
 requests==2.32.4
+segno==1.6.6
 sentry-sdk==2.33.0
 sib-api-v3-sdk==7.6.0
 Unidecode==1.4.0


### PR DESCRIPTION
Test :
1. activer la 2FA avec la variable d'environnement `DJANGO_ADMIN_2FA_ENABLED=true` ;
2. aller sur django-admin ;
3. créer un _TOTP device_ ;
4. cliquer sur le lien _qrcode_ ;
5. un code QR doit s'afficher.