### PR TITLE
fix(auth): ignore silencieusement les erreurs d’accès à localStorage

### DIFF
--- a/front/src/lib/utils/auth.ts
+++ b/front/src/lib/utils/auth.ts
@@ -118,7 +118,11 @@ export function disconnect() {
   if (browser) {
     setUserInfo(null);
     removeToken();
-    localStorage.clear();
+    try {
+      localStorage.clear();
+    } catch {
+      // Même en cas d'accès refusé, on poursuit la déconnexion.
+    }
   }
 }
 
@@ -126,11 +130,16 @@ function migrateTokenFromLocalStorageToCookie(
   authTokenFromCookie: string | null
 ) {
   if (!authTokenFromCookie) {
-    const lsToken = localStorage.getItem(TOKEN_KEY);
-    if (lsToken) {
-      setToken(lsToken);
-      localStorage.removeItem(TOKEN_KEY);
-      return lsToken;
+    try {
+      const lsToken = localStorage.getItem(TOKEN_KEY);
+      if (lsToken) {
+        setToken(lsToken);
+        localStorage.removeItem(TOKEN_KEY);
+        return lsToken;
+      }
+    } catch {
+      // Certains contextes navigateur interdisent localStorage
+      // (iframe sandboxée, mode privacy strict, etc.).
     }
   }
 


### PR DESCRIPTION
Erreur Sentry : https://inclusion.sentry.io/issues/112190472/

Les contextes où localStorage est refusé sont généralement très spécifiques (sandbox iframe, privacy mode strict, politiques navigateur/entreprise), et souvent ces contextes ont aussi des contraintes plus larges.

localStorage sert uniquement de fallback de migration ; si son accès est refusé, le cookie token reste prioritaire et le fonctionnement auth n’est pas dégradé.