### PR TITLE
refactor: déplaces les appels d'api de `onMount` à `load`

### DIFF
--- a/front/src/lib/requests/admin.ts
+++ b/front/src/lib/requests/admin.ts
@@ -32,9 +32,9 @@ export async function getStructuresToModerate(fetchFunction = fetch) {
   return (await fetchData(url, fetchFunction)).data;
 }
 
-export async function getServicesAdmin() {
+export async function getServicesAdmin(fetchFunction = fetch) {
   const url = `${getApiURL()}/services-admin/`;
-  return (await fetchData(url)).data;
+  return (await fetchData(url, fetchFunction)).data;
 }
 
 export async function getServiceAdmin(slug: string, fetchFunction = fetch) {

--- a/front/src/lib/requests/admin.ts
+++ b/front/src/lib/requests/admin.ts
@@ -27,9 +27,9 @@ export async function getStructureAdmin(
   return (await fetchData<Structure>(url, fetchFunction)).data;
 }
 
-export async function getStructuresToModerate() {
+export async function getStructuresToModerate(fetchFunction = fetch) {
   const url = `${getApiURL()}/structures-admin/?moderation=1`;
-  return (await fetchData(url)).data;
+  return (await fetchData(url, fetchFunction)).data;
 }
 
 export async function getServicesAdmin() {

--- a/front/src/lib/requests/saved-search.ts
+++ b/front/src/lib/requests/saved-search.ts
@@ -97,3 +97,12 @@ export function getSavedSearchQueryString(savedSearch: SavedSearch) {
     fundingLabels: savedSearch.fundingLabels.sort(),
   });
 }
+
+export async function getSavedSearches(fetchFunction = fetch) {
+  const url = `${getApiURL()}/saved-searches/`;
+  const result = await fetchData(url, fetchFunction);
+  if (result.ok) {
+    return result.data as Array<SavedSearch>;
+  }
+  return [];
+}

--- a/front/src/lib/utils/moderation.ts
+++ b/front/src/lib/utils/moderation.ts
@@ -67,3 +67,43 @@ export function filterAndSortStructures(
     });
   return result;
 }
+export function filterAndSortServices(
+  services: Array<unknown>,
+  searchString: string
+): Array<unknown> {
+  return (
+    searchString
+      ? services.filter(
+          (entity) =>
+            entity.name.toLowerCase().includes(searchString) ||
+            entity.structureName.toLowerCase().includes(searchString) ||
+            entity.structureDept === searchString
+        )
+      : services
+  )
+    .filter((entity) => !entity.parent)
+    .sort((entity1, entity2) => {
+      if (entity1.structureDept !== entity2.structureDept) {
+        return entity1.structureDept.localeCompare(
+          entity2.structureDept,
+          "fr",
+          {
+            numeric: true,
+          }
+        );
+      }
+
+      if (
+        entity1.structureName.toLowerCase() !==
+        entity2.structureName.toLowerCase()
+      ) {
+        return entity1.structureName
+          .toLowerCase()
+          .localeCompare(entity2.structureName.toLowerCase(), "fr");
+      }
+
+      return entity1.name
+        .toLowerCase()
+        .localeCompare(entity2.name.toLowerCase(), "fr");
+    });
+}

