### PR TITLE
fix: stop erasing mtm table with sync-analytics (:

### DIFF
--- a/analytics/sync-analytics.sh
+++ b/analytics/sync-analytics.sh
@@ -78,7 +78,7 @@ fetch_and_export_dora_data() {
 
     time pg_dump "$DORA_DATABASE_URL" --jobs=8 --format=directory --compress=1 --clean --if-exists --no-owner --no-privileges --verbose $(cat args.txt) --file=/tmp/out.dump
     time psql "$DATABASE_URL" -c "DROP SCHEMA public CASCADE; CREATE SCHEMA public; CREATE EXTENSION IF NOT EXISTS postgis;"
-    time pg_restore --dbname="$DATABASE_URL" --jobs=8 --format=directory --clean --if-exists --no-owner --no-privileges --verbose /tmp/out.dump
+    time pg_restore --dbname="$DATABASE_URL" --jobs=8 --format=directory --clean --if-exists --no-owner --no-privileges --verbose /tmp/out.dump --exclude-table=matomo.mtm_share_service_tracking
 
     echo "✔️ Fait."
     echo ""

--- a/analytics/sync-matomo.py
+++ b/analytics/sync-matomo.py
@@ -101,7 +101,7 @@ def push_to_db():
     table = get_share_services_actions(matomo_base_url, matomo_token)
     print("🔄 Pushing data to database")
 
-    table.to_sql("mtm_share_service_tracking", engine, if_exists="replace", index=False)
+    table.to_sql("mtm_share_service_tracking", engine, schema="matomo", if_exists="replace", index=False)
     print("✅ Data ready")
 
 


### PR DESCRIPTION
1) changer la table de schema, car on drop toutes les tables de public dans sync-analytics
2) exclure la table dans le pg_restore pour éviter de la drop sans la recréer