### PR TITLE
fix: assurer que `inert` est enlevé quand le modal ferme

### DIFF
--- a/front/src/lib/components/hoc/modal.svelte
+++ b/front/src/lib/components/hoc/modal.svelte
@@ -57,9 +57,7 @@
 
   function closeActions() {
     document.body.style.overflow = "inherit";
-    if (modalEl) {
-      document.querySelector(appSelector)?.removeAttribute("inert");
-    }
+    document.querySelector(appSelector)?.removeAttribute("inert");
     // Retour du focus sur le bouton d'ouverture
     if (activeElementSave) {
       activeElementSave.focus();


### PR DESCRIPTION
Après qu'on ouvre/ferme la carte devient non-responsive. Quand on fait `document.querySelector("body > div:first-child")`, dans la console : on vois que `inert` est présent dans le div `main-content`. 

Une cause possible est que dans modal.svelte, closeActions() ne supprimait inert que si modalEl était non-null. Parc contre, en Svelte 5, $effect s'exécute après la mise à jour du DOM — donc bind:this est déjà nullifié au moment où            
  closeActions() est appelé, et removeAttribute("inert") était systématiquement ignoré.                                                                                                                                   
                                                                                                                                                                                                                          
On supprime `inert` systématiquement pour assurer qu'on enlève `inert` Le ?. sur querySelector suffit pour gérer le cas où le sélecteur ne trouve rien.                                                                                      
                                                                                                                                         