--- a/front/src/lib/utils/moderation.ts
+++ b/front/src/lib/utils/moderation.ts
@@ -1,0 +1,69 @@
+const STATUS_VALUE = {
+  NEED_INITIAL_MODERATION: 1,
+  NEED_NEW_MODERATION: 2,
+  IN_PROGRESS: 3,
+  VALIDATED: 4,
+};
+
+export function filterAndSortStructures(
+  entities: Array<unknown>,
+  searchString: string
+): Array<unknown> {
+  const result = (
+    searchString
+      ? entities.filter((entity) => {
+          if (entity.isStructure) {
+            return (
+              entity.name.toLowerCase().includes(searchString) ||
+              entity.department === searchString
+            );
+          } else {
+            return (
+              entity.name.toLowerCase().includes(searchString) ||
+              entity.structureName.toLowerCase().includes(searchString) ||
+              entity.structureDept === searchString
+            );
+          }
+        })
+      : entities
+  )
+    .filter((entity) => !entity.parent)
+    .sort((entity1, entity2) => {
+      // On tri d'abord par statut de modération
+      const val1 = entity1.moderationStatus
+        ? STATUS_VALUE[entity1.moderationStatus]
+        : 999;
+      const val2 = entity2.moderationStatus
+        ? STATUS_VALUE[entity2.moderationStatus]
+        : 999;
+      if (val1 !== val2) {
+        return val1 - val2;
+      }
+      // Puis les structures en premier
+      if (entity1.isStructure && !entity2.isStructure) {
+        return -1;
+      }
+      if (entity2.isStructure && !entity1.isStructure) {
+        return 1;
+      }
+      // Puis par dept de structure
+      const sdept1 = entity1.isStructure
+        ? entity1.department
+        : entity1.structureDept;
+      const sdept2 = entity1.isStructure
+        ? entity1.department
+        : entity1.structureDept;
+      if (sdept1 !== sdept2) {
+        return sdept1 > sdept2;
+      }
+      // Puis par nom de structure
+      const sname1 = entity1.isStructure ? entity1.name : entity1.structureName;
+      const sname2 = entity1.isStructure ? entity1.name : entity1.structureName;
+      if (sname1 !== sname2) {
+        return sname1 > sname2;
+      }
+      // Finalement par nom
+      return entity1.name > entity2.name;
+    });
+  return result;
+}

--- a/front/src/routes/admin/moderation/+page.svelte
+++ b/front/src/routes/admin/moderation/+page.svelte
@@ -4,87 +4,19 @@
   import EyeLineSystem from "svelte-remix/EyeLineSystem.svelte";
   import { capitalize, shortenString } from "$lib/utils/misc";
   import ModerationLabel from "../moderation-label.svelte";
+  import { filterAndSortStructures } from "$lib/utils/moderation";
 
   let { data } = $props();
 
   let entities = $state([]);
   let searchString = $state("");
-  let filteredEntities = $derived(filterAndSortEntities(searchString));
+  let filteredEntities = $derived(
+    filterAndSortStructures(entities, searchString)
+  );
 
   data.structures.then((structures) => {
     entities = [...structures];
   });
