### PR TITLE
feat: l'antenne peut voir les modèles de service de son parent

### DIFF
--- a/back/dora/structures/serializers.py
+++ b/back/dora/structures/serializers.py
@@ -1,5 +1,5 @@
 from data_inclusion.schema.v0 import TypologieStructure
-from django.db.models import Count, Q
+from django.db.models import BooleanField, Case, Count, Q, Value, When
 from rest_framework import exceptions, serializers
 
 from dora.services.enums import ServiceStatus
@@ -284,12 +284,15 @@ class StructureSerializer(serializers.ModelSerializer):
                 required=False,
             )
 
+            can_user_edit = serializers.SerializerMethodField()
+
             num_services = serializers.SerializerMethodField()
 
             class Meta:
                 model = ServiceModel
                 fields = [
                     "categories_display",
+                    "can_user_edit",
                     "department",
                     "modification_date",
                     "name",
@@ -302,11 +305,36 @@ class StructureSerializer(serializers.ModelSerializer):
             def get_num_services(self, obj):
                 return obj.copies.exclude(status=ServiceStatus.ARCHIVED).count()
 
-        qs = ServiceModel.objects.filter(structure=structure)
+            def get_can_user_edit(self, obj):
+                return obj.can_user_edit
+
+        user = self.context.get("request").user
+        structures = [structure]
+
+        can_user_edit_base_structure = Value(
+            structure.can_edit_services(user), output_field=BooleanField()
+        )
+        can_user_edit_parent_structure = can_user_edit_base_structure
+        if structure.parent:
+            structures.append(structure.parent)
+            can_user_edit_parent_structure = Value(
+                structure.parent.can_edit_services(user), output_field=BooleanField()
+            )
+
+        qs = (
+            ServiceModel.objects.filter(structure__in=structures)
+            .annotate(
+                can_user_edit=Case(
+                    When(structure=structure, then=can_user_edit_base_structure),
+                    default=can_user_edit_parent_structure,
+                    output_field=BooleanField(),
+                )
+            )
+            .prefetch_related("categories")
+        )
+
         return StructureModelsSerializer(
-            qs.prefetch_related(
-                "categories",
-            ),
+            qs,
             many=True,
         ).data
 

--- a/back/dora/structures/serializers.py
+++ b/back/dora/structures/serializers.py
@@ -309,24 +309,21 @@ class StructureSerializer(serializers.ModelSerializer):
                 return obj.can_user_edit
 
         user = self.context.get("request").user
-        structures = [structure]
+        target_structures = [structure]
 
-        can_user_edit_base_structure = Value(
-            structure.can_edit_services(user), output_field=BooleanField()
-        )
-        can_user_edit_parent_structure = can_user_edit_base_structure
+        can_edit_current = structure.can_edit_services(user)
+        can_edit_parent = False
+
         if structure.parent:
-            structures.append(structure.parent)
-            can_user_edit_parent_structure = Value(
-                structure.parent.can_edit_services(user), output_field=BooleanField()
-            )
+            target_structures.append(structure.parent)
+            can_edit_parent = structure.parent.can_edit_services(user)
 
         qs = (
-            ServiceModel.objects.filter(structure__in=structures)
+            ServiceModel.objects.filter(structure__in=target_structures)
             .annotate(
                 can_user_edit=Case(
-                    When(structure=structure, then=can_user_edit_base_structure),
-                    default=can_user_edit_parent_structure,
+                    When(structure=structure, then=Value(can_edit_current)),
+                    default=Value(can_edit_parent),
                     output_field=BooleanField(),
                 )
             )

--- a/back/dora/structures/tests/test_structures.py
+++ b/back/dora/structures/tests/test_structures.py
@@ -197,11 +197,12 @@ class StructureTestCase(APITestCase):
             (self.superuser, True),
             (self.manager, True),
         ]
+
+        own_struct = make_structure(department="31")
+        make_structure_member(user=self.me, structure=own_struct)
+        make_model(structure=own_struct)
         for user, can_edit in cases:
             with self.subTest(user=user):
-                own_struct = make_structure()
-                make_structure_member(user=user, structure=own_struct)
-                make_model(structure=own_struct)
                 self.client.force_authenticate(user=user)
                 response = self.client.get(f"/structures/{own_struct.slug}/")
                 self.assertEqual(response.status_code, 200)
@@ -213,12 +214,13 @@ class StructureTestCase(APITestCase):
         """
         Le staff et les GTs (quand la structure est dans leur département) peuvent modifier les structures)
         """
-        make_model(structure=self.struct_31)
         cases = [
             (self.me, False),
             (self.superuser, True),
             (self.manager, True),
         ]
+        make_model(structure=self.struct_31)
+
         for user, can_edit in cases:
             with self.subTest(user=user):
                 self.client.force_authenticate(user=user)
@@ -236,13 +238,13 @@ class StructureTestCase(APITestCase):
             (self.superuser, True),
             (self.manager, True),
         ]
