### PR TITLE
feat: atterrissage sur le formulaire d'orientation depuis les emplois

### DIFF
--- a/back/dora/orientations/serializers.py
+++ b/back/dora/orientations/serializers.py
@@ -313,3 +313,4 @@ class OrientationBeneficiaryInfoOutputSerializer(serializers.Serializer):
     email = serializers.CharField(default="")
     phone = serializers.CharField(default="")
     france_travail_id = serializers.CharField(default="")
+    user_structure_slug = serializers.CharField(default="")

--- a/back/dora/orientations/tests/test_orientation_beneficiary_info.py
+++ b/back/dora/orientations/tests/test_orientation_beneficiary_info.py
@@ -8,7 +8,6 @@ from dora.core.test_utils import make_service, make_structure, make_user
 from dora.sirene.models import Establishment
 from dora.structures.models import StructureMember
 
-
 URL = "/orientations/emplois/beneficiary-info/"
 
 BENEFICIARY_DATA = {

--- a/back/dora/orientations/tests/test_orientation_beneficiary_info.py
+++ b/back/dora/orientations/tests/test_orientation_beneficiary_info.py
@@ -51,7 +51,7 @@ def test_orientation_beneficiary_info_returns_beneficiary_data(api_client):
         )
 
     assert response.status_code == 200
-    assert response.data == BENEFICIARY_DATA
+    assert response.data == {**BENEFICIARY_DATA, "user_structure_slug": structure.slug}
 
 
 def test_orientation_beneficiary_info_invalid_token_returns_error(

--- a/back/dora/orientations/tests/test_orientation_beneficiary_info.py
+++ b/back/dora/orientations/tests/test_orientation_beneficiary_info.py
@@ -25,7 +25,7 @@ def test_orientation_beneficiary_info_requires_auth(api_client):
     assert response.status_code == 401
 
 
-def test_orientation_beneficiary_info_returns_beneficiary_data(api_client):
+def test_orientation_beneficiary_info_returns_beneficiary_data(api_client, monkeypatch):
     user = make_user()
     structure = make_structure(siret="12345678901234")
     baker.make(Establishment, siret=structure.siret)
@@ -41,13 +41,16 @@ def test_orientation_beneficiary_info_returns_beneficiary_data(api_client):
 
     api_client.force_authenticate(user=user)
 
-    with (
-        patch("dora.orientations.serializers.decode_token", return_value=claims),
-        patch("dora.orientations.views.decode_token", return_value=claims),
-    ):
-        response = api_client.get(
-            f"{URL}?op=fake-token&service_slug={make_service().slug}"
-        )
+    monkeypatch.setattr(
+        "dora.orientations.serializers.decode_token",
+        lambda _: claims,
+    )
+    monkeypatch.setattr(
+        "dora.orientations.views.decode_token",
+        lambda _: claims,
+    )
+
+    response = api_client.get(f"{URL}?op=fake-token&service_slug={make_service().slug}")
 
     assert response.status_code == 200
     assert response.data == {**BENEFICIARY_DATA, "user_structure_slug": structure.slug}
@@ -74,7 +77,7 @@ def test_orientation_beneficiary_info_invalid_token_redirects_to_homepage_with_e
 
 
 def test_orientation_beneficiary_info_missing_beneficiary_data_returns_error(
-    api_client,
+    api_client, monkeypatch
 ):
     user = make_user()
     api_client.force_authenticate(user=user)
@@ -89,17 +92,16 @@ def test_orientation_beneficiary_info_missing_beneficiary_data_returns_error(
         },
     }
 
-    with (
-        patch(
-            "dora.orientations.serializers.decode_token",
-            return_value=claims_without_beneficiary,
-        ),
-        patch(
-            "dora.orientations.views.decode_token",
-            return_value=claims_without_beneficiary,
-        ),
-    ):
-        response = api_client.get(f"{URL}?op=token_without_beneficiary")
+    monkeypatch.setattr(
+        "dora.orientations.serializers.decode_token",
+        lambda _: claims_without_beneficiary,
+    )
+    monkeypatch.setattr(
+        "dora.orientations.views.decode_token",
+        lambda _: claims_without_beneficiary,
+    )
+
+    response = api_client.get(f"{URL}?op=token_without_beneficiary")
 
     assert response.status_code == 400
     assert len(response.data["op"]) == 1
@@ -109,7 +111,7 @@ def test_orientation_beneficiary_info_missing_beneficiary_data_returns_error(
 
 
 def test_user_with_different_email_redirects_to_homepage_with_link_invalid_param(
-    api_client,
+    api_client, monkeypatch
 ):
     user = make_user()
     api_client.force_authenticate(user=user)
@@ -122,18 +124,23 @@ def test_user_with_different_email_redirects_to_homepage_with_link_invalid_param
         "beneficiary": BENEFICIARY_DATA,
     }
 
-    with (
-        patch("dora.orientations.serializers.decode_token", return_value=claims),
-        patch("dora.orientations.views.decode_token", return_value=claims),
-    ):
-        response = api_client.get(f"{URL}?op=fake-token")
+    monkeypatch.setattr(
+        "dora.orientations.serializers.decode_token",
+        lambda _: claims,
+    )
+    monkeypatch.setattr(
+        "dora.orientations.views.decode_token",
+        lambda _: claims,
+    )
+
+    response = api_client.get(f"{URL}?op=fake-token")
 
     assert response.status_code == 200
     assert response.data["next_url"] == f"{settings.FRONTEND_URL}?link_invalid=true"
 
 
 def test_no_structure_for_establishment_redirects_to_rattachement_with_orienter(
-    api_client,
+    api_client, monkeypatch
 ):
     user = make_user()
     service = make_service()
