### PR TITLE
fix: assurer que `getManagedStructures()` renvoie toujours une liste

### DIFF
--- a/front/src/lib/requests/structures.ts
+++ b/front/src/lib/requests/structures.ts
@@ -66,8 +66,12 @@ export async function getManagedStructures(
   const url = `${getApiURL()}/structures/?managed=1${searchParam}`;
   try {
     const result = await fetchData<ShortStructure[]>(url);
+    if (!result.ok) {
+      logException(new Error(`getManagedStructures: ${result.status} ${result.error}`));
+    }
     return result.data ?? [];
-  } catch {
+  } catch (err) {
+    logException(err);
     return [];
   }
 }

--- a/front/src/lib/requests/structures.ts
+++ b/front/src/lib/requests/structures.ts
@@ -64,7 +64,12 @@ export async function getManagedStructures(
 ): Promise<ShortStructure[]> {
   const searchParam = searchText ? `&search=${searchText}` : "";
   const url = `${getApiURL()}/structures/?managed=1${searchParam}`;
-  return (await fetchData<ShortStructure[]>(url)).data;
+  try {
+    const result = await fetchData<ShortStructure[]>(url);
+    return result.data ?? [];
+  } catch {
+    return [];
+  }
 }
 
 export async function getActiveStructures({

--- a/front/src/lib/requests/structures.ts
+++ b/front/src/lib/requests/structures.ts
@@ -67,7 +67,9 @@ export async function getManagedStructures(
   try {
     const result = await fetchData<ShortStructure[]>(url);
     if (!result.ok) {
-      logException(new Error(`getManagedStructures: ${result.status} ${result.error}`));
+      logException(
+        new Error(`getManagedStructures: ${result.status} ${result.error}`)
+      );
     }
     return result.data ?? [];
   } catch (err) {


### PR DESCRIPTION
https://inclusion.sentry.io/issues/112309498/?environment=production&project=4509599011045456&query=is%3Aunresolved&referrer=issue-stream

il y a une erreur quand `structures` n'est pas défini mais on fait `structures.map` en présumant que c'est toujours une liste. le problème vient de l'appel api qui cherche les structures. Ce PR fait en sorte qu'on renvoie toujours une liste pour éviter cette erreur