### PR TITLE
fix: corriger diffusion zone details pour services importes

### DIFF
--- a/back/dora/services/migrations/0125_correct_diffusion_zone_details.py
+++ b/back/dora/services/migrations/0125_correct_diffusion_zone_details.py
@@ -11,7 +11,6 @@ logger = logging.getLogger(__name__)
 
 
 def get_department_for_service(service):
-    logger.info(f"Mise à jour du service avec l'id {service.id}")
     if service.city_code.startswith("97"):
         department = service.city_code[:3]
     else:
@@ -41,6 +40,10 @@ def fix_departmental_diffusion_zone_details(apps):
         service.diffusion_zone_details = department
         services_to_update.append(service)
 
+        logger.info(
+            f"Le service avec l'id {service.id} est du type 'département' et ses diffusion_zone_details sont {department}."
+        )
+
     return services_to_update
 
 
@@ -65,6 +68,10 @@ def fix_regional_diffusion_zone_details(apps):
         service.diffusion_zone_details = region
         services_to_update.append(service)
 
+        logger.info(
+            f"Le service avec l'id {service.id} est du type 'région' et ses diffusion_zone_details sont {region}."
+        )
+
     return services_to_update
 
 
@@ -86,8 +93,13 @@ def fix_epci_diffusion_zone_details(apps):
             logger.error(f"L'EPCI pour le département {department} n'existe pas")
             raise EPCI.DoesNotExist
 
-        service.diffusion_zone_details = epci.code
+        epci_code = epci.code
+        service.diffusion_zone_details = epci_code
         services_to_update.append(service)
+
+        logger.info(
+            f"Le service avec l'id {service.id} est du type 'epci' et ses diffusion_zone_details sont {epci_code}."
+        )
 
     return services_to_update
 

--- a/back/dora/services/migrations/0125_correct_diffusion_zone_details.py
+++ b/back/dora/services/migrations/0125_correct_diffusion_zone_details.py
@@ -1,0 +1,96 @@
+from django.db import migrations
+from django.db.models import Q
+from django.utils import timezone
+
+from dora.admin_express.models import AdminDivisionType
+
+
+def get_department_for_service(service):
+    if service.city_code.startswith("97"):
+        department = service.city_code[:3]
+    else:
+        department = service.city_code[:2]
+    if not department:
+        department = service.structure.department
+    return department
+
+
+def fix_departmental_diffusion_zone_details(apps):
+    Service = apps.get_model("services", "Service")
+
+    departmental_services = Service.objects.filter(
+        diffusion_zone_type=AdminDivisionType.DEPARTMENT
+    )
+
+    problematic_services = departmental_services.filter(
+        ~Q(diffusion_zone_details__length=2)
+        & ~Q(diffusion_zone_details__length=3, diffusion_zone_details__startswith="97")
+    )
+
+    for service in problematic_services:
+        department = get_department_for_service(service)
+
+        service.diffusion_zone_details = department
+        service.modification_date = timezone.now()
+        service.save()
+
+
+def fix_regional_diffusion_zone_details(apps):
+    Service = apps.get_model("services", "Service")
+    Department = apps.get_model("admin_express", "Department")
+
+    regional_services = Service.objects.filter(
+        diffusion_zone_type=AdminDivisionType.REGION
+    )
+    problematic_services = regional_services.filter(
+        ~Q(diffusion_zone_details__length=2)
+    )
+    for service in problematic_services:
+        department = get_department_for_service(service)
+        try:
+            region = Department.objects.get(code=department).region
+        except Department.DoesNotExist:
+            continue
+        service.diffusion_zone_details = region
+        service.modification_date = timezone.now()
+        service.save()
+
+
+def fix_epci_diffusion_zone_details(apps):
+    Service = apps.get_model("services", "Service")
+    EPCI = apps.get_model("admin_express", "EPCI")
+
+    epci_services = Service.objects.filter(diffusion_zone_type=AdminDivisionType.EPCI)
+
+    problematic_services = epci_services.filter(~Q(diffusion_zone_details__length=9))
+
+    for service in problematic_services:
+        department = get_department_for_service(service)
+
+        epci = EPCI.objects.filter(departments__contains=[department]).first()
+
+        if not epci:
+            continue
+
+        service.diffusion_zone_details = epci.code
+        service.modification_date = timezone.now()
+        service.save()
+
+
+def fix_all_services_with_incorrect_diffusion_zone_details(apps, schema_editor):
+    fix_departmental_diffusion_zone_details(apps)
+    fix_regional_diffusion_zone_details(apps)
+    fix_epci_diffusion_zone_details(apps)
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("services", "0124_rename_concerned_public_service_publics"),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            fix_all_services_with_incorrect_diffusion_zone_details,
+            migrations.RunPython.noop,
+        )
+    ]


### PR DESCRIPTION
On a vu un bug où les services importés avec un diffusion_zone_type de département ne sont pas apparus sur une recherche dans une zone pertinente. Un bon exemple est ce [service](https://dora.inclusion.beta.gouv.fr/services/caisse-primaire-assu-rovg--lxwe) de santé à Poissy qui n'apparait pas pour des recherches des services de santé à Poissy comme celui-ci /search/?cats=sante&city=78498&cl=Poissy%20(78)&l=Poissy%20(78)

Le problème est que pour les services ajouté par l'import on met toujours le city_code pour les diffusion_zone_details sans prendre compte de la diffusion_zone_type comme vu [ici](https://github.com/gip-inclusion/dora/blob/89fd9bfdcb214b6af9013efca0722612ef362c4c/back/dora/services/csv_import.py#L286)

Ce PR fait une migration pour corriger les services dont les `diffusion_zone_details` sont pas alignés avec le `diffusion_zone_type` et ça corrige la partie de l'import pour que les `diffusion_zone_details` sont bonne par rapport au `diffusion_zone_type.`