### PR TITLE
fix: mise à jour forcée de cookie pour cause de vulnérabilité

### DIFF
--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -4670,9 +4670,9 @@
       "license": "MIT"
     },
     "node_modules/cookie": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.6.0.tgz",
-      "integrity": "sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==",
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"

--- a/front/package.json
+++ b/front/package.json
@@ -75,6 +75,9 @@
     "wicg-inert": "^3.1.3",
     "xlsx": "https://cdn.sheetjs.com/xlsx-0.20.3/xlsx-0.20.3.tgz"
   },
+  "overrides": {
+    "cookie": "0.7.2"
+  },
   "type": "module",
   "lint-staged": {
     "*.{js,ts,svelte}": [


### PR DESCRIPTION
Concerne l'alerte de sécurité https://github.com/gip-inclusion/dora/security/dependabot/2

On doit forcer la mise à jour (override) car SvelteKit de peut pas se permettre de mettre à jour _cookie_ avant sa version v3 car la version 0.7.0 de _cookie_ comporte un breaking change. Celui-ci ne nous concerne pas et on peut donc forcer la mise à jour et ainsi éliminer la vulnérabilité et l'alerte de sécurité.

Voir : https://github.com/sveltejs/kit/pull/12767