### PR TITLE
perf: réduction du nombre de requêtes des infos utilisateur (`/auth/user-info/`)

### DIFF
--- a/back/dora/rest_auth/serializers.py
+++ b/back/dora/rest_auth/serializers.py
@@ -1,6 +1,7 @@
+from django.db.models import Prefetch
 from rest_framework import serializers
 
-from dora.services.models import Bookmark, SavedSearch
+from dora.services.models import Bookmark, SavedSearch, Service
 from dora.services.serializers import BookmarkListSerializer, SavedSearchSerializer
 from dora.sirene.models import Establishment
 from dora.structures.models import Structure
@@ -41,7 +42,11 @@ class UserInfoSerializer(serializers.ModelSerializer):
             qs = Structure.objects.none()
         else:
             qs = Structure.objects.filter(membership__user=user).prefetch_related(
-                "services"
+                Prefetch(
+                    "services",
+                    queryset=Service.objects.update_advised(),
+                    to_attr="prefetched_services_to_update",
+                )
             )
         return StructureListSerializer(qs, many=True, context={"user": user}).data
 
@@ -52,6 +57,12 @@ class UserInfoSerializer(serializers.ModelSerializer):
             qs = Structure.objects.filter(
                 putative_membership__user=user,
                 putative_membership__invited_by_admin=False,
+            ).prefetch_related(
+                Prefetch(
+                    "services",
+                    queryset=Service.objects.update_advised(),
+                    to_attr="prefetched_services_to_update",
+                )
             )
         return StructureListSerializer(qs, many=True, context={"user": user}).data
 

--- a/back/dora/rest_auth/serializers.py
+++ b/back/dora/rest_auth/serializers.py
@@ -81,7 +81,18 @@ class UserInfoSerializer(serializers.ModelSerializer):
         if not user or not user.is_authenticated:
             qs = SavedSearch.objects.none()
         else:
-            qs = SavedSearch.objects.filter(user=user).order_by("-creation_date")
+            qs = (
+                SavedSearch.objects.filter(user=user)
+                .select_related("category")
+                .prefetch_related(
+                    "subcategories",
+                    "kinds",
+                    "fees",
+                    "location_kinds",
+                    "funding_labels",
+                )
+                .order_by("-creation_date")
+            )
         return SavedSearchSerializer(qs, many=True).data
 
 

--- a/back/dora/rest_auth/serializers.py
+++ b/back/dora/rest_auth/serializers.py
@@ -70,7 +70,11 @@ class UserInfoSerializer(serializers.ModelSerializer):
         if not user or not user.is_authenticated:
             qs = Bookmark.objects.none()
         else:
-            qs = Bookmark.objects.filter(user=user).order_by("-creation_date")
+            qs = (
+                Bookmark.objects.filter(user=user)
+                .select_related("service")
+                .order_by("-creation_date")
+            )
         return BookmarkListSerializer(qs, many=True).data
 
     def get_saved_searches(self, user):

--- a/back/dora/rest_auth/serializers.py
+++ b/back/dora/rest_auth/serializers.py
@@ -41,11 +41,15 @@ class UserInfoSerializer(serializers.ModelSerializer):
         if not user or not user.is_authenticated:
             qs = Structure.objects.none()
         else:
