### PR TITLE
fix: Pas de 404 sur Sentry lorsqu'on ne trouve pas un service DI

### DIFF
--- a/back/dora/data_inclusion/client.py
+++ b/back/dora/data_inclusion/client.py
@@ -10,12 +10,16 @@ from django.conf import settings
 logger = logging.getLogger(__name__)
 
 
-def log_and_raise(resp: requests.Response, *args, **kwargs):
-    try:
-        resp.raise_for_status()
-    except requests.HTTPError as err:
-        logger.error(resp.json())
-        raise err
+def log_and_raise(disable_404_log=False):
+    def _hook(resp: requests.Response, *args, **kwargs):
+        try:
+            resp.raise_for_status()
+        except requests.HTTPError as err:
+            if not (disable_404_log and resp.status_code == 404):
+                logger.error(resp.json())
+            raise err
+
+    return _hook
 
 
 def di_client_factory():
@@ -48,7 +52,7 @@ class DataInclusionClient:
         self.base_url = furl.furl(base_url)
         self.session = requests.Session()
         self.session.headers.update({"Authorization": f"Bearer {token}"})
-        self.session.hooks["response"] = [log_and_raise]
+        self.session.hooks["response"] = [log_and_raise()]
         self.timeout_timedelta = (
             timedelta(seconds=timeout_seconds)
             if timeout_seconds is not None
@@ -102,6 +106,8 @@ class DataInclusionClient:
         if user_hash is not None:
             self.session.headers.update({"Anonymous-User-Hash": user_hash})
 
+        original_response_hooks = self.session.hooks.get("response", [])
+        self.session.hooks["response"] = [log_and_raise(disable_404_log=True)]
         try:
             response = self._get(url)
             return response.json()
@@ -109,6 +115,8 @@ class DataInclusionClient:
             return None
         except requests.ReadTimeout:
             return None
+        finally:
+            self.session.hooks["response"] = original_response_hooks
 
     @log_conn_error
     def search_services(


### PR DESCRIPTION
## Contexte

Erreur Sentry : https://inclusion.sentry.io/issues/51133195/?project=4509599009144912

Lorsque la récupération d'un service DI via `DataInclusionClient.retrieve_service()` lève une erreur 404, celle-ci est automatiquement remontée sur Sentry alors que c'est une erreur attendue dans certains contextes d'utilisation (URL d'un service n'existant plus référencée hors de la plateforme).

## Solution

- Transformation de `log_and_raise()` en factory permettant de désactiver le logging en cas de 404.
- Utilisation de cette option dans `DataInclusionClient.retrieve_service()`.