### PR TITLE
fix: augmenter la limite des requêtes pour les utilisateurs pas connectés

### DIFF
--- a/back/config/settings/base.py
+++ b/back/config/settings/base.py
@@ -266,6 +266,9 @@ LOGGING = {
 # Rest Framework :
 # https://www.django-rest-framework.org/api-guide/settings/
 
+ANON_THROTTLE_RATE_PER_MINUTE = os.getenv("ANON_THROTTLE_RATE", "24")
+USER_THROTTLE_RATE_PER_MINUTE = os.getenv("USER_THROTTLE_RATE", "120")
+
 REST_FRAMEWORK = {
     # Let's lock down access by default
     "DEFAULT_PERMISSION_CLASSES": [
@@ -295,8 +298,8 @@ REST_FRAMEWORK = {
         "rest_framework.throttling.UserRateThrottle",
     ],
     "DEFAULT_THROTTLE_RATES": {
-        "anon": "16/minute",
-        "user": "120/minute",
+        "anon": f"{ANON_THROTTLE_RATE_PER_MINUTE}/minute",
+        "user": f"{USER_THROTTLE_RATE_PER_MINUTE}/minute",
     },
 }
 

--- a/back/config/settings/base.py
+++ b/back/config/settings/base.py
@@ -266,8 +266,8 @@ LOGGING = {
 # Rest Framework :
 # https://www.django-rest-framework.org/api-guide/settings/
 
-ANON_THROTTLE_RATE_PER_MINUTE = os.getenv("ANON_THROTTLE_RATE", "24")
-USER_THROTTLE_RATE_PER_MINUTE = os.getenv("USER_THROTTLE_RATE", "120")
+ANON_THROTTLE_RATE_PER_MINUTE = os.getenv("ANON_THROTTLE_RATE_PER_MINUTE", "24")
+USER_THROTTLE_RATE_PER_MINUTE = os.getenv("USER_THROTTLE_RATE_PER_MINUTE", "120")
 
 REST_FRAMEWORK = {
     # Let's lock down access by default


### PR DESCRIPTION
Pour améliorer l'UX, ce PR augmente le nombre de requêtes permis pour des utilisateurs non connectés. La limitation du débit pour les utilisateurs connectés et non-connectés sont aussi configurables par deux env vars pour plus facilement les modifier dans l'avenir. 