### PR TITLE
fix: ne remonte pas d'erreur en cas d'échec de récupération du menu Nexus

### DIFF
--- a/front/src/lib/requests/nexus.ts
+++ b/front/src/lib/requests/nexus.ts
@@ -25,10 +25,10 @@ export const getNexusMenuStatus = async () => {
       Authorization: `Token ${getToken()}`,
     },
   });
-  if (!response.ok) {
-    throw new Error("Failed to fetch Nexus menu status");
+  if (response.ok) {
+    return response.json() as Promise<NexusMenuStatus>;
   }
-  return response.json() as Promise<NexusMenuStatus>;
+  return undefined;
 };
 
 type OrientationBeneficiaryInfoData = {


### PR DESCRIPTION
## Contexte

Erreur Sentry : https://inclusion.sentry.io/issues/112142526/events/2f6547b37aa54f7eb2728cefc16c9164/

Certains appels de récupération du statut du menu Nexus mènent à une erreur 401. Comme cette appel est fait lorsque l'utilisateur est connecté (dans `menu.svelte`), cette erreur ne devrait en théorie pas se produire.

## Hypothèse

Le token utilisateur stocké dans le navigateur n'est plus valide côté backend au moment de cet appel, tandis que le frontend ne l'a pas encore invalidé.

## Solution

Ce n'est pas un vrai problème. Si le endpoint était vraiment en erreur (type 500), on aurait une erreur remontée sur Sentry depuis le backend. On peut donc se contenter d'éviter de générer une exception côté frontend.