### PR TITLE
fix: connexion ProConnect avec sub différent

### DIFF
--- a/back/dora/oidc/backends.py
+++ b/back/dora/oidc/backends.py
@@ -109,6 +109,7 @@ class OIDCAuthenticationBackend(MozillaOIDCAuthenticationBackend):
         # L'utilisateur peut déjà étre inscrit à IC, dans ce cas on réutilise la plupart
         # des informations déjà connues
         sub = claims.get("sub")
+        email = claims.get("email")
 
         if not sub:
             raise SuspiciousOperation(
@@ -116,9 +117,25 @@ class OIDCAuthenticationBackend(MozillaOIDCAuthenticationBackend):
             )
 
         if user.sub_pc and str(user.sub_pc) != sub:
-            raise SuspiciousOperation(
-                "Le sub enregistré est différent de celui fourni par ProConnect"
+            # Le sub n'est pas censé changer sauf dans certains cas où
+            # l'utilisateur utilise deux fournisseurs d'identité différents.
+            # Dans ce cas, on vérifie que l'adresse e-mail est la même.
+            # Si l'adresse e-mail n'est pas la même, on considère l'opération comme suspecte.
+            core_logger.warning(
+                "sub ProConnect différent de celui enregistré",
+                {
+                    "legal": True,
+                    "userId": str(user.pk),
+                    "userEmail": user.email,
+                    "pcEmail": email,
+                    "userSub": user.sub_pc,
+                    "pcSub": sub,
+                },
             )
+            if user.email != email:
+                raise SuspiciousOperation(
+                    "Le sub et l'adresse e-mail fournis par ProConnect sont différents de ceux enregistrés"
+                )
 
         if not user.sub_pc:
             # utilisateur existant, mais non-enregistré sur ProConnect


### PR DESCRIPTION
On permet la connexion si le sub est différent de celui enregistré à condition que l'adresse e-mail soit la même.

On logue les cas où le sub est différent pour analyse postérieure.