### PR TITLE
chore: ajouter la limitation du debit

### DIFF
--- a/back/config/settings/base.py
+++ b/back/config/settings/base.py
@@ -280,6 +280,14 @@ REST_FRAMEWORK = {
     },
     "EXCEPTION_HANDLER": "dora.core.exceptions_handler.custom_exception_handler",
     "TEST_REQUEST_DEFAULT_FORMAT": "json",
+    "DEFAULT_THROTTLE_CLASSES": [
+        "rest_framework.throttling.AnonRateThrottle",
+        "rest_framework.throttling.UserRateThrottle",
+    ],
+    "DEFAULT_THROTTLE_RATES": {
+        "anon": "12/minute",
+        "user": "120/minute",
+    },
 }
 
 # CORS :

--- a/back/config/settings/base.py
+++ b/back/config/settings/base.py
@@ -285,7 +285,7 @@ REST_FRAMEWORK = {
         "rest_framework.throttling.UserRateThrottle",
     ],
     "DEFAULT_THROTTLE_RATES": {
-        "anon": "12/minute",
+        "anon": "16/minute",
         "user": "120/minute",
     },
 }

--- a/back/config/settings/test.py
+++ b/back/config/settings/test.py
@@ -3,6 +3,7 @@ import os
 import dj_database_url
 
 from .base import *  # noqa F403
+from .base import REST_FRAMEWORK
 
 DEBUG = True
 
@@ -45,3 +46,8 @@ BREVO_ONBOARDING_PUTATIVE_MEMBER_LIST = int(
 BREVO_ONBOARDING_MEMBER_LIST = int(os.getenv("BREVO_ONBOARDING_MEMBER_LIST", "3"))
 
 DATA_INCLUSION_SCORE_QUALITE_MINIMUM = None
+
+REST_FRAMEWORK = {
+    **REST_FRAMEWORK,
+    "DEFAULT_THROTTLE_CLASSES": [],
+}


### PR DESCRIPTION
Pour mieux protéger la sécurité de l'app, ce PR ajoute une limitation du débit pour empêcher des attaques qui cherchent à spammer l'app. On s'appuie sur le throttling de Django qui utilise la cache redis déjà mise en place. Ça nous permet de verifier la limitation à travers nos deux conteneurs Scalingo.  