### PR TITLE
feat: retente les appels à la BAN en cas d'erreur 5xx ou réseau

### DIFF
--- a/front/src/lib/components/inputs/geo/street-search.svelte
+++ b/front/src/lib/components/inputs/geo/street-search.svelte
@@ -1,10 +1,16 @@
 <script lang="ts">
+  import { getContext } from "svelte";
+
+  import * as Sentry from "@sentry/sveltekit";
+
   import Select from "$lib/components/inputs/select/select.svelte";
+
+  import { fetchWithRetry } from "$lib/utils/fetch-retry";
+
   import {
     contextValidationKey,
     type ValidationContext,
   } from "$lib/validation/validation";
-  import { getContext } from "svelte";
 
   interface Props {
     id: string;
@@ -30,19 +36,32 @@
 
   const banAPIUrl = "https://api-adresse.data.gouv.fr/search/";
 
-  async function searchAddress(query) {
+  async function searchAddress(query: string) {
     const url = `${banAPIUrl}?q=${encodeURIComponent(
       query
     )}&limit=10&citycode=${cityCode}`;
-    const response = await fetch(url);
-    const jsonResponse = await response.json();
-    const results = jsonResponse.features
-      .filter((feature) => feature.properties.type !== "municipality")
-      .map((feature) => ({
-        value: feature,
-        label: feature.properties.name,
-      }));
-    return results;
+
+    try {
+      const response = await fetchWithRetry(url, undefined, {
+        maxAttempts: 3,
+      });
+
+      if (!response.ok) {
+        return [];
+      }
+
+      const jsonResponse = await response.json();
+      const results = jsonResponse.features
+        .filter((feature) => feature.properties.type !== "municipality")
+        .map((feature) => ({
+          value: feature,
+          label: feature.properties.name,
+        }));
+      return results;
+    } catch (error) {
+      Sentry.captureException(error);
+      return [];
+    }
   }
 
   const context = getContext<ValidationContext>(contextValidationKey);
@@ -64,8 +83,8 @@
   {disabled}
   hideArrow
   searchFunction={searchAddress}
-  delay="200"
+  delay={200}
   localFiltering={false}
-  minCharactersToSearch="3"
+  minCharactersToSearch={3}
   {readonly}
 />

--- a/front/src/lib/components/inputs/geo/street-search.svelte
+++ b/front/src/lib/components/inputs/geo/street-search.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { getContext } from "svelte";
+  import { getContext, onDestroy } from "svelte";
 
   import * as Sentry from "@sentry/sveltekit";
 
@@ -35,16 +35,25 @@
   }: Props = $props();
 
   const banAPIUrl = "https://api-adresse.data.gouv.fr/search/";
+  let currentSearchController: AbortController | undefined;
 
   async function searchAddress(query: string) {
+    currentSearchController?.abort();
+    const controller = new AbortController();
+    currentSearchController = controller;
+
     const url = `${banAPIUrl}?q=${encodeURIComponent(
       query
     )}&limit=10&citycode=${cityCode}`;
 
     try {
-      const response = await fetchWithRetry(url, undefined, {
-        maxAttempts: 3,
-      });
+      const response = await fetchWithRetry(
+        url,
+        { signal: controller.signal },
+        {
+          maxAttempts: 3,
+        }
+      );
 
       if (!response.ok) {
         return [];
@@ -59,10 +68,21 @@
         }));
       return results;
     } catch (error) {
+      if (error instanceof DOMException && error.name === "AbortError") {
+        return [];
+      }
       Sentry.captureException(error);
       return [];
+    } finally {
+      if (currentSearchController === controller) {
+        currentSearchController = undefined;
+      }
     }
   }
+
+  onDestroy(() => {
+    currentSearchController?.abort();
+  });
 
   const context = getContext<ValidationContext>(contextValidationKey);
 

--- a/front/src/lib/utils/fetch-retry.ts
+++ b/front/src/lib/utils/fetch-retry.ts
@@ -1,0 +1,44 @@
+import { sleep } from "$lib/utils/misc";
+
+export type FetchRetryOptions = {
+  maxAttempts?: number;
+  fetchFn?: typeof fetch;
+};
+
+/**
+ * `fetch` avec retry (ex: 500/504) + backoff + timeout.
+ * Ne monkey-patche pas `window.fetch`: l'appelant choisit explicitement de l'utiliser.
+ */
+export function fetchWithRetry(
+  input: RequestInfo | URL,
+  init?: RequestInit,
+  options?: FetchRetryOptions
+): Promise<Response> {
+  const fetchFn = options?.fetchFn ?? fetch;
+  const maxAttempts = options?.maxAttempts ?? 3;
+
+  async function attempt(attemptIndex: number): Promise<Response> {
+    try {
+      const response = await fetchFn(input, init);
+      if (response.status < 500 || response.status >= 600) {
+        return response;
+      }
+      if (attemptIndex === maxAttempts - 1) {
+        return response;
+      }
+    } catch (error) {
+      if (attemptIndex === maxAttempts - 1 || init?.signal?.aborted) {
+        throw error;
+      }
+    }
+
+    const exponentialBackoff = 250 * Math.pow(2, attemptIndex);
+    const boundedBackoff = Math.min(1000, exponentialBackoff);
+    const jitter = Math.random() * 150;
+    const delayMs = boundedBackoff + jitter;
+    await sleep(delayMs);
+    return attempt(attemptIndex + 1);
+  }
+
+  return attempt(0);
+}

