### PR TITLE
chore: centralisation du Markdown avec @html dans un seul composant

### DIFF
--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -25,6 +25,7 @@
         "@tiptap/extension-placeholder": "^3.0.9",
         "@tiptap/starter-kit": "^3.0.9",
         "@types/iframe-resizer": "^4.0.0",
+        "@types/insane": "^1.0.0",
         "@types/showdown": "^2.0.6",
         "@typescript-eslint/eslint-plugin": "^8.38.0",
         "@typescript-eslint/parser": "^8.38.0",
@@ -3588,6 +3589,13 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@types/iframe-resizer/-/iframe-resizer-4.0.0.tgz",
       "integrity": "sha512-RKrT4goNVtqZvf9WPkV0cUcphQWXzLVW1IE4yOIY21c1W+obJJbcHFD1lQu5ncNHm/6TeQSeedVf9bmkx2NaGQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/insane": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@types/insane/-/insane-1.0.0.tgz",
+      "integrity": "sha512-9FNbmwdaQezEszc5B/w4kRSpMJMOVj+gX7CKSbBCFO4WPiUqKO3HJlUNXzjtus0w5tF2BOJoKTbyps/Envlg/Q==",
       "dev": true,
       "license": "MIT"
     },

--- a/front/package.json
+++ b/front/package.json
@@ -41,6 +41,7 @@
     "@tiptap/extension-placeholder": "^3.0.9",
     "@tiptap/starter-kit": "^3.0.9",
     "@types/iframe-resizer": "^4.0.0",
+    "@types/insane": "^1.0.0",
     "@types/showdown": "^2.0.6",
     "@typescript-eslint/eslint-plugin": "^8.38.0",
     "@typescript-eslint/parser": "^8.38.0",

--- a/front/src/lib/components/display/markdown-renderer.svelte
+++ b/front/src/lib/components/display/markdown-renderer.svelte
@@ -1,4 +1,10 @@
 <script lang="ts">