+        parent_struct = make_structure(department="31")
+        child_struct = make_structure(parent=parent_struct)
+        make_structure_member(user=self.me, structure=child_struct)
+        parent_model = make_model(structure=parent_struct)
 
         for user, can_edit in cases:
             with self.subTest(user=user):
-                parent_struct = make_structure(department="31")
-                child_struct = make_structure(parent=parent_struct)
-                make_structure_member(user=user, structure=child_struct)
-                parent_model = make_model(structure=parent_struct)
                 self.client.force_authenticate(user=user)
                 response = self.client.get(f"/structures/{child_struct.slug}/")
                 self.assertEqual(response.status_code, 200)
@@ -257,13 +259,14 @@ class StructureTestCase(APITestCase):
             (self.superuser, True),
             (self.manager, True),
         ]
+        parent_struct = make_structure(department="31")
+        child_struct = make_structure(parent=parent_struct)
+        make_structure_member(user=self.me, structure=child_struct)
+        make_structure_member(user=self.me, structure=parent_struct)
+        make_model(structure=parent_struct)
+
         for user, can_edit in cases:
             with self.subTest(user=user):
-                parent_struct = make_structure(department="31")
-                child_struct = make_structure(parent=parent_struct)
-                make_structure_member(user=user, structure=child_struct)
-                make_structure_member(user=user, structure=parent_struct)
-                make_model(structure=parent_struct)
                 self.client.force_authenticate(user=user)
                 response = self.client.get(f"/structures/{child_struct.slug}/")
                 self.assertEqual(response.status_code, 200)

