### PR TITLE
fix: Fiche service : le clic sur « Marquer comme à jour » provoque la mise à jour du libellé d'actualisation

### DIFF
--- a/front/src/lib/components/specialized/services/set-as-updated-modal.svelte
+++ b/front/src/lib/components/specialized/services/set-as-updated-modal.svelte
@@ -38,7 +38,7 @@
   width="small"
 >
   <div class="pt-s16 text-f18 text-france-blue">
-    Périmètre : <strong>{service.diffusionZoneDetailsDisplay}</strong>
+    Périmètre&#8239;: <strong>{service.diffusionZoneDetailsDisplay}</strong>
   </div>
 
   <hr class="my-s24" />

--- a/front/src/routes/(modeles-services)/services/[slug]/+page.svelte
+++ b/front/src/routes/(modeles-services)/services/[slug]/+page.svelte
@@ -24,14 +24,19 @@
     data: PageData;
   }
 
-  let { data = $bindable() }: Props = $props();
+  let { data }: Props = $props();
+
+  let reactiveData = $state(data);
 
   let isServiceFeedbackModalOpen = $state(false);
 
   let showFeedbackModal = $derived(
     browser &&
-      data.service &&
-      !isMemberOrPotentialMemberOfStructure($userInfo, data.service.structure)
+      reactiveData.service &&
+      !isMemberOrPotentialMemberOfStructure(
+        $userInfo,
+        reactiveData.service.structure
+      )
   );
 
   $effect(() => {
@@ -40,12 +45,12 @@
 
   onMount(() => {
     const searchId = $page.url.searchParams.get("searchId");
-    trackService(data.service, $page.url, searchId, data.isDI);
+    trackService(reactiveData.service, $page.url, searchId, reactiveData.isDI);
   });
 
   async function handleRefresh() {
-    if (data.service) {
-      data.service = await getService(data.service.slug);
+    if (reactiveData.service) {
+      reactiveData.service = await getService(reactiveData.service.slug);
     }
   }
 
@@ -57,40 +62,40 @@
   }
 
   const serviceWasJustPublished =
-    data.service &&
-    data.service.publicationDate &&
-    data.service.status === "PUBLISHED" &&
-    getMinutesSincePublication(data.service) < 1;
+    reactiveData.service &&
+    reactiveData.service.publicationDate &&
+    reactiveData.service.status === "PUBLISHED" &&
+    getMinutesSincePublication(reactiveData.service) < 1;
 </script>
 
-{#if data.service}
+{#if reactiveData.service}
   <CenteredGrid bgColor="bg-blue-light">
-    <ServiceHeader service={data.service} />
+    <ServiceHeader service={reactiveData.service} />
   </CenteredGrid>
 
   <CenteredGrid roundedColor="bg-blue-light" noPadding extraClass="mb-s8">
     <ServiceToolbar
-      service={data.service}
-      servicesOptions={data.servicesOptions}
+      service={reactiveData.service}
+      servicesOptions={reactiveData.servicesOptions}
       onRefresh={handleRefresh}
       onFeedbackButtonClick={() => (isServiceFeedbackModalOpen = true)}
     />
   </CenteredGrid>
 
   <ServiceBody
-    service={data.service}
-    servicesOptions={data.servicesOptions}
+    service={reactiveData.service}
+    servicesOptions={reactiveData.servicesOptions}
     onFeedbackButtonClick={() => (isServiceFeedbackModalOpen = true)}
   />
 
   {#if showFeedbackModal}
     <ServiceFeedbackModal
       bind:isOpen={isServiceFeedbackModalOpen}
-      service={data.service}
+      service={reactiveData.service}
     />
   {/if}
 
-  {#if browser && data.service.canWrite && serviceWasJustPublished && !data.service.hasAlreadyBeenUnpublished}
+  {#if browser && reactiveData.service.canWrite && serviceWasJustPublished && !reactiveData.service.hasAlreadyBeenUnpublished}
     <TallyPopup
       formId={TallyFormId.SERVICE_CREATION_FORM_ID}
       timeoutSeconds={3}

--- a/front/src/routes/(modeles-services)/services/[slug]/service-toolbar.svelte
+++ b/front/src/routes/(modeles-services)/services/[slug]/service-toolbar.svelte
@@ -9,7 +9,7 @@
   interface Props {
     service: Service;
     servicesOptions: ServicesOptions;
-    onRefresh: () => void;
+    onRefresh: () => Promise<void>;
     onFeedbackButtonClick: () => void;
   }
 

--- a/front/src/routes/(modeles-services)/services/[slug]/service-toolbar.svelte
+++ b/front/src/routes/(modeles-services)/services/[slug]/service-toolbar.svelte
@@ -17,9 +17,12 @@
     $props();
 </script>
 
-<div class="hidden print:block">
-  <RelativeDateLabel date={service.modificationDate} prefix="Actualisé le" />
-</div>
+{#if service.modificationDate}
+  <div class="hidden print:block">
+    <RelativeDateLabel date={service.modificationDate} prefix="Actualisé le" />
+  </div>
+{/if}
+
 <div
   class="border-gray-02 py-s40 gap-s24 relative flex flex-col items-center justify-between border-b sm:flex-row print:hidden"
 >

--- a/front/src/routes/(modeles-services)/services/[slug]/service-update-buttons.svelte
+++ b/front/src/routes/(modeles-services)/services/[slug]/service-update-buttons.svelte
@@ -10,7 +10,7 @@
   interface Props {
     service: Service;
     servicesOptions: ServicesOptions;
-    onRefresh: () => void;
+    onRefresh: () => Promise<void>;
   }
 
   let { service, servicesOptions, onRefresh }: Props = $props();

--- a/front/src/routes/(modeles-services)/services/[slug]/service-update-date.svelte
+++ b/front/src/routes/(modeles-services)/services/[slug]/service-update-date.svelte
@@ -17,11 +17,13 @@
     class:text-orange={service.updateNeeded}
     class:text-service-green-darker={!service.updateNeeded}
   >
-    <RelativeDateLabel
-      date={service.modificationDate}
-      prefix="Actualisé"
-      bold
-    />
+    {#if service.modificationDate}
+      <RelativeDateLabel
+        date={service.modificationDate}
+        prefix="Actualisé"
+        bold
+      />
+    {/if}
   </div>
   <ServiceFeedbackButton onclick={onFeedbackButtonClick} />
 </div>


### PR DESCRIPTION
Le problème était dû à `data = $bindable()` dans `+page.svelte` qui ne suffisait pas à rendre la variable `data` réactive. En utilisant `$state()`, on en crée une copie réactive.

J'ai profité de ce changement pour faire quelques corrections de typage et utiliser une espace insécable.