### PR TITLE
fix: invert metabase urls on GT dashboard

### DIFF
--- a/front/src/routes/admin/structures/+page.svelte
+++ b/front/src/routes/admin/structures/+page.svelte
@@ -202,7 +202,7 @@
               extraClass="mb-s12"
             />
             <a
-              href={METABASE_DASHBOARD_URL(selectedDepartment.code)}
+              href={DI_METABASE_DASHBOARD_URL(selectedDepartment.name)}
               target="_blank"
               rel="noopener nofollow"
               class="text-f18 text-france-blue leading-32 underline"
@@ -210,7 +210,7 @@
               Cartographie des services référencés
             </a>
             <a
-              href={DI_METABASE_DASHBOARD_URL(selectedDepartment.name)}
+              href={METABASE_DASHBOARD_URL(selectedDepartment.code)}
               target="_blank"
               rel="noopener nofollow"
               class="text-f18 text-france-blue leading-32 underline"


### PR DESCRIPTION
https://www.notion.so/gip-inclusion/Lien-sur-TDB-GT-25a5f321b60480e9a195dd475d5b3436?source=copy_link