### PR TITLE
feat : supplementer les logs avec des infos utiles

### DIFF
--- a/back/config/settings/base.py
+++ b/back/config/settings/base.py
@@ -251,15 +251,16 @@ LOGGING = {
     },
     "handlers": {
         "console": {"class": "logging.StreamHandler", "formatter": "json"},
-        "null": {"class": "logging.NullHandler"},
     },
     "loggers": {
-        "django": {
+        "": {
             "handlers": ["console"],
             "level": os.getenv("DJANGO_LOG_LEVEL", "INFO"),
         },
+        "django": {
+            "level": os.getenv("DJANGO_LOG_LEVEL", "INFO"),
+        },
         "dora.logs.core": {
-            "handlers": ["console"],
             "level": os.getenv("DORA_LOGS_CORE_LEVEL", "INFO"),
         },
     },

--- a/back/config/settings/base.py
+++ b/back/config/settings/base.py
@@ -247,18 +247,19 @@ LOGGING = {
     "version": 1,
     "disable_existing_loggers": False,
     "formatters": {
-        "json": {"()": "dora.logs.core.RedactUserInformationDataDogJSONFormatter"},
+        "json": {"()": "dora.logs.utils.RedactUserInformationDataDogJSONFormatter"},
     },
     "handlers": {
         "console": {"class": "logging.StreamHandler", "formatter": "json"},
         "null": {"class": "logging.NullHandler"},
     },
     "loggers": {
-        "": {"handlers": ["console"], "level": "INFO"},
         "django": {
+            "handlers": ["console"],
             "level": os.getenv("DJANGO_LOG_LEVEL", "INFO"),
         },
         "dora.logs.core": {
+            "handlers": ["console"],
             "level": os.getenv("DORA_LOGS_CORE_LEVEL", "INFO"),
         },
     },

--- a/back/config/settings/dev.py
+++ b/back/config/settings/dev.py
@@ -47,6 +47,9 @@ REST_FRAMEWORK["DEFAULT_RENDERER_CLASSES"] += (  # noqa F405
     "rest_framework.renderers.BrowsableAPIRenderer",
 )
 
+# Don't use json formatter in dev
+del LOGGING["handlers"]["console"]["formatter"]  # noqa: F405
+
 # Profiling :
 # utilisation de Silk (configurable via var env)
 PROFILE = os.getenv("DJANGO_PROFILE") == "true"

--- a/back/config/settings/dev.py
+++ b/back/config/settings/dev.py
@@ -47,9 +47,6 @@ REST_FRAMEWORK["DEFAULT_RENDERER_CLASSES"] += (  # noqa F405
     "rest_framework.renderers.BrowsableAPIRenderer",
 )
 
-# Don't use json formatter in dev
-del LOGGING["handlers"]["console"]["formatter"]  # noqa: F405
-
 # Profiling :
 # utilisation de Silk (configurable via var env)
 PROFILE = os.getenv("DJANGO_PROFILE") == "true"
@@ -74,4 +71,6 @@ if DEBUG and PROFILE:
 # Q : est-ce c'est justifié pour staging ?
 DATA_UPLOAD_MAX_NUMBER_FIELDS = 10000
 
+# Don't use json formatter in dev
+# del LOGGING["handlers"]["console"]["formatter"]  # noqa: F405
 LOGGING["loggers"]["django"]["level"] = os.getenv("DJANGO_LOG_LEVEL", "INFO")  # noqa F405

--- a/back/dora/logs/core.py
+++ b/back/dora/logs/core.py
@@ -1,6 +1,17 @@
 import logging
 
+from django_datadog_logger.formatters import datadog
+
 from .models import ActionLog
+
+
+class RedactUserInformationDataDogJSONFormatter(datadog.DataDogJSONFormatter):
+    def json_record(self, message, extra, record):
+        log_entry_dict = super().json_record(message, extra, record)
+        for log_key in {"usr.name", "usr.email", "usr.session_key"}:
+            if log_key in log_entry_dict:
+                del log_entry_dict[log_key]
+        return log_entry_dict
 
 
 class ActionLogHandler(logging.Handler):

--- a/back/dora/logs/core.py
+++ b/back/dora/logs/core.py
@@ -1,17 +1,6 @@
 import logging
 
-from django_datadog_logger.formatters import datadog
-
 from .models import ActionLog
-
-
-class RedactUserInformationDataDogJSONFormatter(datadog.DataDogJSONFormatter):
-    def json_record(self, message, extra, record):
-        log_entry_dict = super().json_record(message, extra, record)
-        for log_key in {"usr.name", "usr.email", "usr.session_key"}:
-            if log_key in log_entry_dict:
-                del log_entry_dict[log_key]
-        return log_entry_dict
 
 
 class ActionLogHandler(logging.Handler):

--- a/back/dora/logs/utils.py
+++ b/back/dora/logs/utils.py
@@ -1,0 +1,10 @@
+from django_datadog_logger.formatters import datadog
+
+
+class RedactUserInformationDataDogJSONFormatter(datadog.DataDogJSONFormatter):
+    def json_record(self, message, extra, record):
+        log_entry_dict = super().json_record(message, extra, record)
+        for log_key in {"usr.name", "usr.email", "usr.session_key"}:
+            if log_key in log_entry_dict:
+                del log_entry_dict[log_key]
+        return log_entry_dict

--- a/back/requirements/base.txt
+++ b/back/requirements/base.txt
@@ -6,6 +6,7 @@ django-otp==1.6.1
 django-csp==4.0
 django-filter==25.1
 django-storages==1.14.6
+django-datadog-logger==0.7.3
 boto3==1.40.35
 djangorestframework-camel-case==1.4.2
 djangorestframework-gis==1.2.0


### PR DESCRIPTION
Pour rendre les logs plus utiles, il faut ajouter ces trois infos à chaque log :

1. un id à chaque requête pour pouvoir facilement regrouper les logs générés par la même requête.
2. l'adresse IP de la machine qui fait la requête
3. l'id de l'utilisateur qui fait la requête (anonymous sinon)

En utilisant `django-datadog-logger`, on ajoute ces infos et chaque log est organisé dans le format json pour rendre la recherche plus facile.

Les logs ressemblent à ça :
```
{
   "message":"HTTP 200 OK",
   "logger.name":"django_datadog_logger.middleware.request_log",
   "logger.thread_name":"Thread-1 (process_request_thread)",
   "logger.method_name":"log_response",
   "date":"2025-10-02T09:46:32.734857+00:00",
   "status":"INFO",
   "network.client.ip":"127.0.0.1",
   "http.url":"/structures-admin/?department=04",
   "http.url_details.host":"localhost",
   "http.url_details.port":8000,
   "http.url_details.path":"/structures-admin/",
   "http.url_details.queryString":{
      "department":"04"
   },
   "http.url_details.scheme":"http",
   "http.url_details.view_name":"structure-admin-list",
   "http.method":"GET",
   "http.accept":"*/*",
   "http.referer":null,
   "http.useragent":"PostmanRuntime/7.48.0",
   "http.request_version":null,
   "http.request_id":"dceeb410-f3c5-4aec-bc3b-11e37a883420",
   "usr.id":51190,
   "duration":5333758115.768433
}
```