### PR TITLE
fix: rafraichit la page quand les chunks sont obsolètes après un build

### DIFF
--- a/front/src/hooks.client.ts
+++ b/front/src/hooks.client.ts
@@ -3,6 +3,7 @@ import { ENVIRONMENT, SENTRY_DSN } from "$lib/env";
 import type { HandleClientError } from "@sveltejs/kit";
 
 import { setupFetchInterceptor } from "$lib/utils/fetch-interceptor";
+import { STALE_CHUNK_ERROR_MESSAGE } from "$lib/consts";
 
 setupFetchInterceptor();
 
@@ -12,11 +13,23 @@ if (ENVIRONMENT !== "local") {
     environment: ENVIRONMENT,
     tracesSampleRate: 0,
     tracePropagationTargets: [],
+    ignoreErrors: [STALE_CHUNK_ERROR_MESSAGE],
   });
 }
 
 export const handleError: HandleClientError = Sentry.handleErrorWithSentry(
   ({ error }) => {
+    // Quand un chunk JS ne peut plus être chargé (ex: après un déploiement qui
+    // change les hash des fichiers), on force un rechargement complet de la page
+    // pour que le navigateur récupère le nouvel HTML et les nouveaux chunks.
+    if (
+      error instanceof TypeError &&
+      error.message.includes(STALE_CHUNK_ERROR_MESSAGE)
+    ) {
+      window.location.reload();
+      return {};
+    }
+
     const message =
       ENVIRONMENT === "local" && error instanceof Error
         ? error.message

--- a/front/src/lib/consts.ts
+++ b/front/src/lib/consts.ts
@@ -37,3 +37,5 @@ export const PROCONNECT_MORE_INFO_URL = "https://www.proconnect.gouv.fr/";
 export const ORIENTATION_JWT_QUERY_PARAM = "op";
 
 export const TOAST_DURATION_MS = 30000;
+
+export const STALE_CHUNK_ERROR_MESSAGE = "dynamically imported module";


### PR DESCRIPTION
Quand on fait un nouveau build les chunks sont renommés et ceux qui ont notre site en cache essaient d'utiliser les chunks qui n'existent plus. C'est pour ça qu'on a cette erreur de `dynamically imported modules` https://inclusion.sentry.io/issues/98723573/?environment=production&project=4509599011045456&query=is%3Aunresolved&referrer=issue-stream

Il y a une référence à ce problème [ici](https://github.com/sveltejs/kit/issues/3978#issuecomment-1043094348)

La solution est de rafraichir la page quand l'app constate que l'utilisateur a ce souci pour utiliser la version la plus récente de l'app. Vu que ce problème est inevitable vu que les chunks seront toujours renommés après un build, je l'ai aussi ajouté à la liste `ignoreErrors` dans `sentry.init()` pour silencer le bruit. 