### PR TITLE
fix: cacher les infos de contact d'un service de DI quand les infos ne sont pas publiques

### DIFF
--- a/back/dora/api/serializers.py
+++ b/back/dora/api/serializers.py
@@ -1,5 +1,3 @@
-from django.conf import settings
-
 # from django.core.files.storage import default_storage
 from rest_framework import serializers
 
@@ -372,16 +370,19 @@ class ServiceSerializer(serializers.ModelSerializer):
         return obj.get_frontend_url()
 
     def get_telephone(self, obj):
-        assert self.context.get("request").user.email == settings.DATA_INCLUSION_EMAIL
-        return obj.contact_phone
+        if obj.is_contact_info_public:
+            return obj.contact_phone
+        return None
 
     def get_courriel(self, obj):
-        assert self.context.get("request").user.email == settings.DATA_INCLUSION_EMAIL
-        return obj.contact_email
+        if obj.is_contact_info_public:
+            return obj.contact_email
+        return None
 
     def get_contact_nom_prenom(self, obj):
-        assert self.context.get("request").user.email == settings.DATA_INCLUSION_EMAIL
-        return obj.contact_name
+        if obj.is_contact_info_public:
+            return obj.contact_name
+        return None
 
     def get_contact_public(self, obj):
         return obj.is_contact_info_public

--- a/back/dora/api/test_api.py
+++ b/back/dora/api/test_api.py
@@ -592,3 +592,22 @@ def test_service_without_suspension_date_is_included(authenticated_user, api_cli
     service = make_service(status=ServiceStatus.PUBLISHED, suspension_date=None)
     response = api_client.get(f"/api/v2/services/{service.id}/")
     assert 200 == response.status_code
+
+
+def test_service_does_not_include_contact_info_when_contact_info_is_not_public(
+    authenticated_user, api_client
+):
+    service = make_service(
+        is_contact_info_public=False,
+        status=ServiceStatus.PUBLISHED,
+        contact_email="private@email.com",
+        contact_phone="0123456789",
+        contact_name="Test Person",
+    )
+    response = api_client.get(f"/api/v2/services/{service.id}/")
+
+    assert response.status_code == 200
+
+    assert response.data["courriel"] is None
+    assert response.data["telephone"] is None
+    assert response.data["contact_nom_prenom"] is None


### PR DESCRIPTION
Ce PR cache les infos de contact (mail/phone/nom de contact) de DI quand `is_contact_info_public == False`

Dans le [modèle](https://github.com/gip-inclusion/data-inclusion/blob/ad9c4eadaa348d3bad014aa50e45dc9077643b3b/api/src/data_inclusion/api/inclusion_data/v1/models.py#L102-L128) d'un Service chez DI, ces trois champs sont nullables donc je passe `None` pour les cacher

Aussi, la [classe de permission exige](https://github.com/gip-inclusion/dora/blob/3e4bfb3399d7e24d4c250880135dcabdd1399933/back/dora/api/views.py#L29) que le mail de l'utilisateur qui fait l'appel à cette route soit celui de DI donc j'ai supprimé les assertions pour ces trois méthodes du serializer parce qu'ils sont redondants.
