### PR TITLE
fix: empêcher les erreurs de null property remontées dans Sentry

### DIFF
--- a/front/src/lib/components/specialized/service-search.svelte
+++ b/front/src/lib/components/specialized/service-search.svelte
@@ -85,7 +85,7 @@
     })
   );
 
-  const categories = servicesOptions.categories
+  const categories = servicesOptions?.categories
     ? associateIconToCategory(sortCategory(servicesOptions.categories))
     : [];
 

--- a/front/src/routes/(modeles-services)/components/service-body/service-presentation/service-key-informations/service-key-informations.svelte
+++ b/front/src/routes/(modeles-services)/components/service-body/service-presentation/service-key-informations/service-key-informations.svelte
@@ -178,7 +178,7 @@
             >
               {getLabelFromValue(
                 service.feeCondition,
-                servicesOptions.feeConditions
+                servicesOptions?.feeConditions
               )}
             </span>
           {/if}


### PR DESCRIPTION
Il y a deux erreurs remontées dans Sentry qui viennent d'une propriété accédée d'une valeur `null`. Ce PR règle ces deux soucis en utilisant optional chaining