### PR TITLE
fix: renvoie une erreur 404 si le modèle n'est pas trouvé

### DIFF
--- a/front/src/routes/(modeles-services)/modeles/[slug]/+page.ts
+++ b/front/src/routes/(modeles-services)/modeles/[slug]/+page.ts
@@ -1,4 +1,3 @@
-import { browser } from "$app/environment";
 import { getModel, getServicesOptions } from "$lib/requests/services";
 import { error } from "@sveltejs/kit";
 import type { PageLoad } from "./$types";
@@ -7,11 +6,6 @@ export const load: PageLoad = async ({ params, parent }) => {
   await parent();
 
   const model = await getModel(params.slug);
-
-  // on ne retourne une 404 que sur le client
-  if (!model && !browser) {
-    return {};
-  }
 
   if (!model) {
     error(404, "Page Not Found");


### PR DESCRIPTION
Corrige https://inclusion.sentry.io/issues/53882782/?environment=production&project=4509599011045456&query=is%3Aunresolved&referrer=issue-stream