--- a/back/dora/structures/tests/test_structures.py
+++ b/back/dora/structures/tests/test_structures.py
@@ -5,6 +5,7 @@ from model_bakery import baker
 from rest_framework.test import APITestCase
 
 from dora.core.test_utils import (
+    make_model,
     make_service,
     make_structure,
     make_structure_member,
@@ -187,6 +188,53 @@ class StructureTestCase(APITestCase):
         self.assertEqual(
             sorted(response.data["national_labels"]), sorted(national_labels)
         )
+
+    # Models can_user_edit
+
+    def test_user_can_see_and_edit_models_of_own_structure(self):
+        make_model(structure=self.my_struct)
+        response = self.client.get(f"/structures/{self.my_struct.slug}/")
+        self.assertEqual(response.status_code, 200)
+        models = response.data["models"]
+        self.assertEqual(len(models), 1)
+        self.assertTrue(models[0]["can_user_edit"])
+
+    def test_user_can_see_but_not_edit_model_when_not_structure_member(self):
+        make_model(structure=self.other_struct)
+        response = self.client.get(f"/structures/{self.other_struct.slug}/")
+        self.assertEqual(response.status_code, 200)
+        models = response.data["models"]
+        self.assertEqual(len(models), 1)
+        self.assertFalse(models[0]["can_user_edit"])
+
+    def test_user_can_see_models_of_parent_structure_but_cannot_edit_when_not_member_of_parent(
+        self,
+    ):
+        parent_struct = make_structure()
+        child_struct = make_structure(parent=parent_struct)
+        make_structure_member(user=self.me, structure=child_struct)
+        parent_model = make_model(structure=parent_struct)
+
+        response = self.client.get(f"/structures/{child_struct.slug}/")
+        self.assertEqual(response.status_code, 200)
+        models = response.data["models"]
+        self.assertEqual(len(models), 1)
+        self.assertEqual(parent_model.slug, models[0]["slug"])
+        self.assertFalse(models[0]["can_user_edit"])
+
+    def test_user_can_edit_parent_structure_models_when_member_of_parent(self):
+        parent_struct = make_structure()
+        child_struct = make_structure(parent=parent_struct)
+        make_structure_member(user=self.me, structure=child_struct)
+        make_structure_member(user=self.me, structure=parent_struct)
+        make_model(structure=parent_struct)
+
+        response = self.client.get(f"/structures/{child_struct.slug}/")
+        self.assertEqual(response.status_code, 200)
+        models = response.data["models"]
+        parent_models = [m for m in models if m["structure"] == parent_struct.slug]
+        self.assertEqual(len(parent_models), 1)
+        self.assertTrue(parent_models[0]["can_user_edit"])
 
     # Superuser
 

--- a/back/dora/structures/tests/test_structures.py
+++ b/back/dora/structures/tests/test_structures.py
@@ -192,49 +192,87 @@ class StructureTestCase(APITestCase):
     # Models can_user_edit
 
     def test_user_can_see_and_edit_models_of_own_structure(self):
-        make_model(structure=self.my_struct)
-        response = self.client.get(f"/structures/{self.my_struct.slug}/")
-        self.assertEqual(response.status_code, 200)
-        models = response.data["models"]
-        self.assertEqual(len(models), 1)
-        self.assertTrue(models[0]["can_user_edit"])
+        cases = [
+            (self.me, True),
+            (self.superuser, True),
+            (self.manager, True),
+        ]
+        for user, can_edit in cases:
+            with self.subTest(user=user):
+                own_struct = make_structure()
+                make_structure_member(user=user, structure=own_struct)
+                make_model(structure=own_struct)
+                self.client.force_authenticate(user=user)
+                response = self.client.get(f"/structures/{own_struct.slug}/")
+                self.assertEqual(response.status_code, 200)
+                models = response.data["models"]
+                self.assertEqual(len(models), 1)
+                self.assertEqual(models[0]["can_user_edit"], can_edit)
 
     def test_user_can_see_but_not_edit_model_when_not_structure_member(self):
-        make_model(structure=self.other_struct)
-        response = self.client.get(f"/structures/{self.other_struct.slug}/")
-        self.assertEqual(response.status_code, 200)
-        models = response.data["models"]
-        self.assertEqual(len(models), 1)
-        self.assertFalse(models[0]["can_user_edit"])
+        """
+        Le staff et les GTs (quand la structure est dans leur département) peuvent modifier les structures)
+        """
+        make_model(structure=self.struct_31)
+        cases = [
+            (self.me, False),
+            (self.superuser, True),
+            (self.manager, True),
+        ]
+        for user, can_edit in cases:
+            with self.subTest(user=user):
+                self.client.force_authenticate(user=user)
+                response = self.client.get(f"/structures/{self.struct_31.slug}/")
+                self.assertEqual(response.status_code, 200)
+                models = response.data["models"]
+                self.assertEqual(len(models), 1)
+                self.assertEqual(models[0]["can_user_edit"], can_edit)
 
     def test_user_can_see_models_of_parent_structure_but_cannot_edit_when_not_member_of_parent(
         self,
     ):
-        parent_struct = make_structure()
-        child_struct = make_structure(parent=parent_struct)
-        make_structure_member(user=self.me, structure=child_struct)
-        parent_model = make_model(structure=parent_struct)
+        cases = [
+            (self.me, False),
+            (self.superuser, True),
+            (self.manager, True),
+        ]
 
-        response = self.client.get(f"/structures/{child_struct.slug}/")
-        self.assertEqual(response.status_code, 200)
-        models = response.data["models"]
-        self.assertEqual(len(models), 1)
-        self.assertEqual(parent_model.slug, models[0]["slug"])
-        self.assertFalse(models[0]["can_user_edit"])
+        for user, can_edit in cases:
+            with self.subTest(user=user):
+                parent_struct = make_structure(department="31")
+                child_struct = make_structure(parent=parent_struct)
+                make_structure_member(user=user, structure=child_struct)
+                parent_model = make_model(structure=parent_struct)
+                self.client.force_authenticate(user=user)
+                response = self.client.get(f"/structures/{child_struct.slug}/")
+                self.assertEqual(response.status_code, 200)
+                models = response.data["models"]
+                self.assertEqual(len(models), 1)
+                self.assertEqual(parent_model.slug, models[0]["slug"])
+                self.assertEqual(models[0]["can_user_edit"], can_edit)
 
     def test_user_can_edit_parent_structure_models_when_member_of_parent(self):
-        parent_struct = make_structure()
-        child_struct = make_structure(parent=parent_struct)
-        make_structure_member(user=self.me, structure=child_struct)
-        make_structure_member(user=self.me, structure=parent_struct)
-        make_model(structure=parent_struct)
-
-        response = self.client.get(f"/structures/{child_struct.slug}/")
-        self.assertEqual(response.status_code, 200)
-        models = response.data["models"]
-        parent_models = [m for m in models if m["structure"] == parent_struct.slug]
-        self.assertEqual(len(parent_models), 1)
-        self.assertTrue(parent_models[0]["can_user_edit"])
+        cases = [
+            (self.me, True),
+            (self.superuser, True),
+            (self.manager, True),
+        ]
+        for user, can_edit in cases:
+            with self.subTest(user=user):
+                parent_struct = make_structure(department="31")
+                child_struct = make_structure(parent=parent_struct)
+                make_structure_member(user=user, structure=child_struct)
+                make_structure_member(user=user, structure=parent_struct)
+                make_model(structure=parent_struct)
+                self.client.force_authenticate(user=user)
+                response = self.client.get(f"/structures/{child_struct.slug}/")
+                self.assertEqual(response.status_code, 200)
+                models = response.data["models"]
+                parent_models = [
+                    m for m in models if m["structure"] == parent_struct.slug
+                ]
+                self.assertEqual(len(parent_models), 1)
+                self.assertEqual(parent_models[0]["can_user_edit"], can_edit)
 
     # Superuser
 

--- a/front/src/routes/structures/[slug]/modeles/list.svelte
+++ b/front/src/routes/structures/[slug]/modeles/list.svelte
@@ -83,10 +83,7 @@
 {:else}
   <div class="mb-s48 gap-s16 grid md:grid-cols-2 lg:grid-cols-3">
     {#each modelsOrdered as model}
-      <ModelCard
-        {model}
-        readOnly={!structure.canEditServices || !model.canUserEdit}
-      />
+      <ModelCard {model} readOnly={!model.canUserEdit} />
     {/each}
   </div>
 {/if}

--- a/front/src/routes/structures/[slug]/modeles/list.svelte
+++ b/front/src/routes/structures/[slug]/modeles/list.svelte
@@ -83,7 +83,10 @@
 {:else}
   <div class="mb-s48 gap-s16 grid md:grid-cols-2 lg:grid-cols-3">
     {#each modelsOrdered as model}
-      <ModelCard {model} readOnly={!structure.canEditServices || !model.canUserEdit} />
+      <ModelCard
+        {model}
+        readOnly={!structure.canEditServices || !model.canUserEdit}
+      />
     {/each}
   </div>
 {/if}

--- a/front/src/routes/structures/[slug]/modeles/list.svelte
+++ b/front/src/routes/structures/[slug]/modeles/list.svelte
@@ -83,7 +83,7 @@
 {:else}
   <div class="mb-s48 gap-s16 grid md:grid-cols-2 lg:grid-cols-3">
     {#each modelsOrdered as model}
-      <ModelCard {model} readOnly={!structure.canEditServices} />
+      <ModelCard {model} readOnly={!structure.canEditServices || !model.canUserEdit} />
     {/each}
   </div>
 {/if}


### PR DESCRIPTION
Pour une structure, la page qui montre les modèles de service montera les modèles de la structure même ET les modèles liées au parent de la structure (s'il y a en un). 

Par contre, l'utilisateur ne va ni voir le bouton `Modifier` ni pouvoir l'éditer en allant à la page directement. 

Le parent ne va pas voir les modèles de ses enfants qui est le comportement actuel. 