@@ -150,11 +157,16 @@ def test_no_structure_for_establishment_redirects_to_rattachement_with_orienter(
 
     api_client.force_authenticate(user=user)
 
-    with (
-        patch("dora.orientations.serializers.decode_token", return_value=claims),
-        patch("dora.orientations.views.decode_token", return_value=claims),
-    ):
-        response = api_client.get(f"{URL}?op=fake-token&service_slug={service.slug}")
+    monkeypatch.setattr(
+        "dora.orientations.serializers.decode_token",
+        lambda _: claims,
+    )
+    monkeypatch.setattr(
+        "dora.orientations.views.decode_token",
+        lambda _: claims,
+    )
+
+    response = api_client.get(f"{URL}?op=fake-token&service_slug={service.slug}")
 
     assert response.status_code == 200
     parsed = urlparse(response.data["next_url"])
@@ -167,7 +179,7 @@ def test_no_structure_for_establishment_redirects_to_rattachement_with_orienter(
 
 
 def test_user_not_structure_member_redirects_to_rattachement_with_orienter(
-    api_client,
+    api_client, monkeypatch
 ):
     user = make_user()
     service = make_service()
@@ -184,11 +196,16 @@ def test_user_not_structure_member_redirects_to_rattachement_with_orienter(
 
     api_client.force_authenticate(user=user)
 
-    with (
-        patch("dora.orientations.serializers.decode_token", return_value=claims),
-        patch("dora.orientations.views.decode_token", return_value=claims),
-    ):
-        response = api_client.get(f"{URL}?op=fake-token&service_slug={service.slug}")
+    monkeypatch.setattr(
+        "dora.orientations.serializers.decode_token",
+        lambda _: claims,
+    )
+    monkeypatch.setattr(
+        "dora.orientations.views.decode_token",
+        lambda _: claims,
+    )
+
+    response = api_client.get(f"{URL}?op=fake-token&service_slug={service.slug}")
 
     assert response.status_code == 200
     parsed = urlparse(response.data["next_url"])

--- a/back/dora/orientations/tests/test_orientation_beneficiary_info.py
+++ b/back/dora/orientations/tests/test_orientation_beneficiary_info.py
@@ -53,7 +53,7 @@ def test_orientation_beneficiary_info_returns_beneficiary_data(api_client):
     assert response.data == {**BENEFICIARY_DATA, "user_structure_slug": structure.slug}
 
 
-def test_orientation_beneficiary_info_invalid_token_returns_error(
+def test_orientation_beneficiary_info_invalid_token_redirects_to_homepage_with_error(
     api_client, monkeypatch
 ):
     user = make_user()
@@ -69,25 +69,37 @@ def test_orientation_beneficiary_info_invalid_token_returns_error(
 
     response = api_client.get(f"{URL}?op=invalid-token")
 
-    assert response.status_code == 400
-    assert len(response.data["op"]) == 1
-    assert response.data["op"][0]["message"] == "Token JWT invalide."
+    assert response.status_code == 200
+    assert response.data["next_url"] == f"{settings.FRONTEND_URL}?link_invalid=true"
 
 
 def test_orientation_beneficiary_info_missing_beneficiary_data_returns_error(
-    api_client, monkeypatch
+    api_client,
 ):
     user = make_user()
     api_client.force_authenticate(user=user)
+    structure = make_structure()
+    baker.make(Establishment, siret=structure.siret)
+    baker.make(StructureMember, structure=structure, user=user)
 
-    claims_without_beneficiary = {"foo": "bar"}
+    claims_without_beneficiary = {
+        "prescriber": {
+            "email": user.email,
+            "organization": {"siret": structure.siret},
+        },
+    }
 
-    monkeypatch.setattr(
-        "dora.orientations.serializers.decode_token",
-        lambda value: claims_without_beneficiary,
-    )
-
-    response = api_client.get(f"{URL}?op=valid-token-without-beneficiary")
+    with (
+        patch(
+            "dora.orientations.serializers.decode_token",
+            return_value=claims_without_beneficiary,
+        ),
+        patch(
+            "dora.orientations.views.decode_token",
+            return_value=claims_without_beneficiary,
+        ),
+    ):
+        response = api_client.get(f"{URL}?op=token_without_beneficiary")
 
     assert response.status_code == 400
     assert len(response.data["op"]) == 1

--- a/back/dora/orientations/tests/test_orientation_beneficiary_info.py
+++ b/back/dora/orientations/tests/test_orientation_beneficiary_info.py
@@ -1,4 +1,3 @@
-from unittest.mock import patch
 from urllib.parse import parse_qs, urlparse
 
 from django.conf import settings

--- a/back/dora/orientations/tests/test_orientation_beneficiary_info.py
+++ b/back/dora/orientations/tests/test_orientation_beneficiary_info.py
@@ -1,47 +1,57 @@
-from django.conf import settings
+from unittest.mock import patch
+from urllib.parse import parse_qs, urlparse
 
-from dora.core.test_utils import make_user
+from django.conf import settings
+from model_bakery import baker
+
+from dora.core.test_utils import make_service, make_structure, make_user
+from dora.sirene.models import Establishment
+from dora.structures.models import StructureMember
+
+
+URL = "/orientations/emplois/beneficiary-info/"
+
+BENEFICIARY_DATA = {
+    "first_name": "John",
+    "last_name": "Doe",
+    "email": "john.doe@example.com",
+    "phone": "0102030405",
+    "france_travail_id": "1234567890",
+}
 
 
 def test_orientation_beneficiary_info_requires_auth(api_client):
-    url = "/orientations/emplois/beneficiary-info/"
-
-    response = api_client.get(url)
+    response = api_client.get(URL)
 
     assert response.status_code == 401
 
 
-def test_orientation_beneficiary_info_returns_beneficiary_data(api_client, monkeypatch):
+def test_orientation_beneficiary_info_returns_beneficiary_data(api_client):
     user = make_user()
-    api_client.force_authenticate(user=user)
+    structure = make_structure(siret="12345678901234")
+    baker.make(Establishment, siret=structure.siret)
+    baker.make(StructureMember, structure=structure, user=user)
 
     claims = {
-        "prescriber": {"email": user.email},
-        "beneficiary": {
-            "first_name": "John",
-            "last_name": "Doe",
-            "email": "john.doe@example.com",
-            "phone": "0102030405",
-            "france_travail_id": "1234567890",
+        "prescriber": {
+            "email": user.email,
+            "organization": {"siret": structure.siret},
         },
+        "beneficiary": BENEFICIARY_DATA,
     }
 
-    monkeypatch.setattr(
-        "dora.orientations.serializers.decode_token",
-        lambda value: claims,
-    )
+    api_client.force_authenticate(user=user)
 
-    url = "/orientations/emplois/beneficiary-info/?op=fake-token"
-    response = api_client.get(url)
+    with (
+        patch("dora.orientations.serializers.decode_token", return_value=claims),
+        patch("dora.orientations.views.decode_token", return_value=claims),
+    ):
+        response = api_client.get(
+            f"{URL}?op=fake-token&service_slug={make_service().slug}"
+        )
 
     assert response.status_code == 200
-    assert response.data == {
-        "first_name": "John",
-        "last_name": "Doe",
-        "email": "john.doe@example.com",
-        "phone": "0102030405",
-        "france_travail_id": "1234567890",
-    }
+    assert response.data == BENEFICIARY_DATA
 
 
 def test_orientation_beneficiary_info_invalid_token_returns_error(
@@ -58,8 +68,7 @@ def test_orientation_beneficiary_info_invalid_token_returns_error(
         _decode_token,
     )
 
-    url = "/orientations/emplois/beneficiary-info/?op=invalid-token"
-    response = api_client.get(url)
+    response = api_client.get(f"{URL}?op=invalid-token")
 
     assert response.status_code == 400
     assert len(response.data["op"]) == 1
@@ -79,8 +88,7 @@ def test_orientation_beneficiary_info_missing_beneficiary_data_returns_error(
         lambda value: claims_without_beneficiary,
     )
 
-    url = "/orientations/emplois/beneficiary-info/?op=valid-token-without-beneficiary"
-    response = api_client.get(url)
+    response = api_client.get(f"{URL}?op=valid-token-without-beneficiary")
 
     assert response.status_code == 400
     assert len(response.data["op"]) == 1
@@ -90,7 +98,7 @@ def test_orientation_beneficiary_info_missing_beneficiary_data_returns_error(
 
 
 def test_user_with_different_email_redirects_to_homepage_with_link_invalid_param(
-    api_client, monkeypatch
+    api_client,
 ):
     user = make_user()
     api_client.force_authenticate(user=user)
@@ -98,23 +106,84 @@ def test_user_with_different_email_redirects_to_homepage_with_link_invalid_param
     claims = {
         "prescriber": {
             "email": "different@invalid.com",
+            "organization": {"siret": "12345678901234"},
         },
-        "beneficiary": {
-            "first_name": "John",
-            "last_name": "Doe",
-            "email": "john.doe@example.com",
-            "phone": "0102030405",
-            "france_travail_id": "1234567890",
-        },
+        "beneficiary": BENEFICIARY_DATA,
     }
 
-    monkeypatch.setattr(
-        "dora.orientations.serializers.decode_token",
-        lambda value: claims,
-    )
-
-    url = "/orientations/emplois/beneficiary-info/?op=fake-token"
-    response = api_client.get(url)
+    with (
+        patch("dora.orientations.serializers.decode_token", return_value=claims),
+        patch("dora.orientations.views.decode_token", return_value=claims),
+    ):
+        response = api_client.get(f"{URL}?op=fake-token")
 
     assert response.status_code == 200
     assert response.data["next_url"] == f"{settings.FRONTEND_URL}?link_invalid=true"
+
+
+def test_no_structure_for_establishment_redirects_to_rattachement_with_orienter(
+    api_client,
+):
+    user = make_user()
+    service = make_service()
+    orphan_siret = "11111111111111"
+    baker.make(Establishment, siret=orphan_siret)
+
+    claims = {
+        "prescriber": {
+            "email": user.email,
+            "organization": {"siret": orphan_siret},
+        },
+        "beneficiary": BENEFICIARY_DATA,
+    }
+
+    api_client.force_authenticate(user=user)
+
+    with (
+        patch("dora.orientations.serializers.decode_token", return_value=claims),
+        patch("dora.orientations.views.decode_token", return_value=claims),
+    ):
+        response = api_client.get(f"{URL}?op=fake-token&service_slug={service.slug}")
+
+    assert response.status_code == 200
+    parsed = urlparse(response.data["next_url"])
+    query_params = parse_qs(parsed.query)
+    assert parsed.path == "/auth/rattachement"
+    assert query_params["siret"] == [orphan_siret]
+    assert query_params["op"] == ["fake-token"]
+    assert query_params["service_slug"] == [service.slug]
+    assert query_params["orienter"] == ["true"]
+
+
+def test_user_not_structure_member_redirects_to_rattachement_with_orienter(
+    api_client,
+):
+    user = make_user()
+    service = make_service()
+    structure = make_structure(siret="12345678901234")
+    baker.make(Establishment, siret=structure.siret)
+
+    claims = {
+        "prescriber": {
+            "email": user.email,
+            "organization": {"siret": structure.siret},
+        },
+        "beneficiary": BENEFICIARY_DATA,
+    }
+
+    api_client.force_authenticate(user=user)
+
+    with (
+        patch("dora.orientations.serializers.decode_token", return_value=claims),
+        patch("dora.orientations.views.decode_token", return_value=claims),
+    ):
+        response = api_client.get(f"{URL}?op=fake-token&service_slug={service.slug}")
+
+    assert response.status_code == 200
+    parsed = urlparse(response.data["next_url"])
+    query_params = parse_qs(parsed.query)
+    assert parsed.path == "/auth/rattachement"
+    assert query_params["siret"] == [structure.siret]
+    assert query_params["service_slug"] == [service.slug]
+    assert query_params["orienter"] == ["true"]
+    assert query_params["fast_track"] == ["true"]

--- a/back/dora/orientations/views.py
+++ b/back/dora/orientations/views.py
@@ -439,7 +439,7 @@ def orientation_beneficiary_info(request):
     op_jwt = request.GET.get("op")
     service_slug = request.GET.get("service_slug", "")
 
-    response, _ = _resolve_emplois_orientation(
+    response, structure = _resolve_emplois_orientation(
         request, op_jwt, service_slug, direct_to_orientation=True
     )
     if response is not None:
@@ -448,4 +448,4 @@ def orientation_beneficiary_info(request):
     output_serializer = OrientationBeneficiaryInfoOutputSerializer(
         claims["beneficiary"]
     )
-    return Response(output_serializer.data)
+    return Response({**output_serializer.data, "user_structure_slug": structure.slug})

--- a/back/dora/orientations/views.py
+++ b/back/dora/orientations/views.py
@@ -432,20 +432,22 @@ def handle_emplois_orientation(request, service_slug):
 @api_view(["GET"])
 @permission_classes([permissions.IsAuthenticated])
 def orientation_beneficiary_info(request):
-    input_serializer = OrientationBeneficiaryInfoInputSerializer(
-        data=request.query_params
-    )
-    input_serializer.is_valid(raise_exception=True)
-
-    claims = input_serializer.validated_data["op"]
     op_jwt = request.GET.get("op")
+
     service_slug = request.GET.get("service_slug", "")
 
     response, structure_slug = _resolve_emplois_orientation(
         request, op_jwt, service_slug, direct_to_orientation=True
     )
+
     if response is not None:
         return response
+
+    input_serializer = OrientationBeneficiaryInfoInputSerializer(
+        data=request.query_params
+    )
+    input_serializer.is_valid(raise_exception=True)
+    claims = input_serializer.validated_data["op"]
 
     output_serializer = OrientationBeneficiaryInfoOutputSerializer(
         claims["beneficiary"]

--- a/back/dora/orientations/views.py
+++ b/back/dora/orientations/views.py
@@ -450,6 +450,6 @@ def orientation_beneficiary_info(request):
     claims = input_serializer.validated_data["op"]
 
     output_serializer = OrientationBeneficiaryInfoOutputSerializer(
-        claims["beneficiary"]
+        {**claims["beneficiary"], "user_structure_slug": structure_slug}
     )
-    return Response({**output_serializer.data, "user_structure_slug": structure_slug})
+    return Response(output_serializer.data)

--- a/back/dora/orientations/views.py
+++ b/back/dora/orientations/views.py
@@ -410,19 +410,21 @@ def _resolve_emplois_orientation(
             params["orienter"] = "true"
         return Response({"next_url": f"{rattachement_url}?{urlencode(params)}"}), None
 
-    return None, structure
+    return None, structure.slug
 
 
 @api_view(["GET"])
 @permission_classes([permissions.IsAuthenticated])
 def handle_emplois_orientation(request, service_slug):
     op_jwt = request.GET.get("op")
-    response, structure = _resolve_emplois_orientation(request, op_jwt, service_slug)
+    response, structure_slug = _resolve_emplois_orientation(
+        request, op_jwt, service_slug
+    )
     if response is not None:
         return response
     return Response(
         {
-            "next_url": f"{settings.FRONTEND_URL}/services/{service_slug}?{urlencode({'op': op_jwt, 'user_structure_slug': structure.slug})}"
+            "next_url": f"{settings.FRONTEND_URL}/services/{service_slug}?{urlencode({'op': op_jwt, 'user_structure_slug': structure_slug})}"
         }
     )
 
@@ -439,7 +441,7 @@ def orientation_beneficiary_info(request):
     op_jwt = request.GET.get("op")
     service_slug = request.GET.get("service_slug", "")
 
-    response, structure = _resolve_emplois_orientation(
+    response, structure_slug = _resolve_emplois_orientation(
         request, op_jwt, service_slug, direct_to_orientation=True
     )
     if response is not None:
@@ -448,4 +450,4 @@ def orientation_beneficiary_info(request):
     output_serializer = OrientationBeneficiaryInfoOutputSerializer(
         claims["beneficiary"]
     )
-    return Response({**output_serializer.data, "user_structure_slug": structure.slug})
+    return Response({**output_serializer.data, "user_structure_slug": structure_slug})

--- a/back/dora/orientations/views.py
+++ b/back/dora/orientations/views.py
@@ -350,10 +350,11 @@ class OrientationExportView(APIView):
 
 
 def _resolve_emplois_orientation(
-    request, op_jwt, service_slug, direct_to_orientation=False
-):
+    request: Request, op_jwt: str, service_slug: str, direct_to_orientation=False
+) -> (str | None, str | None):
     """
     Logique métier partagé entre les routes appelé pour diriger l'utilisateur avec un jwt "OP" vers la bonne page
+    Ça renvoie un tuple qui est soit (<next_url>, None) soit (None, <structure_slug>)
     """
     try:
         orientation_data = decode_token(op_jwt)

--- a/back/dora/orientations/views.py
+++ b/back/dora/orientations/views.py
@@ -349,21 +349,25 @@ class OrientationExportView(APIView):
         return Response(serializer.data)
 
 
-@api_view(["GET"])
-@permission_classes([permissions.IsAuthenticated])
-def handle_emplois_orientation(request, service_slug):
-    op_jwt = request.GET.get("op")
-
+def _resolve_emplois_orientation(
+    request, op_jwt, service_slug, direct_to_orientation=False
+):
+    """
+    Logique métier partagé entre les routes appelé pour diriger l'utilisateur avec un jwt "OP" vers la bonne page
+    """
     try:
         orientation_data = decode_token(op_jwt)
     except ValueError:
-        return Response({"next_url": f"{settings.FRONTEND_URL}?link_invalid=true"})
+        return Response(
+            {"next_url": f"{settings.FRONTEND_URL}?link_invalid=true"}
+        ), None
 
     prescriber_data = orientation_data["prescriber"]
-    prescriber_email = prescriber_data["email"]
 
-    if request.user.is_authenticated and request.user.email != prescriber_email:
-        return Response({"next_url": f"{settings.FRONTEND_URL}?link_invalid=true"})
+    if request.user.email != prescriber_data["email"]:
+        return Response(
+            {"next_url": f"{settings.FRONTEND_URL}?link_invalid=true"}
+        ), None
 
     user_has_new_dora_account = (
         not request.user.main_activity and not request.user.discovery_method
@@ -374,38 +378,47 @@ def handle_emplois_orientation(request, service_slug):
         request.user.save()
 
     structure_siret = prescriber_data["organization"]["siret"]
-    is_siret_recognized = Establishment.objects.filter(siret=structure_siret).exists()
-
     rattachement_url = f"{settings.FRONTEND_URL}/auth/rattachement"
 
-    if not is_siret_recognized:
+    if not Establishment.objects.filter(siret=structure_siret).exists():
         return Response(
             {
                 "next_url": f"{rattachement_url}?{urlencode({'siret': structure_siret, 'unknown_siret': 'true'})}"
             }
-        )
+        ), None
 
     try:
         structure = Structure.objects.get(siret=structure_siret)
     except Structure.DoesNotExist:
-        return Response(
-            {
-                "next_url": f"{rattachement_url}?{urlencode({'siret': structure_siret, 'op': op_jwt, 'service_slug': service_slug})}"
-            }
-        )
+        params = {"siret": structure_siret, "op": op_jwt, "service_slug": service_slug}
+        if direct_to_orientation:
+            params["orienter"] = "true"
+        return Response({"next_url": f"{rattachement_url}?{urlencode(params)}"}), None
 
-    is_structure_member = structure.membership.filter(user=request.user).exists()
-
-    if not is_structure_member:
+    if not structure.membership.filter(user=request.user).exists():
         orientation_data["fast_track"] = True
         orientation_data["exp"] = ceil(time.time()) + 3600
         op_jwt_with_fast_track = generate_token(orientation_data)
-        return Response(
-            {
-                "next_url": f"{rattachement_url}?{urlencode({'siret': structure_siret, 'op': op_jwt_with_fast_track, 'service_slug': service_slug, 'fast_track': 'true'})}"
-            }
-        )
+        params = {
+            "siret": structure_siret,
+            "op": op_jwt_with_fast_track,
+            "service_slug": service_slug,
+            "fast_track": "true",
+        }
+        if direct_to_orientation:
+            params["orienter"] = "true"
+        return Response({"next_url": f"{rattachement_url}?{urlencode(params)}"}), None
 
+    return None, structure
+
+
+@api_view(["GET"])
+@permission_classes([permissions.IsAuthenticated])
+def handle_emplois_orientation(request, service_slug):
+    op_jwt = request.GET.get("op")
+    response, structure = _resolve_emplois_orientation(request, op_jwt, service_slug)
+    if response is not None:
+        return response
     return Response(
         {
             "next_url": f"{settings.FRONTEND_URL}/services/{service_slug}?{urlencode({'op': op_jwt, 'user_structure_slug': structure.slug})}"
@@ -422,9 +435,14 @@ def orientation_beneficiary_info(request):
     input_serializer.is_valid(raise_exception=True)
 
     claims = input_serializer.validated_data["op"]
+    op_jwt = request.GET.get("op")
+    service_slug = request.GET.get("service_slug", "")
 
-    if claims["prescriber"]["email"] != request.user.email:
-        return Response({"next_url": f"{settings.FRONTEND_URL}?link_invalid=true"})
+    response, _ = _resolve_emplois_orientation(
+        request, op_jwt, service_slug, direct_to_orientation=True
+    )
+    if response is not None:
+        return response
 
     output_serializer = OrientationBeneficiaryInfoOutputSerializer(
         claims["beneficiary"]

--- a/front/src/lib/requests/nexus.ts
+++ b/front/src/lib/requests/nexus.ts
@@ -50,13 +50,14 @@ export type OrientationBeneficiaryInfo =
 
 export const getOrientationBeneficiaryInfo = async (
   opJwt: string,
-  serviceSlug: string
+  serviceSlug: string,
+  fetchFunction: typeof fetch
 ) => {
   const url = new URL("/orientations/emplois/beneficiary-info/", getApiURL());
   url.searchParams.set(ORIENTATION_JWT_QUERY_PARAM, opJwt);
   url.searchParams.set("service_slug", serviceSlug);
 
-  const response = await fetch(url, {
+  const response = await fetchFunction(url, {
     method: "GET",
     headers: {
       Accept: "application/json; version=1.0",

--- a/front/src/lib/requests/nexus.ts
+++ b/front/src/lib/requests/nexus.ts
@@ -47,9 +47,13 @@ export type OrientationBeneficiaryInfo =
   | OrientationBeneficiaryInfoData
   | OrientationBeneficiaryInfoRedirect;
 
-export const getOrientationBeneficiaryInfo = async (opJwt: string) => {
+export const getOrientationBeneficiaryInfo = async (
+  opJwt: string,
+  serviceSlug: string
+) => {
   const url = new URL("/orientations/emplois/beneficiary-info/", getApiURL());
   url.searchParams.set(ORIENTATION_JWT_QUERY_PARAM, opJwt);
+  url.searchParams.set("service_slug", serviceSlug);
 
   const response = await fetch(url, {
     method: "GET",

--- a/front/src/lib/requests/nexus.ts
+++ b/front/src/lib/requests/nexus.ts
@@ -51,7 +51,7 @@ export type OrientationBeneficiaryInfo =
 export const getOrientationBeneficiaryInfo = async (
   opJwt: string,
   serviceSlug: string,
-  fetchFunction: typeof fetch
+  fetchFunction = fetch
 ) => {
   const url = new URL("/orientations/emplois/beneficiary-info/", getApiURL());
   url.searchParams.set(ORIENTATION_JWT_QUERY_PARAM, opJwt);

--- a/front/src/lib/requests/nexus.ts
+++ b/front/src/lib/requests/nexus.ts
@@ -37,6 +37,7 @@ type OrientationBeneficiaryInfoData = {
   email: string;
   phone: string;
   franceTravailId: string;
+  userStructureSlug: string;
 };
 
 type OrientationBeneficiaryInfoRedirect = {

--- a/front/src/routes/(modeles-services)/services/[slug]/+page.svelte
+++ b/front/src/routes/(modeles-services)/services/[slug]/+page.svelte
@@ -129,12 +129,3 @@
 
   <MonRecapPopup />
 {/if}
-
-<style>
-  :global(._toastItem) {
-    top: 5.1rem !important;
-    left: 50% !important;
-    right: auto !important;
-    transform: translateX(-50%) !important;
-  }
-</style>

--- a/front/src/routes/(modeles-services)/services/[slug]/+page.svelte
+++ b/front/src/routes/(modeles-services)/services/[slug]/+page.svelte
@@ -13,7 +13,6 @@
   import type { Service } from "$lib/types";
   import { userInfo } from "$lib/utils/auth";
   import { isMemberOrPotentialMemberOfStructure } from "$lib/utils/current-structure";
-  import { setCurrentStructure } from "$lib/utils/preferences";
   import { trackService } from "$lib/utils/stats";
 
   import ServiceBody from "../../components/service-body/service-body.svelte";
@@ -21,7 +20,6 @@
   import ServiceHeader from "./service-header.svelte";
   import ServiceToolbar from "./service-toolbar.svelte";
   import type { PageData } from "./$types";
-  import { toast } from "@zerodevx/svelte-toast";
 
   interface Props {
     data: PageData;
@@ -53,25 +51,6 @@
   onMount(() => {
     const searchId = $page.url.searchParams.get("searchId");
     trackService(service, $page.url, searchId, isDI);
-  });
-
-  $effect(() => {
-    const userStructureSlug = $page.url.searchParams.get("user_structure_slug");
-    if (userStructureSlug && $userInfo) {
-      const userStructure = [
-        ...$userInfo.pendingStructures,
-        ...$userInfo.structures,
-      ].find((struct) => struct.slug === userStructureSlug);
-
-      if (userStructure && setCurrentStructure(userStructureSlug)) {
-        toast.push({
-          msg: `Votre structure active a été automatiquement modifiée : vous utilisez désormais ${userStructure.name}.<br/><br/>Attention : si d'autres onglets DORA sont ouverts dans votre navigateur, votre activité dans ces onglets sera également associée à la structure ${userStructure.name}.`,
-          theme: {
-            "--toastWidth": "50%",
-          },
-        });
-      }
-    }
   });
 
   beforeNavigate(({ from, to }) => {

--- a/front/src/routes/(modeles-services)/services/[slug]/orienter/+page.svelte
+++ b/front/src/routes/(modeles-services)/services/[slug]/orienter/+page.svelte
@@ -33,6 +33,7 @@
         email: string;
         phone: string;
         franceTravailId: string;
+        userStructureSlug: string;
       } | null;
     };
   }
@@ -81,6 +82,13 @@
       $orientation.beneficiaryPhone = data.beneficiaryInfo.phone;
       $orientation.beneficiaryFranceTravailNumber =
         data.beneficiaryInfo.franceTravailId;
+      if (data.beneficiaryInfo.userStructureSlug) {
+        $page.url.searchParams.set(
+          "user_structure_slug",
+          data.beneficiaryInfo.userStructureSlug
+        );
+        history.replaceState(null, "", $page.url.pathname + $page.url.search);
+      }
     } else {
       $page.url.searchParams.delete(ORIENTATION_JWT_QUERY_PARAM);
       history.replaceState(null, "", $page.url.pathname + $page.url.search);

--- a/front/src/routes/(modeles-services)/services/[slug]/orienter/+page.ts
+++ b/front/src/routes/(modeles-services)/services/[slug]/orienter/+page.ts
@@ -5,7 +5,7 @@ import {
   type OrientationBeneficiaryInfo,
 } from "$lib/requests/nexus";
 
-export const load = async ({ parent, url, params }) => {
+export const load = async ({ parent, url, params, fetch }) => {
   const data = await parent();
   const { service } = data;
 
@@ -24,7 +24,11 @@ export const load = async ({ parent, url, params }) => {
   const opJwt = url.searchParams.get(ORIENTATION_JWT_QUERY_PARAM);
   if (opJwt) {
     try {
-      beneficiaryInfo = await getOrientationBeneficiaryInfo(opJwt, params.slug);
+      beneficiaryInfo = await getOrientationBeneficiaryInfo(
+        opJwt,
+        params.slug,
+        fetch
+      );
     } catch {
       beneficiaryInfo = null;
     }

--- a/front/src/routes/(modeles-services)/services/[slug]/orienter/+page.ts
+++ b/front/src/routes/(modeles-services)/services/[slug]/orienter/+page.ts
@@ -5,7 +5,7 @@ import {
   type OrientationBeneficiaryInfo,
 } from "$lib/requests/nexus";
 
-export const load = async ({ parent, url }) => {
+export const load = async ({ parent, url, params }) => {
   const data = await parent();
   const { service } = data;
 
@@ -24,7 +24,7 @@ export const load = async ({ parent, url }) => {
   const opJwt = url.searchParams.get(ORIENTATION_JWT_QUERY_PARAM);
   if (opJwt) {
     try {
-      beneficiaryInfo = await getOrientationBeneficiaryInfo(opJwt);
+      beneficiaryInfo = await getOrientationBeneficiaryInfo(opJwt, params.slug);
     } catch {
       beneficiaryInfo = null;
     }

--- a/front/src/routes/+layout.svelte
+++ b/front/src/routes/+layout.svelte
@@ -15,7 +15,7 @@
   import CookieBanner from "$lib/components/specialized/cookie-banner/cookie-banner.svelte";
   import { TOAST_DURATION_MS } from "$lib/consts";
   import type { PageData } from "./$types";
-  import {setCurrentStructure} from "$lib/utils/preferences";
+  import { setCurrentStructure } from "$lib/utils/preferences";
 
   interface Props {
     children?: Snippet;
@@ -93,7 +93,10 @@
 <CookieBanner />
 <SvelteToast options={{ duration: TOAST_DURATION_MS }} />
 <div class="structure-switch-toast">
-  <SvelteToast target="structure-switch" options={{ duration: TOAST_DURATION_MS }} />
+  <SvelteToast
+    target="structure-switch"
+    options={{ duration: TOAST_DURATION_MS }}
+  />
 </div>
 
 <style>
@@ -104,6 +107,6 @@
     transform: translateX(-50%);
   }
   .structure-switch-toast :global(._toastItem) {
-    width: 50vw
+    width: 50vw;
   }
 </style>

--- a/front/src/routes/+layout.svelte
+++ b/front/src/routes/+layout.svelte
@@ -48,12 +48,10 @@
       ].find((struct) => struct.slug === userStructureSlug);
 
       if (userStructure && setCurrentStructure(userStructureSlug)) {
-        toast.push({
-          msg: `Votre structure active a été automatiquement modifiée : vous utilisez désormais ${userStructure.name}.<br/><br/>Attention : si d'autres onglets DORA sont ouverts dans votre navigateur, votre activité dans ces onglets sera également associée à la structure ${userStructure.name}.`,
-          theme: {
-            "--toastWidth": "50%",
-          },
-        });
+        toast.push(
+          `Votre structure active a été automatiquement modifiée : vous utilisez désormais ${userStructure.name}.<br/><br/>Attention : si d'autres onglets DORA sont ouverts dans votre navigateur, votre activité dans ces onglets sera également associée à la structure ${userStructure.name}.`,
+          { target: "structure-switch" }
+        );
       }
     }
   });
@@ -94,3 +92,18 @@
 <Footer />
 <CookieBanner />
 <SvelteToast options={{ duration: TOAST_DURATION_MS }} />
+<div class="structure-switch-toast">
+  <SvelteToast target="structure-switch" options={{ duration: TOAST_DURATION_MS }} />
+</div>
+
+<style>
+  .structure-switch-toast :global(._toastContainer) {
+    top: 6.6rem;
+    left: 50%;
+    right: auto;
+    transform: translateX(-50%);
+  }
+  .structure-switch-toast :global(._toastItem) {
+    width: 50vw
+  }
+</style>

--- a/front/src/routes/+layout.svelte
+++ b/front/src/routes/+layout.svelte
@@ -15,6 +15,7 @@
   import CookieBanner from "$lib/components/specialized/cookie-banner/cookie-banner.svelte";
   import { TOAST_DURATION_MS } from "$lib/consts";
   import type { PageData } from "./$types";
+  import {setCurrentStructure} from "$lib/utils/preferences";
 
   interface Props {
     children?: Snippet;
@@ -35,6 +36,25 @@
   $effect(() => {
     if (browser && $page.url.searchParams.get("link_invalid") === "true") {
       toast.push("Lien expiré ou invalide");
+    }
+  });
+
+  $effect(() => {
+    const userStructureSlug = $page.url.searchParams.get("user_structure_slug");
+    if (userStructureSlug && $userInfo) {
+      const userStructure = [
+        ...$userInfo.pendingStructures,
+        ...$userInfo.structures,
+      ].find((struct) => struct.slug === userStructureSlug);
+
+      if (userStructure && setCurrentStructure(userStructureSlug)) {
+        toast.push({
+          msg: `Votre structure active a été automatiquement modifiée : vous utilisez désormais ${userStructure.name}.<br/><br/>Attention : si d'autres onglets DORA sont ouverts dans votre navigateur, votre activité dans ces onglets sera également associée à la structure ${userStructure.name}.`,
+          theme: {
+            "--toastWidth": "50%",
+          },
+        });
+      }
     }
   });
 </script>

--- a/front/src/routes/auth/rattachement/+page.svelte
+++ b/front/src/routes/auth/rattachement/+page.svelte
@@ -35,7 +35,7 @@
     unknownSiret,
     opJwt,
     serviceSlug,
-    isOrienter,
+    directToOrientationPage,
     proposedSafir,
     userIsFranceTravail,
   } = data;
@@ -84,7 +84,7 @@
       result.data = await response.json();
       await refreshUserInfo();
       const redirectUrl = opJwt
-        ? `/services/${serviceSlug}${isOrienter ? "/orienter" : ""}?${ORIENTATION_JWT_QUERY_PARAM}=${encodeURIComponent(opJwt)}`
+        ? `/services/${serviceSlug}${directToOrientationPage ? "/orienter" : ""}?${ORIENTATION_JWT_QUERY_PARAM}=${encodeURIComponent(opJwt)}`
         : `/structures/${result.data.slug}`;
       await goto(redirectUrl);
       loading = false;

--- a/front/src/routes/auth/rattachement/+page.svelte
+++ b/front/src/routes/auth/rattachement/+page.svelte
@@ -35,6 +35,7 @@
     unknownSiret,
     opJwt,
     serviceSlug,
+    isOrienter,
     proposedSafir,
     userIsFranceTravail,
   } = data;
@@ -83,7 +84,7 @@
       result.data = await response.json();
       await refreshUserInfo();
       const redirectUrl = opJwt
-        ? `/services/${serviceSlug}?${ORIENTATION_JWT_QUERY_PARAM}=${encodeURIComponent(opJwt)}`
+        ? `/services/${serviceSlug}${isOrienter ? "/orienter" : ""}?${ORIENTATION_JWT_QUERY_PARAM}=${encodeURIComponent(opJwt)}`
         : `/structures/${result.data.slug}`;
       await goto(redirectUrl);
       loading = false;

--- a/front/src/routes/auth/rattachement/+page.ts
+++ b/front/src/routes/auth/rattachement/+page.ts
@@ -41,7 +41,7 @@ export const load: PageLoad = async ({ fetch, url, parent }) => {
   const unknownSiret = url.searchParams.get("unknown_siret") === "true";
   const opJwt = url.searchParams.get(ORIENTATION_JWT_QUERY_PARAM);
   const serviceSlug = url.searchParams.get("service_slug");
-  const isOrienter = url.searchParams.get("orienter") === "true";
+  const directToOrientationPage = url.searchParams.get("orienter") === "true";
   const proposedSafir = userIsFranceTravail
     ? url.searchParams.get("safir")
     : "";
@@ -65,7 +65,7 @@ export const load: PageLoad = async ({ fetch, url, parent }) => {
     unknownSiret,
     opJwt,
     serviceSlug,
-    isOrienter,
+    directToOrientationPage,
     proposedSafir,
     userIsFranceTravail,
   };

--- a/front/src/routes/auth/rattachement/+page.ts
+++ b/front/src/routes/auth/rattachement/+page.ts
@@ -41,6 +41,7 @@ export const load: PageLoad = async ({ fetch, url, parent }) => {
   const unknownSiret = url.searchParams.get("unknown_siret") === "true";
   const opJwt = url.searchParams.get(ORIENTATION_JWT_QUERY_PARAM);
   const serviceSlug = url.searchParams.get("service_slug");
+  const isOrienter = url.searchParams.get("orienter") === "true";
   const proposedSafir = userIsFranceTravail
     ? url.searchParams.get("safir")
     : "";
@@ -64,6 +65,7 @@ export const load: PageLoad = async ({ fetch, url, parent }) => {
     unknownSiret,
     opJwt,
     serviceSlug,
+    isOrienter,
     proposedSafir,
     userIsFranceTravail,
   };


### PR DESCRIPTION
Quand l'utilisateur est dirigé vers `/services/<slug>/orienter?op=<op_jwt>`, il experimentera le même flow que s'il a été dirigé vers `/services/<slug>?op=<op_jwt>`. C'est à dire, on applique la même logique métier pour déterminer la bonne page où il doit atterrir. 

Par exemple :  S'il n'est pas encore membre de sa structure mais la structure existe déjà, il ira à la page de rattachement avec certains params. 

Quand l'utilisateur est dirigé vers `/services/<slug>?op=<op_jwt>`, le comportement reste le même. 

Pour que le toast qui affiche le gros message concernant le changement de la structure active soit stylé sans ni dupliquer le styling ni empêcher l'ajout des autres toasts sans ce styling sur les mêmes pages, il faut créer une nouvelle instance de `<SvelteToast />` avec son propre styling. 
