### PR TITLE
perf: optimisation de la route des membres d'une structure

### DIFF
--- a/back/dora/structures/views.py
+++ b/back/dora/structures/views.py
@@ -162,27 +162,29 @@ class StructureMemberViewset(viewsets.ModelViewSet):
             if structure.can_view_members(user):
                 return StructureMember.objects.filter(
                     structure=structure, user__is_valid=True
-                )
+                ).select_related("user")
             raise exceptions.PermissionDenied
 
         else:
             # Les superuser ont accès à tous les collaborateurs
             if user.is_staff:
-                return StructureMember.objects.all()
+                return StructureMember.objects.all().select_related("user")
 
             # Les gestionnaires ont accès à tous les collaborateurs de
             # leur département
             elif user.is_manager and user.departments:
                 return StructureMember.objects.filter(
                     structure__department__in=user.departments
-                )
+                ).select_related("user")
 
             # Les membres des structures ont accès à tous leurs collègues
             else:
                 user_structures = StructureMember.objects.filter(
                     user_id=user.id
                 ).values_list("structure_id", flat=True)
-                return StructureMember.objects.filter(structure_id__in=user_structures)
+                return StructureMember.objects.filter(
+                    structure_id__in=user_structures
+                ).select_related("user")
 
 
 class StructurePutativeMemberViewset(viewsets.ModelViewSet):


### PR DESCRIPTION
Il y a un query n + 1 à cause de la manque de `select_related('user')` pour la liste des structure members 

https://inclusion.sentry.io/issues/55654742/?project=4509599009144912&query=is%3Aunresolved&referrer=issue-stream

Avant :
<img width="212" height="179" alt="Screenshot 2026-04-21 at 11 58 26" src="https://github.com/user-attachments/assets/ed805276-5227-454c-acdf-9603ea37e5c7" />

Après :
<img width="212" height="179" alt="Screenshot 2026-04-21 at 11 58 31" src="https://github.com/user-attachments/assets/5fc66b8e-6bd1-4ed0-bbcd-de83acb6e3a9" />


J'ai fait la même chose pour le détail d'un membre pour enlever un query 

Avant :
<img width="523" height="158" alt="Screenshot 2026-04-21 at 11 58 56" src="https://github.com/user-attachments/assets/ece39ad5-95d0-47ab-9ae4-82748eeba45e" />

Après :
<img width="523" height="158" alt="Screenshot 2026-04-21 at 11 58 42" src="https://github.com/user-attachments/assets/fe059e2b-6328-42a5-aa64-d19a4e364777" />