### PR TITLE
fix: montrer une erreur plus claire quand le csv de l'import n'a pas le bon encodage

### DIFF
--- a/back/dora/core/mixins.py
+++ b/back/dora/core/mixins.py
@@ -54,6 +54,7 @@ class BaseImportAdminMixin:
                 request.POST.get("should_remove_instructions") == "on"
             )
 
+            csv_file.seek(0)
             csv_content = csv_file.read().decode("utf-8")
 
             import_job = ImportJob.objects.create(
@@ -89,8 +90,11 @@ class BaseImportAdminMixin:
             return self._create_failed_job(
                 request,
                 csv_file.name,
-                "<b>Échec de l'import - Erreur d'encodage du fichier</b><br/>"
-                "Le fichier contient des caractères spéciaux illisibles. Sauvegardez votre fichier en UTF-8 et relancez l'import.",
+                """
+                <b>Échec de l'import - Erreur d'encodage du fichier</b><br/>
+                Le fichier contient des caractères spéciaux illisibles.<br/>
+                Si possible, faites les modifications et l'export dans le Google Sheet avec le template.
+                """,
             )
         except Exception as e:
             return self._create_failed_job(

--- a/back/dora/core/templates/admin/import_csv_form.html
+++ b/back/dora/core/templates/admin/import_csv_form.html
@@ -182,7 +182,13 @@
             spinnerText.textContent = 'Import échoué';
             spinnerActions.classList.remove('import-hidden');
 
-            if (data.error_message) {
+            if (data.messages && data.messages.length > 0) {
+              spinnerMessages.classList.remove('import-hidden');
+              spinnerMessages.innerHTML = '<ul class="messagelist">' +
+              data.messages.map(msg =>
+                `<li class="${msg.level || 'error'}">${msg.message}</li>`
+              ).join('') + '</ul>';
+            } else if (data.error_message) {
               spinnerError.classList.remove('import-hidden');
               spinnerError.innerHTML = '<div class="error-details">' + escapeHtml(data.error_message) + '</div>';
             }


### PR DESCRIPTION
Suite à un import qui n'avait pas le bon encodage, on a constaté que le message d'erreur n'était pas clair. 
<img width="1339" height="664" alt="image" src="https://github.com/user-attachments/assets/d5bdf8c1-a83a-41e0-bd63-49eeb746b733" />

Ce PR fait en sorte que :
1. La bloque d'exception pour `UnicodeDecodeError` s'execute. 
2. Le message d'erreur s'affiche dans l'admin
3. Le message mentionne l'importance de faire les modifications et l'export dans le Google Sheet

<img width="681" height="618" alt="Screenshot 2026-04-17 at 10 59 02" src="https://github.com/user-attachments/assets/bdca5d2b-e51b-4ac5-8b85-71a1520762c2" />
