### PR TITLE
fix: ajouter un timeout à la cache Redis

### DIFF
--- a/back/config/settings/base.py
+++ b/back/config/settings/base.py
@@ -133,7 +133,7 @@ CACHES = {
         "BACKEND": "django.core.cache.backends.redis.RedisCache",
         "LOCATION": os.getenv("REDIS_URL"),
         "TIMEOUT": int(
-            os.getenv("DJANGO_CACHE_TIMEOUT", "300")
+            os.getenv("DJANGO_CACHE_TIMEOUT", 300)
         ),  # 5 minutes par défaut
     }
 }


### PR DESCRIPTION
On voit beaucoup de `SystemExit` dans Sentry du back production. Je soupçonne que la limitation du débit implémenté avec la cache Redis est coupable pour deux raisons : 
1. le timing du début du problème et la MEP de la limitation
2. les SystemExits sont pas liés à une seule route et les exits de la même routes sont liés aux opérations différentes. 

Sans un timeout, les clés de redis restent toujours qui submerge son mémoire de la cache Redis. Ce PR nous permet de controler le timeout avec un env var mais c'est 5 minutes par défaut 