-
-  const STATUS_VALUE = {
-    NEED_INITIAL_MODERATION: 1,
-    NEED_NEW_MODERATION: 2,
-    IN_PROGRESS: 3,
-    VALIDATED: 4,
-  };
-
-  function filterAndSortEntities(searchString: string) {
-    const result = (
-      searchString
-        ? entities.filter((entity) => {
-            if (entity.isStructure) {
-              return (
-                entity.name.toLowerCase().includes(searchString) ||
-                entity.department === searchString
-              );
-            } else {
-              return (
-                entity.name.toLowerCase().includes(searchString) ||
-                entity.structureName.toLowerCase().includes(searchString) ||
-                entity.structureDept === searchString
-              );
-            }
-          })
-        : entities
-    )
-      .filter((entity) => !entity.parent)
-      .sort((entity1, entity2) => {
-        // On tri d'abord par statut de modération
-        const val1 = entity1.moderationStatus
-          ? STATUS_VALUE[entity1.moderationStatus]
-          : 999;
-        const val2 = entity2.moderationStatus
-          ? STATUS_VALUE[entity2.moderationStatus]
-          : 999;
-        if (val1 !== val2) {
-          return val1 - val2;
-        }
-        // Puis les structures en premier
-        if (entity1.isStructure && !entity2.isStructure) {
-          return -1;
-        }
-        if (entity2.isStructure && !entity1.isStructure) {
-          return 1;
-        }
-        // Puis par dept de structure
-        const sdept1 = entity1.isStructure
-          ? entity1.department
-          : entity1.structureDept;
-        const sdept2 = entity1.isStructure
-          ? entity1.department
-          : entity1.structureDept;
-        if (sdept1 !== sdept2) {
-          return sdept1 > sdept2;
-        }
-        // Puis par nom de structure
-        const sname1 = entity1.isStructure
-          ? entity1.name
-          : entity1.structureName;
-        const sname2 = entity1.isStructure
-          ? entity1.name
-          : entity1.structureName;
-        if (sname1 !== sname2) {
-          return sname1 > sname2;
-        }
-        // Finalement par nom
-        return entity1.name > entity2.name;
-      });
-    return result;
-  }
 
   function handleFilterChange(event) {
     searchString = event.target.value.toLowerCase().trim();

--- a/front/src/routes/admin/moderation/+page.svelte
+++ b/front/src/routes/admin/moderation/+page.svelte
@@ -45,7 +45,7 @@
 
     {#await data.structures}
       Chargement…
-    {:then}
+    {:then _}
       {#if !entities.length}
         Rien à modérer 🎉
       {:else}

--- a/front/src/routes/admin/moderation/+page.svelte
+++ b/front/src/routes/admin/moderation/+page.svelte
@@ -2,15 +2,18 @@
   import CenteredGrid from "$lib/components/display/centered-grid.svelte";
   import LinkButton from "$lib/components/display/link-button.svelte";
   import EyeLineSystem from "svelte-remix/EyeLineSystem.svelte";
-  import { getStructuresToModerate } from "$lib/requests/admin";
   import { capitalize, shortenString } from "$lib/utils/misc";
-  import { onMount } from "svelte";
   import ModerationLabel from "../moderation-label.svelte";
 
-  // let services,
-  let structures,
-    entities = $state();
-  let filteredEntities = $state([]);
+  let { data } = $props();
+
+  let entities = $state([]);
+  let searchString = $state("");
+  let filteredEntities = $derived(filterAndSortEntities(searchString));
+
+  data.structures.then((structures) => {
+    entities = [...structures];
+  });
 
   const STATUS_VALUE = {
     NEED_INITIAL_MODERATION: 1,
@@ -19,7 +22,7 @@
     VALIDATED: 4,
   };
 
-  function filterAndSortEntities(searchString) {
+  function filterAndSortEntities(searchString: string) {
     const result = (
       searchString
         ? entities.filter((entity) => {
@@ -84,16 +87,8 @@
   }
 
   function handleFilterChange(event) {
-    const searchString = event.target.value.toLowerCase().trim();
-    filteredEntities = filterAndSortEntities(searchString);
+    searchString = event.target.value.toLowerCase().trim();
   }
-
-  onMount(async () => {
-    structures = await getStructuresToModerate();
-    structures.forEach((struct) => (struct.isStructure = true));
-    entities = [...structures];
-    filteredEntities = filterAndSortEntities("");
-  });
 </script>
 
 <CenteredGrid>
@@ -116,7 +111,9 @@
       {/if}
     </div>
 
-    {#if entities}
+    {#await data.structures}
+      Chargement…
+    {:then}
       {#if !entities.length}
         Rien à modérer 🎉
       {:else}
@@ -171,8 +168,6 @@
           </div>
         {/each}
       {/if}
-    {:else}
-      Chargement…
-    {/if}
+    {/await}
   </div>
 </CenteredGrid>

--- a/front/src/routes/admin/moderation/+page.ts
+++ b/front/src/routes/admin/moderation/+page.ts
@@ -1,7 +1,11 @@
 import type { PageLoad } from "./$types";
+import { getStructuresToModerate } from "$lib/requests/admin";
 
-export const load: PageLoad = () => {
+export const load: PageLoad = ({ fetch }) => {
   return {
+    structures: getStructuresToModerate(fetch).then((list) =>
+      list.map((struct) => ({ ...struct, isStructure: true }))
+    ),
     title: "Modération | Administration | DORA",
     noIndex: true,
   };

--- a/front/src/routes/admin/services/+page.svelte
+++ b/front/src/routes/admin/services/+page.svelte
@@ -51,7 +51,7 @@
     </div>
 
     {#await data.services}
-      Chargement...
+      Chargement…
     {:then _}
       {#each filteredServices as service}
         <div

--- a/front/src/routes/admin/services/+page.svelte
+++ b/front/src/routes/admin/services/+page.svelte
@@ -1,65 +1,34 @@
 <script lang="ts">
-  import { onMount } from "svelte";
-
   import EyeLineSystem from "svelte-remix/EyeLineSystem.svelte";
   import Home6LineBuildings from "svelte-remix/Home6LineBuildings.svelte";
 
   import CenteredGrid from "$lib/components/display/centered-grid.svelte";
   import Label from "$lib/components/display/label.svelte";
   import LinkButton from "$lib/components/display/link-button.svelte";
-  import { getServicesAdmin } from "$lib/requests/admin";
   import { shortenString } from "$lib/utils/misc";
+  import { filterAndSortServices } from "$lib/utils/moderation";
 
-  let services = $state(),
-    filteredServices = $state();
+  let { data } = $props();
 
-  function filterAndSortEntities(searchString) {
-    return (
-      searchString
-        ? services.filter(
-            (entity) =>
-              entity.name.toLowerCase().includes(searchString) ||
-              entity.structureName.toLowerCase().includes(searchString) ||
-              entity.structureDept === searchString
-          )
-        : services
-    )
-      .filter((entity) => !entity.parent)
-      .sort((entity1, entity2) => {
-        if (entity1.structureDept !== entity2.structureDept) {
-          return entity1.structureDept.localeCompare(
-            entity2.structureDept,
-            "fr",
-            {
-              numeric: true,
-            }
-          );
-        }
+  let services = $state([]);
+  let searchString = $state("");
+  let filteredServices = $derived(
+    filterAndSortServices(services, searchString)
+  );
 
-        if (
-          entity1.structureName.toLowerCase() !==
-          entity2.structureName.toLowerCase()
-        ) {
-          return entity1.structureName
-            .toLowerCase()
-            .localeCompare(entity2.structureName.toLowerCase(), "fr");
-        }
+  data.services.then((result) => {
+    services = result;
+  });
 
-        return entity1.name
-          .toLowerCase()
-          .localeCompare(entity2.name.toLowerCase(), "fr");
-      });
-  }
+  let debounceTimer: ReturnType<typeof setTimeout>;
 
   function handleFilterChange(event) {
-    const searchString = event.target.value.toLowerCase().trim();
-    filteredServices = filterAndSortEntities(searchString);
+    const value = event.target.value.toLowerCase().trim();
+    clearTimeout(debounceTimer);
+    debounceTimer = setTimeout(() => {
+      searchString = value;
+    }, 300);
   }
-
-  onMount(async () => {
-    services = await getServicesAdmin();
-    filteredServices = filterAndSortEntities("");
-  });
 </script>
 
 <CenteredGrid>
@@ -81,7 +50,9 @@
       {/if}
     </div>
 
-    {#if services}
+    {#await data.services}
+      Chargement...
+    {:then _}
       {#each filteredServices as service}
         <div
           class="gap-s16 border-gray-01 p-s16 flex flex-row items-center rounded-lg border bg-white"
@@ -114,8 +85,6 @@
           </div>
         </div>
       {/each}
-    {:else}
-      Chargement…
-    {/if}
+    {/await}
   </div>
 </CenteredGrid>

--- a/front/src/routes/admin/services/+page.ts
+++ b/front/src/routes/admin/services/+page.ts
@@ -1,7 +1,9 @@
 import type { PageLoad } from "./$types";
+import { getServicesAdmin } from "$lib/requests/admin";
 
-export const load: PageLoad = () => {
+export const load: PageLoad = ({ fetch }) => {
   return {
+    services: getServicesAdmin(fetch),
     title: "Services | Administration | DORA",
     noIndex: true,
   };

--- a/front/src/routes/mes-alertes/+page.svelte
+++ b/front/src/routes/mes-alertes/+page.svelte
@@ -7,31 +7,21 @@
   import CenteredGrid from "$lib/components/display/centered-grid.svelte";
   import EnsureLoggedIn from "$lib/components/hoc/ensure-logged-in.svelte";
   import type { SavedSearch } from "$lib/types";
-  import { getApiURL } from "$lib/utils/api";
   import { refreshUserInfo, userInfo } from "$lib/utils/auth";
-  import { fetchData } from "$lib/utils/misc";
-  import { onMount } from "svelte";
   import SavedSearchCard from "./saved-search-card.svelte";
   import { URL_HELP_SITE } from "$lib/consts";
 
-  let savedSearches: SavedSearch[] | undefined = $state();
+  let { data } = $props();
 
-  async function getSavedSearches() {
-    const url = `${getApiURL()}/saved-searches/`;
-    const result = await fetchData(url);
-    if (result.ok) {
-      return result.data as Array<SavedSearch>;
-    }
-    return [];
-  }
+  let savedSearches: SavedSearch[] = $state([]);
 
   function handleDelete(searchId: number) {
-    savedSearches = savedSearches?.filter((search) => search.id !== searchId);
+    savedSearches = savedSearches.filter((search) => search.id !== searchId);
     refreshUserInfo();
   }
 
-  onMount(async () => {
-    savedSearches = await getSavedSearches();
+  data.savedSearches.then((result) => {
+    savedSearches = result;
   });
 </script>
 
@@ -42,61 +32,63 @@
     <div class="mb-s32">
       <Breadcrumb currentLocation="saved-searches" />
     </div>
-    {#if savedSearches == null}
+    {#await data.savedSearches}
       <p class="mb-s40 text-f16 text-gray-dark">Chargement…</p>
-    {:else if savedSearches.length}
-      <p class="mb-s40 text-f21 text-gray-dark font-bold">
-        {$userInfo.savedSearches.length} alerte{$userInfo.savedSearches.length >
-        1
-          ? "s"
-          : ""}
-      </p>
-      <div class="gap-s16 flex flex-col">
-        {#each savedSearches as search}
-          <SavedSearchCard {search} onDelete={handleDelete} />
-        {/each}
-      </div>
-    {:else}
-      <div
-        class="gap-s40 border-gray-03 px-s20 py-s32 flex flex-col-reverse items-center justify-center rounded-lg border lg:flex-row"
-      >
-        <div class="max-w-lg basis-1/2 text-center">
-          <div class="mb-s12 h-s24 w-s24 mx-auto">
-            <BookmarkLineBusiness />
-          </div>
-          <h2 class="legend text-f32 text-gray-text leading-40 font-bold">
-            Vous n’avez pas encore créé d’alerte
-          </h2>
-          <p class="legend">
-            Pour mettre en place votre première alerte, il vous suffit
-            d’effectuer une recherche pour un lieu spécifique, ou pour un lieu
-            et une thématique combinés. Une fois que vous êtes sur la page des
-            résultats, il vous faudra simplement cliquer sur le bouton
-            "Sauvegarder la recherche". Dès qu’un nouveau service répondant à
-            ces critères est ajouté sur DORA, vous recevrez une notification par
-            e-mail.
-          </p>
+    {:then _}
+      {#if savedSearches.length}
+        <p class="mb-s40 text-f21 text-gray-dark font-bold">
+          {$userInfo.savedSearches.length} alerte{$userInfo.savedSearches
+            .length > 1
+            ? "s"
+            : ""}
+        </p>
+        <div class="gap-s16 flex flex-col">
+          {#each savedSearches as search}
+            <SavedSearchCard {search} onDelete={handleDelete} />
+          {/each}
+        </div>
+      {:else}
+        <div
+          class="gap-s40 border-gray-03 px-s20 py-s32 flex flex-col-reverse items-center justify-center rounded-lg border lg:flex-row"
+        >
+          <div class="max-w-lg basis-1/2 text-center">
+            <div class="mb-s12 h-s24 w-s24 mx-auto">
+              <BookmarkLineBusiness />
+            </div>
+            <h2 class="legend text-f32 text-gray-text leading-40 font-bold">
+              Vous n’avez pas encore créé d’alerte
+            </h2>
+            <p class="legend">
+              Pour mettre en place votre première alerte, il vous suffit
+              d’effectuer une recherche pour un lieu spécifique, ou pour un lieu
+              et une thématique combinés. Une fois que vous êtes sur la page des
+              résultats, il vous faudra simplement cliquer sur le bouton
+              "Sauvegarder la recherche". Dès qu’un nouveau service répondant à
+              ces critères est ajouté sur DORA, vous recevrez une notification
+              par e-mail.
+            </p>
 
-          <a
-            target="_blank"
-            title="Ouverture dans une nouvelle fenêtre"
-            rel="noopener"
-            href={`${URL_HELP_SITE}article/alertes-comment-enregistrer-des-recherches-1xpnlc9/?bust=1698336652095`}
-            class="text-magenta-cta inline-block h-full"
-          >
-            Découvrez comment créer une alerte
-            <span
-              class="h-s20 w-s20 pl-s4 pt-s6 inline-block fill-current"
-              aria-hidden="true"
+            <a
+              target="_blank"
+              title="Ouverture dans une nouvelle fenêtre"
+              rel="noopener"
+              href={`${URL_HELP_SITE}article/alertes-comment-enregistrer-des-recherches-1xpnlc9/?bust=1698336652095`}
+              class="text-magenta-cta inline-block h-full"
             >
-              <ExternalLinkLineSystem />
-            </span>
-          </a>
+              Découvrez comment créer une alerte
+              <span
+                class="h-s20 w-s20 pl-s4 pt-s6 inline-block fill-current"
+                aria-hidden="true"
+              >
+                <ExternalLinkLineSystem />
+              </span>
+            </a>
+          </div>
+          <div class="shrink-0">
+            <img src={illustration} alt="" />
+          </div>
         </div>
-        <div class="shrink-0">
-          <img src={illustration} alt="" />
-        </div>
-      </div>
-    {/if}
+      {/if}
+    {/await}
   </CenteredGrid>
 </EnsureLoggedIn>

--- a/front/src/routes/mes-alertes/+page.ts
+++ b/front/src/routes/mes-alertes/+page.ts
@@ -1,11 +1,13 @@
 import type { PageLoad } from "./$types";
+import { getSavedSearches } from "$lib/requests/saved-search";
 
 export const ssr = false;
 
-export const load: PageLoad = async ({ parent }) => {
+export const load: PageLoad = async ({ parent, fetch }) => {
   await parent();
 
   return {
+    savedSearches: getSavedSearches(fetch),
     title: "Mes alertes | DORA",
     noIndex: true,
   };


### PR DESCRIPTION
Il y a trois endroits où on fait l'appel api pour alimenter la page dans `onMount` et pas dans le `load()`
1. [dora/front/src/routes/admin/moderation/+page.svelte](https://github.com/gip-inclusion/dora/blob/e9b5492d4895490802ad25a1b538fabc6d02b6e0/front/src/routes/admin/moderation/+page.svelte#L92)
2. [dora/front/src/routes/admin/services/+page.svelte](https://github.com/gip-inclusion/dora/blob/e9b5492d4895490802ad25a1b538fabc6d02b6e0/front/src/routes/admin/services/+page.svelte#L60)
3. [dora/front/src/routes/mes-alertes/+page.svelte](https://github.com/gip-inclusion/dora/blob/2c96f8d2ef7d8d921b9cab53c8942e5eecec3ecb/front/src/routes/mes-alertes/+page.svelte#L33)

Pour répliquer le même comportement où on montre `Chargement...` jusqu'à ce que l'appel finisse, je passe la promesse pas encore résolue depuis `load` jusqu'au navigateur et on attend sa résolution. Ça nous permet d'utiliser `{#await}` et `{:then}` pour montrer l'état de chargement. 

Dans `/admin/services`, le saisi du texte dans la barre de recherche est très lent à cause du grand nombre de services. C'est pour ça j'ai ajouté un timeout pour améliorer le problème.  