### PR TITLE
Échec explicite lorsque que /services-options/ ne retourne pas de données

### DIFF
--- a/front/src/lib/requests/services.ts
+++ b/front/src/lib/requests/services.ts
@@ -321,9 +321,13 @@ export async function convertSuggestionToDraft(serviceSlug) {
   return response.json();
 }
 
-export async function getServicesOptions(): Promise<ServicesOptions | null> {
+export async function getServicesOptions() {
   const url = `${getApiURL()}/services-options/`;
-  return (await fetchData<ServicesOptions>(url)).data;
+  const response = await fetchData<ServicesOptions>(url);
+  if (!response.data) {
+    throw Error(response.statusText);
+  }
+  return response.data;
 }
 
 export function updateServicesFromModel(

--- a/front/src/lib/utils/choice.ts
+++ b/front/src/lib/utils/choice.ts
@@ -1,10 +1,16 @@
 import type { Choice } from "$lib/types";
 
-export function getChoiceFromValue(value: string, choices: Choice[]): Choice {
+export function getChoiceFromValue(
+  value: string,
+  choices: Choice[]
+): Choice | undefined {
   return choices.find((choice) => choice.value === value);
 }
-export function getLabelFromValue(value: string, choices: Choice[]): string {
-  return getChoiceFromValue(value, choices).label;
+export function getLabelFromValue(
+  value: string,
+  choices: Choice[]
+): string | undefined {
+  return getChoiceFromValue(value, choices)?.label;
 }
 export function getCategoryKeyFromSubcategoryChoice(choice: Choice): string {
   return choice.value.split("--")[0];

--- a/front/src/routes/(modeles-services)/components/service-body/service-presentation/service-key-informations/service-key-informations.svelte
+++ b/front/src/routes/(modeles-services)/components/service-body/service-presentation/service-key-informations/service-key-informations.svelte
@@ -178,7 +178,7 @@
             >
               {getLabelFromValue(
                 service.feeCondition,
-                servicesOptions?.feeConditions
+                servicesOptions.feeConditions
               )}
             </span>
           {/if}

--- a/front/src/routes/(modeles-services)/services/[slug]/+page.svelte
+++ b/front/src/routes/(modeles-services)/services/[slug]/+page.svelte
@@ -72,7 +72,7 @@
   );
 </script>
 
-{#if service}
+{#if service && servicesOptions}
   <CenteredGrid bgColor="bg-blue-light">
     <ServiceHeader {service} />
   </CenteredGrid>


### PR DESCRIPTION
**Problème :** la fonction `getServicesOptions()` retourne `null` en cas d'échec de l'appel. Or, le code appelant ne gère pas ce cas, occasionnant de nombreuses erreurs `Cannot read properties of undefined/null**`.

**Solution :** on gère l'échec au plus tôt et on lève une exception avec le message d'erreur. Elle sera remontée sur Sentry à la place de toutes les autres erreurs `Cannot read properties of undefined/null`.