### PR TITLE
fix: gérer les erreurs de fetch

### DIFF
--- a/front/src/lib/utils/fetch-interceptor.ts
+++ b/front/src/lib/utils/fetch-interceptor.ts
@@ -25,7 +25,13 @@ export function setupFetchInterceptor(): void {
     input: string | URL | Request,
     init?: RequestInit
   ): Promise<Response> => {
-    const response = await originalFetch(input, init);
+    let response: Response;
+    try {
+      response = await originalFetch(input, init);
+    } catch (err) {
+      Sentry.captureException(err);
+      throw err;
+    }
 
     if (response.status === 429) {
       Sentry.captureMessage(response.statusText);


### PR DESCRIPTION
On a beaucoup de rapports de Sentry qui sont `Failed to fetch (api.dora.inclusion.gouv.fr)` https://inclusion.sentry.io/issues/112234989/?project=4509599011045456&query=is%3Aunresolved&referrer=issue-stream

Ce PR attrape les erreurs pour avoir des rapports Sentry clair. Il faut toujours `throw` dans le catch block pour montrer le message d'erreur mais Sentry fait la deduplication pour ne pas enregistrer ces erreurs une deuxième fois. 