### PR TITLE
build(dependabot): Définition d'une période de cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,13 +3,17 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "daily"
+    cooldown:
+      default-days: 5
     open-pull-requests-limit: 20
 
   - package-ecosystem: "pip"
     directory: "/back"
     schedule:
-      interval: "weekly"
+      interval: "daily"
+    cooldown:
+      default-days: 5
     commit-message:
       prefix: "build"
       prefix-development: "build(dev)"
@@ -26,7 +30,9 @@ updates:
   - package-ecosystem: "npm"
     directory: "/front"
     schedule:
-      interval: "weekly"
+      interval: "daily"
+    cooldown:
+      default-days: 5
     commit-message:
       prefix: "build"
       prefix-development: "build(dev)"


### PR DESCRIPTION
Avec cette période de cooldown, Dependabot attend 5 jours avant de
proposer des mises à jour non liées à la sécurité. Cela réduit le
risque d'installer une nouvelle version infectée par un malware (qui
est généralement détectée et retirée des dépôts PyPI et NPM en
quelques heures ou quelques jours).
    
Le cooldown ne s'applique pas aux mises à jour de sécurité, qui sont
proposées dès qu'elles sont disponibles.
    
Puisque le cooldown introduit un délai avant les mises à jour, nous
exécutons désormais Dependabot plus fréquemment (quotidiennement au
lieu d'hebdomadairement) afin d'éviter d'attendre trop longtemps
(jusqu'à 6 jours au lieu de 12 jours si l'exécution est hebdomadaire).

Doc Dependabot : https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#cooldown-