### PR TITLE
feat: la structure créée par import a toujours le nom fourni dans le csv

### DIFF
--- a/back/dora/structures/csv_import.py
+++ b/back/dora/structures/csv_import.py
@@ -142,14 +142,14 @@ class ImportStructuresHelper:
     ) -> Structure:
         if parent_siret:
             parent_structure = self._get_or_create_structure_from_siret(
-                parent_siret, importing_user, is_parent=True, **kwargs
+                parent_siret, name, importing_user, is_parent=True, **kwargs
             )
             structure = self._get_or_create_branch(
                 name, siret, parent_structure, **kwargs
             )
         else:
             structure = self._get_or_create_structure_from_siret(
-                siret, importing_user, **kwargs
+                siret, name, importing_user, **kwargs
             )
 
         return structure
@@ -261,7 +261,12 @@ class ImportStructuresHelper:
         return branch
 
     def _get_or_create_structure_from_siret(
-        self, siret: str, importing_user: User, is_parent: bool = False, **kwargs
+        self,
+        siret: str,
+        name: str,
+        importing_user: User,
+        is_parent: bool = False,
+        **kwargs,
     ) -> Structure:
         try:
             structure = Structure.objects.get(siret=siret)
@@ -278,6 +283,8 @@ class ImportStructuresHelper:
             structure = Structure.objects.create_from_establishment(
                 establishment, **kwargs
             )
+            if not is_parent:
+                structure.name = name
             structure.creator = importing_user
             structure.last_editor = importing_user
             structure.source = self.source

--- a/back/dora/structures/tests/__snapshots__/test_import_structures.ambr
+++ b/back/dora/structures/tests/__snapshots__/test_import_structures.ambr
@@ -15,7 +15,7 @@
   list([
     '⚠️ PRODUCTION RUN ⚠️',
     '2. Import de la structure Foo (SIRET:12345678901234)',
-    'Création de la structure  My Establishment (Parent) (http://localhost:3000/structures/my-establishment-par)',
+    'Création de la structure  Foo (http://localhost:3000/structures/my-establishment-par)',
     'http://localhost:3000/structures/my-establishment-par',
     'foo@buzz.com invité·e comme administrateur·rice',
   ])

--- a/back/dora/structures/tests/test_import_structures.py
+++ b/back/dora/structures/tests/test_import_structures.py
@@ -494,7 +494,7 @@ class StructuresImportTestCase(APITestCase):
             name="My Establishment",
             parent_name="Parent",
         )
-        csv_content = f"{self.csv_headers}\nFoo,12345678901234,,foo@buzz.com,,,,email@structure.com"
+        csv_content = f"{self.csv_headers}\nNew structure,12345678901234,,foo@buzz.com,,,,email@structure.com"
         reader = csv.reader(io.StringIO(csv_content))
         result = self.import_structures_helper.import_structures(
             reader, self.importing_user, self.source_info, wet_run=True
@@ -505,7 +505,7 @@ class StructuresImportTestCase(APITestCase):
         self.assertTrue(
             Structure.objects.filter(
                 siret="12345678901234",
-                name="My Establishment (Parent)",
+                name="New structure",
                 email="email@structure.com",
             ).exists()
         )
@@ -517,7 +517,7 @@ class StructuresImportTestCase(APITestCase):
             name="My Establishment",
             parent_name="Parent",
         )
-        csv_content = f"{self.csv_headers}\nFoo,,12345678901234,foo@buzz.com,,,,email@structure.com"
+        csv_content = f"{self.csv_headers}\nNew structure,,12345678901234,foo@buzz.com,,,,email@structure.com"
         reader = csv.reader(io.StringIO(csv_content))
         result = self.import_structures_helper.import_structures(
             reader, self.importing_user, self.source_info, wet_run=True
@@ -535,7 +535,9 @@ class StructuresImportTestCase(APITestCase):
 
         self.assertTrue(
             Structure.objects.filter(
-                name="Foo", parent=parent_structure.first(), email="email@structure.com"
+                name="New structure",
+                parent=parent_structure.first(),
+                email="email@structure.com",
             ).exists()
         )
 


### PR DESCRIPTION
Quand on crée une structure par import, on n'applique le nom fourni dans la colonne `nom` que quand il s'agit d'une branche d'une antenne. L'objectif de ce PR est d'appliquer le nom fourni dans le csv à la nouvelle structure créée. 

Il y a trois cas qui sont possible :

1. on crée une nouvelle structure en fournissant le siret dans la colonne `siret` => 1 structure est créée est celle-ci a le nom fourni dans l'import 
2. on crée une structure avec un siret dans la colonne `parent_sirent` ET le parent existe déjà l'antenne a le nom fourni (le comportement reste le même)
3. on crée une structure avec un siret dans la colonne `parent_sirent` MAIS le parent n'existe PAS ENCORE => le parent a le nom de l'établissement en suivant la logique [ici](https://github.com/gip-inclusion/dora/blob/ba8a232de3afabce74137ee07f4edb5c0441d7ce/back/dora/sirene/serializers.py#L28) et la branche a le nom fourni dans la colonne `nom`