### PR TITLE
fix: transmettre une vraie instance Error à Sentry depuis +error.svelte

### DIFF
--- a/front/src/routes/+error.svelte
+++ b/front/src/routes/+error.svelte
@@ -11,7 +11,7 @@
 
   onMount(() => {
     if (!notFound) {
-      logException($page.error);
+      logException(new Error($page.error?.message ?? String($page.status)));
     }
   });
 </script>


### PR DESCRIPTION
Dans `+error.svelte`, `logException($page.error)` transmettait un objet plat { message: string } à Sentry. SvelteKit sérialise les erreurs entre le serveur et le client, donc $page.error n'est jamais une instance d'Error. Sentry le signalait comme : "Object captured as exception with keys: message".

Ce PR enveloppe `$page.error` dans une vraie instance Error avant de l'envoyer à Sentry pour avoir le format nécessaire et d'éviter ce problème.

avant (sans stack trace): 
<img width="665" height="886" alt="Screenshot 2026-04-15 at 16 39 45" src="https://github.com/user-attachments/assets/58e184a7-a99a-4041-8f7a-db2a33065cdf" />

après (avec stack trace):
<img width="665" height="886" alt="Screenshot 2026-04-15 at 16 34 38" src="https://github.com/user-attachments/assets/f941dfd7-e990-4190-80c6-ae861675b619" />
