### PR TITLE
feat: changer le nombre de structures listé sur le site

### DIFF
--- a/back/dora/structures/templates/notification-service-activation.mjml
+++ b/back/dora/structures/templates/notification-service-activation.mjml
@@ -9,7 +9,7 @@
 
   <p>A ce jour, votre structure n’a encore publié aucun service et n’est donc pas visible des acteurs de votre territoire.</p>
 
-  <p>Rejoignez les 15 000 structures actives sur Dora en référençant votre offre de services afin de gagner en visibilité, fluidifier le traitement de vos orientations, et rendre vos services disponibles sur nos sites partenaires.</p>
+  <p>Rejoignez les 23 000 structures actives sur Dora en référençant votre offre de services afin de gagner en visibilité, fluidifier le traitement de vos orientations, et rendre vos services disponibles sur nos sites partenaires.</p>
 
   <p>Pour vous aider dans le référencement de vos services, vous pouvez consulter <a href="{{ dora_doc_link }}">notre article dédié</a> et vous inscrire à <a href="{{ webinar_link }}">un webinaire de prise en main</a>.</p>
 

--- a/front/src/routes/(static)/nos-partenaires/+page.svelte
+++ b/front/src/routes/(static)/nos-partenaires/+page.svelte
@@ -19,8 +19,8 @@
   <div>
     <h1 class="text-france-blue">Nos partenaires</h1>
     <p>
-      Plus de 1 000 structures ont déjà commencé à référencer leurs services sur
-      DORA
+      Plus de 23 000 structures ont déjà commencé à référencer leurs services
+      sur DORA
     </p>
 
     <ul class="mt-s24 gap-s24 flex w-full flex-wrap justify-center">

--- a/front/src/routes/+page.svelte
+++ b/front/src/routes/+page.svelte
@@ -165,7 +165,7 @@
 
     <div class="mt-s16">
       <p class="text-f12 text-center">
-        Plus de 5 000 structures ont déjà commencé à référencer leurs services
+        Plus de 23 000 structures ont déjà commencé à référencer leurs services
         sur DORA
       </p>
 


### PR DESCRIPTION
Il y a deux endroits où le nombre de structures référencés est affiché. Ce PR change les deux pour montrer 23 000

<img width="588" height="388" alt="Screenshot 2025-10-03 at 10 12 54" src="https://github.com/user-attachments/assets/b7881452-0370-4ef3-803d-eef6c926629c" />
<img width="829" height="423" alt="Screenshot 2025-10-03 at 10 13 39" src="https://github.com/user-attachments/assets/b7f893d2-7dfb-4f09-a307-0e3bd86b6e2b" />
