### PR TITLE
feat: changer les liens pour les stats dans le TdB des GTs

### DIFF
--- a/front/src/lib/consts.ts
+++ b/front/src/lib/consts.ts
@@ -24,13 +24,7 @@ export const DI_METABASE_STATS_DASHBOARD_URL = (
   departmentName: string,
   dataSource: string = "dora"
 ) =>
-  `https://stats.inclusion.beta.gouv.fr/public/dashboard/bbe6a581-0ecc-40cb-84d3-b3f2e9625f5b?d%25C3%25A9partement=${departmentName}&producteur_de_donn%25C3%25A9es=${dataSource}`;
-
-export const DI_METABASE_LIST_DASHBOARD_URL = (
-  departmentName: string,
-  dataSource: string = "dora"
-) =>
-  `https://stats.inclusion.beta.gouv.fr/public/dashboard/e5baef58-cc06-4c9c-aec4-5919654b2534?d%25C3%25A9partement=${departmentName}&producteur_de_donn%25C3%25A9es=${dataSource}`;
+  `https://stats.inclusion.beta.gouv.fr/public/dashboard/3b0582bc-cdff-41a8-b94d-a57e4d97f512?d%25C3%25A9partement=${departmentName}&producteur_de_donn%25C3%25A9es=${dataSource}`;
 
 export const RATE_LIMIT_MESSAGE =
   "Vous avez effectué trop de requêtes. Veuillez patienter une minute avant de réessayer.";

--- a/front/src/routes/admin/structures/+page.svelte
+++ b/front/src/routes/admin/structures/+page.svelte
@@ -6,7 +6,6 @@
   import AdminDivisionSearch from "$lib/components/inputs/geo/admin-division-search.svelte";
   import Notice from "$lib/components/display/notice.svelte";
   import {
-    DI_METABASE_LIST_DASHBOARD_URL,
     DI_METABASE_STATS_DASHBOARD_URL,
     METABASE_DASHBOARD_URL,
     URL_HELP_SITE,
@@ -202,14 +201,6 @@
               class="text-f18 text-france-blue leading-32 underline"
             >
               Cartographie des structures et services référencés
-            </a>
-            <a
-              href={DI_METABASE_LIST_DASHBOARD_URL(selectedDepartment.name)}
-              target="_blank"
-              rel="noopener nofollow"
-              class="text-f18 text-france-blue leading-32 underline"
-            >
-              Liste des structures et services référencés
             </a>
             <a
               href={METABASE_DASHBOARD_URL(selectedDepartment.code)}


### PR DESCRIPTION
Ce PR change le lien pour `Cartographie des structures et services référencés` à https://stats.inclusion.beta.gouv.fr/public/dashboard/3b0582bc-cdff-41a8-b94d-a57e4d97f512 en passent les mêmes query params qu'avant. 

On supprime aussi `Liste des structures et services référencés`