--- a/front/src/lib/utils/misc.ts
+++ b/front/src/lib/utils/misc.ts
@@ -264,3 +264,7 @@ export function debounce<T extends (...args: any[]) => any>(
     });
   };
 }
+
+export function sleep(milliseconds: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, milliseconds));
+}

--- a/front/src/tests/utils/fetch/fetchWithRetry.test.ts
+++ b/front/src/tests/utils/fetch/fetchWithRetry.test.ts
@@ -1,0 +1,91 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import { fetchWithRetry } from "$lib/utils/fetch-retry";
+import { sleep } from "$lib/utils/misc";
+
+vi.mock("$lib/utils/misc", () => ({
+  // on mocke la fonction sleep pour ne pas attendre réellement durant les tests
+  sleep: vi.fn().mockResolvedValue(undefined),
+}));
+
+describe("fetchWithRetry", () => {
+  const sleepMock = vi.mocked(sleep);
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test("retourne la reponse immediatement si le status n'est pas 5xx", async () => {
+    const fetchFn = vi
+      .fn()
+      .mockResolvedValue(new Response(null, { status: 200 }));
+
+    const response = await fetchWithRetry("https://example.com", undefined, {
+      fetchFn,
+    });
+
+    expect(response.status).toBe(200);
+    expect(fetchFn).toHaveBeenCalledTimes(1);
+    expect(sleepMock).not.toHaveBeenCalled();
+  });
+
+  test("retente quand le serveur renvoie 5xx puis réussit", async () => {
+    const fetchFn = vi
+      .fn()
+      .mockResolvedValueOnce(new Response(null, { status: 500 }))
+      .mockResolvedValueOnce(new Response(null, { status: 200 }));
+
+    const response = await fetchWithRetry("https://example.com", undefined, {
+      fetchFn,
+      maxAttempts: 3,
+    });
+
+    expect(response.status).toBe(200);
+    expect(fetchFn).toHaveBeenCalledTimes(2);
+    expect(sleepMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("renvoie la dernière réponse 5xx quand maxAttempts est atteint", async () => {
+    const fetchFn = vi
+      .fn()
+      .mockResolvedValue(new Response(null, { status: 503 }));
+
+    const response = await fetchWithRetry("https://example.com", undefined, {
+      fetchFn,
+      maxAttempts: 3,
+    });
+
+    expect(response.status).toBe(503);
+    expect(fetchFn).toHaveBeenCalledTimes(3);
+    expect(sleepMock).toHaveBeenCalledTimes(2);
+  });
+
+  test("retente apres une erreur reseau puis réussit", async () => {
+    const fetchFn = vi
+      .fn()
+      .mockRejectedValueOnce(new TypeError("network error"))
+      .mockResolvedValueOnce(new Response(null, { status: 200 }));
+
+    const response = await fetchWithRetry("https://example.com", undefined, {
+      fetchFn,
+      maxAttempts: 2,
+    });
+
+    expect(response.status).toBe(200);
+    expect(fetchFn).toHaveBeenCalledTimes(2);
+    expect(sleepMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("propage l'erreur réseau quand maxAttempts est atteint", async () => {
+    const fetchFn = vi.fn().mockRejectedValue(new TypeError("network error"));
+
+    await expect(
+      fetchWithRetry("https://example.com", undefined, {
+        fetchFn,
+        maxAttempts: 2,
+      })
+    ).rejects.toThrow("network error");
+
+    expect(fetchFn).toHaveBeenCalledTimes(2);
+    expect(sleepMock).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Contexte

Erreur Sentry : https://inclusion.sentry.io/issues/112510483/?environment=production&project=4509599011045456

Certains appels à la BAN (https://api-adresse.data.gouv.fr/search/) peuvent échouer temporairement (erreurs 5xx ou réseau). On ne gère pas ces erreurs.

## Solution

Ajout de 2 fonctions utilitaires :

- `sleep()` pour attendre un nombre de millisecondes ;
- `fetchWithRetry()` pour retenter un appel `fetch()` en cas d'erreurs 5xx ou réseau.

`fetchWithRetry()` utilise `sleep()`.

Utilisation de `fetchWithRetry()` lors de la recherche d'une adresse sur la BAN dans `searchAddress()`.