+  /* eslint-disable svelte/no-at-html-tags */
+  /*
+   * Pour des raisons de sécurité, on centralise l'affichage du rendu Markdown
+   * en utilisant @html dans ce fichier.
+   * On utilise markdownToHTML() qui fait appel à insane() pour sécuriser le HTML.
+   */
   import { markdownToHTML } from "$lib/utils/misc";
 
   interface Props {

--- a/front/src/lib/components/display/markdown-renderer.svelte
+++ b/front/src/lib/components/display/markdown-renderer.svelte
@@ -1,0 +1,14 @@
+<script lang="ts">
+  import { markdownToHTML } from "$lib/utils/misc";
+
+  interface Props {
+    content: string;
+    titleLevel?: number;
+  }
+
+  let { content, titleLevel }: Props = $props();
+
+  const html = markdownToHTML(content, titleLevel);
+</script>
+
+{@html html}

--- a/front/src/lib/components/display/static-markdown.svelte
+++ b/front/src/lib/components/display/static-markdown.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { markdownToHTML } from "$lib/utils/misc";
+  import MarkdownRenderer from "./markdown-renderer.svelte";
 
   interface Props {
     content: string;
@@ -9,7 +9,7 @@
 </script>
 
 <div class="prose max-w-3xl">
-  {@html markdownToHTML(content, 1)}
+  <MarkdownRenderer {content} titleLevel={1} />
 </div>
 
 <style lang="postcss">

--- a/front/src/lib/components/display/text-clamp.svelte
+++ b/front/src/lib/components/display/text-clamp.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
   import { randomId } from "$lib/utils/random";
+
   import Button from "./button.svelte";
+  import MarkdownRenderer from "./markdown-renderer.svelte";
 
   interface Props {
     text: string;
@@ -23,12 +25,12 @@
 </script>
 
 <div class="hidden print:inline">
-  <div class="prose mb-s24">{@html text}</div>
+  <div class="prose mb-s24"><MarkdownRenderer content={text} /></div>
 </div>
 <div class="print:hidden">
   <div {id} class:h-s112={!showAll} class="mb-s6 relative overflow-hidden">
     <div class="prose mb-s12" bind:clientHeight={height}>
-      {@html text}
+      <MarkdownRenderer content={text} />
     </div>
     {#if !showAll && textIsTooLong}
       <div

--- a/front/src/lib/components/inputs/select/simple-autocomplete.svelte
+++ b/front/src/lib/components/inputs/select/simple-autocomplete.svelte
@@ -10,6 +10,8 @@
   import CheckLineSystem from "svelte-remix/CheckLineSystem.svelte";
   import CloseCircleFillSystem from "svelte-remix/CloseCircleFillSystem.svelte";
 
+  import insane from "insane";
+
   import CheckboxMark from "$lib/components/display/checkbox-mark.svelte";
   import { clickOutside } from "$lib/utils/misc";
   import { formatErrors } from "$lib/validation/validation";
@@ -840,9 +842,13 @@
                   {@render itemContent({ item: listItem })}
                 {:else}
                   <div>
-                    {@html listItem.highlighted
-                      ? listItem.highlighted.label
-                      : listItem.label}
+                    {#if listItem.highlighted}
+                      {@html insane(listItem.highlighted.label, {
+                        allowedTags: ["b"],
+                      })}
+                    {:else}
+                      {listItem.label}
+                    {/if}
                   </div>
                 {/if}
 

--- a/front/src/lib/components/specialized/services/field-model.svelte
+++ b/front/src/lib/components/specialized/services/field-model.svelte
@@ -2,6 +2,7 @@
   import type { Snippet } from "svelte";
 
   import Button from "$lib/components/display/button.svelte";
+  import MarkdownRenderer from "$lib/components/display/markdown-renderer.svelte";
   import Tag from "$lib/components/display/tag.svelte";
   import {
     arraysCompare,
@@ -134,7 +135,7 @@
               {/each}
             </div>
           {:else if type === "markdown"}
-            {@html markdownToHTML(value, 2)}
+            <MarkdownRenderer content={value} titleLevel={2} />
           {:else if type === "boolean"}
             <p class="mb-s0 text-f14">{value === true ? "Oui" : "Non"}</p>
           {:else if type === "text"}

--- a/front/src/routes/admin/contributions/line.svelte
+++ b/front/src/routes/admin/contributions/line.svelte
@@ -3,7 +3,7 @@
 
   interface Props {
     label: string;
-    data: any;
+    data?: any;
     isList?: boolean;
     verticalLayout?: boolean;
     isBool?: boolean;
@@ -28,10 +28,12 @@
   <div class="mr-s16 text-gray-text w-1/3 font-bold">{label}</div>
   <div class="text-gray-text">
     {#if isList}
-      {#each data as item}
+      {#each data || [] as item}
         <li>{item}</li>
       {/each}
-    {:else if children}{@render children()}{:else if isBool}
+    {:else if children}
+      {@render children()}
+    {:else if isBool}
       {data ? "Oui" : "Non"}
     {:else}
       {data}

--- a/front/src/routes/admin/contributions/suggestion-modal.svelte
+++ b/front/src/routes/admin/contributions/suggestion-modal.svelte
@@ -1,7 +1,8 @@
 <script lang="ts">
   import Button from "$lib/components/display/button.svelte";
+  import MarkdownRenderer from "$lib/components/display/markdown-renderer.svelte";
   import Modal from "$lib/components/hoc/modal.svelte";
-  import { markdownToHTML } from "$lib/utils/misc";
+
   import Line from "./line.svelte";
 
   interface Props {
@@ -46,13 +47,12 @@
           data={suggestion.serviceInfo.shortDesc}
         />
 
-        <Line
-          label="Descriptif complet du service"
-          data={markdownToHTML(suggestion.serviceInfo.fullDesc, 2)}
-          verticalLayout
-        >
+        <Line label="Descriptif complet du service" verticalLayout>
           <div class="m-s16 border-gray-02 pl-s16 border-l-8">
-            {@html markdownToHTML(suggestion.serviceInfo.fullDesc, 2)}
+            <MarkdownRenderer
+              content={suggestion.serviceInfo.fullDesc}
+              titleLevel={2}
+            />
           </div>
         </Line>
 


### PR DESCRIPTION
Utilisation de `@html` dans deux fichiers uniquement :

- MardownRenderer qui centralise l'affichage du rendu Markdown ;
- SimpleAutocomplete pour le _highlighting_.

Dans les deux cas, `insane()` est utilisé pour sécuriser le HTML.