-            qs = Structure.objects.filter(membership__user=user).prefetch_related(
-                Prefetch(
-                    "services",
-                    queryset=Service.objects.update_advised(),
-                    to_attr="prefetched_services_to_update",
+            qs = (
+                Structure.objects.filter(membership__user=user)
+                .select_related("parent")
+                .prefetch_related(
+                    Prefetch(
+                        "services",
+                        queryset=Service.objects.update_advised(),
+                        to_attr="prefetched_services_to_update",
+                    )
                 )
             )
         return StructureListSerializer(qs, many=True, context={"user": user}).data
@@ -54,14 +58,18 @@ class UserInfoSerializer(serializers.ModelSerializer):
         if not user or not user.is_authenticated:
             qs = Structure.objects.none()
         else:
-            qs = Structure.objects.filter(
-                putative_membership__user=user,
-                putative_membership__invited_by_admin=False,
-            ).prefetch_related(
-                Prefetch(
-                    "services",
-                    queryset=Service.objects.update_advised(),
-                    to_attr="prefetched_services_to_update",
+            qs = (
+                Structure.objects.filter(
+                    putative_membership__user=user,
+                    putative_membership__invited_by_admin=False,
+                )
+                .select_related("parent")
+                .prefetch_related(
+                    Prefetch(
+                        "services",
+                        queryset=Service.objects.update_advised(),
+                        to_attr="prefetched_services_to_update",
+                    )
                 )
             )
         return StructureListSerializer(qs, many=True, context={"user": user}).data

--- a/back/dora/rest_auth/tests/test_auth.py
+++ b/back/dora/rest_auth/tests/test_auth.py
@@ -1,7 +1,5 @@
 from unittest.mock import patch
 
-from django.db import connection
-from django.test.utils import CaptureQueriesContext
 from model_bakery import baker
 from rest_framework.authtoken.models import Token
 from rest_framework.test import APITestCase
@@ -39,11 +37,10 @@ class AuthenticationTestCase(APITestCase):
         saved_search.location_kinds.set([baker.make("LocationKind")])
         saved_search.funding_labels.set([baker.make("FundingLabel")])
 
-        with CaptureQueriesContext(connection) as queries:
+        with self.assertNumQueries(15):
             response = self.client.post("/auth/user-info/", {"key": token.key})
 
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(len(queries), 15)
 
     def test_join_structure_creates_structure(self):
         baker.make("Establishment", siret=DUMMY_SIRET)

--- a/back/dora/rest_auth/tests/test_auth.py
+++ b/back/dora/rest_auth/tests/test_auth.py
@@ -1,6 +1,9 @@
 from unittest.mock import patch
 
+from django.db import connection
+from django.test.utils import CaptureQueriesContext
 from model_bakery import baker
+from rest_framework.authtoken.models import Token
 from rest_framework.test import APITestCase
 
 from dora.core.models import ModerationStatus
@@ -11,6 +14,37 @@ DUMMY_SIRET = "12345678901234"
 
 
 class AuthenticationTestCase(APITestCase):
+    def test_user_info_query_count(self):
+        user = baker.make("users.User", is_valid=True)
+        token = Token.objects.create(user=user)
+
+        structure = make_structure()
+        make_structure_member(user=user, structure=structure, is_admin=True)
+        pending_structure = make_structure()
+        baker.make(
+            "StructurePutativeMember",
+            user=user,
+            structure=pending_structure,
+            invited_by_admin=False,
+        )
+
+        service = baker.make("Service", structure=structure, is_model=False)
+        baker.make("Bookmark", user=user, service=service)
+
+        category = baker.make("ServiceCategory")
+        saved_search = baker.make("SavedSearch", user=user, category=category)
+        saved_search.subcategories.set([baker.make("ServiceSubCategory")])
+        saved_search.kinds.set([baker.make("ServiceKind")])
+        saved_search.fees.set([baker.make("ServiceFee")])
+        saved_search.location_kinds.set([baker.make("LocationKind")])
+        saved_search.funding_labels.set([baker.make("FundingLabel")])
+
+        with CaptureQueriesContext(connection) as queries:
+            response = self.client.post("/auth/user-info/", {"key": token.key})
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(queries), 15)
+
     def test_join_structure_creates_structure(self):
         baker.make("Establishment", siret=DUMMY_SIRET)
         user = baker.make("users.User", is_valid=True)

--- a/back/dora/structures/serializers.py
+++ b/back/dora/structures/serializers.py
@@ -445,7 +445,9 @@ class StructureListSerializer(StructureSerializer):
         return obj.can_edit_informations(user or request.user)
 
     def get_services_to_update(self, obj):
-        services = obj.services.update_advised()
+        services = getattr(obj, "prefetched_services_to_update", None)
+        if services is None:
+            services = obj.services.update_advised()
         return [{"name": service.name, "slug": service.slug} for service in services]
 
 


### PR DESCRIPTION
Erreur Sentry : https://inclusion.sentry.io/issues/56677621/?project=4509599009144912

Ajout des `select_related` et `prefetch_related` manquants.