### PR TITLE
refactor: diminuer le nombre de queries sur la route du détail d'une structure

### DIFF
--- a/back/dora/structures/models.py
+++ b/back/dora/structures/models.py
@@ -550,10 +550,17 @@ class Structure(NexusModelMixin, ModerationMixin, models.Model):
         ]
 
     def has_admin(self):
-        return bool(self.num_admins())
+        return StructureMember.objects.filter(
+            structure_id=self.id,
+            is_admin=True,
+            user__is_valid=True,
+            user__is_active=True,
+        ).exists()
 
     def num_admins(self):
-        return len(self.admins)
+        return self.membership.filter(
+            is_admin=True, user__is_valid=True, user__is_active=True
+        ).count()
 
     def is_pending_member(self, user):
         return StructurePutativeMember.objects.filter(

--- a/back/dora/structures/serializers.py
+++ b/back/dora/structures/serializers.py
@@ -222,8 +222,8 @@ class StructureSerializer(serializers.ModelSerializer):
 
         qs = qs.filter(is_model=False)
         return StructureServicesSerializer(
-            qs.prefetch_related(
-                "categories",
+            qs.select_related("structure", "model").prefetch_related(
+                "categories", "location_kinds", "coach_orientation_modes"
             ),
             many=True,
         ).data
@@ -267,7 +267,7 @@ class StructureSerializer(serializers.ModelSerializer):
 
         qs = qs.filter(is_model=False)
         return StructureServicesSerializer(
-            qs.prefetch_related(
+            qs.select_related("structure", "model").prefetch_related(
                 "categories",
             ),
             many=True,
@@ -286,7 +286,7 @@ class StructureSerializer(serializers.ModelSerializer):
 
             can_user_edit = serializers.SerializerMethodField()
 
-            num_services = serializers.SerializerMethodField()
+            num_services = serializers.IntegerField()
 
             class Meta:
                 model = ServiceModel
@@ -301,9 +301,6 @@ class StructureSerializer(serializers.ModelSerializer):
                     "slug",
                     "structure",
                 ]
-
-            def get_num_services(self, obj):
-                return obj.copies.exclude(status=ServiceStatus.ARCHIVED).count()
 
             def get_can_user_edit(self, obj):
                 return obj.can_user_edit
@@ -325,8 +322,13 @@ class StructureSerializer(serializers.ModelSerializer):
                     When(structure=structure, then=Value(can_edit_current)),
                     default=Value(can_edit_parent),
                     output_field=BooleanField(),
-                )
+                ),
+                num_services=Count(
+                    "copies",
+                    filter=~Q(copies__status=ServiceStatus.ARCHIVED),
+                ),
             )
+            .select_related("structure")
             .prefetch_related("categories")
         )
 


### PR DESCRIPTION
Cette route a des n+1 queries comme vu [ici](https://inclusion.sentry.io/issues/51157614/?environment=production&project=4509599009144912&query=is%3Aunresolved&referrer=issue-stream)

Il y a bcp de méthodes sur le serializer de la route donc les 22 queries qui restent les correspondent. C'est pas optimisé au fond mais on n'a plus le problème de n+1. 

(Il y a plus de queries cause l'utilisateur est authentifié parce que certaines méthodes ne revoient rien sinon)

Aussi, j'ai extrait des classes définies à l'intérieur de méthodes vers le niveau module. Avant, la requête recréait ces classes à chaque appel de méthode. Avec la définition au niveau module, elles ne sont créées qu'une seule fois au démarrage du processus.

Avant :
<img width="304" height="191" alt="Screenshot 2026-04-20 at 11 48 49" src="https://github.com/user-attachments/assets/653cc237-f922-412f-ac29-2645fa231ecb" />

Après :
<img width="304" height="191" alt="Screenshot 2026-04-20 at 12 06 12" src="https://github.com/user-attachments/assets/7951b00f-91d4-429e-b9c9-90542d976a9c" />

