### PR TITLE
fix: Correction de la recherche de jeton d'authentification dans Django Admin

### DIFF
--- a/back/dora/users/admin.py
+++ b/back/dora/users/admin.py
@@ -354,6 +354,13 @@ class TokenProxyAdmin(TokenAdmin):
     # DRF utilise par défaut user__username, ce qui casse avec un modèle
     # User custom qui utilise l'email comme identifiant sans champ username.
     search_fields = ("key", "user__email")
+    list_select_related = ("user",)
+    raw_id_fields = ("user",)
+
+    def get_readonly_fields(self, request, obj=None):
+        # En édition : tous les champs du formulaire sont en lecture seule.
+        # En création : l'utilisateur peut être sélectionné.
+        return self.fields if obj is not None else ()
 
 
 # Now register the new UserAdmin...

--- a/back/dora/users/admin.py
+++ b/back/dora/users/admin.py
@@ -7,6 +7,8 @@ from django.core.exceptions import ValidationError
 from django.utils import timezone
 from django.utils.html import format_html
 from django.utils.safestring import mark_safe
+from rest_framework.authtoken.admin import TokenAdmin
+from rest_framework.authtoken.models import TokenProxy
 
 from dora.services.models import Bookmark, SavedSearch
 from dora.structures.models import StructureMember, StructurePutativeMember
@@ -348,9 +350,17 @@ class ConsentRecordAdmin(admin.ModelAdmin):
         return False
 
 
+class TokenProxyAdmin(TokenAdmin):
+    # DRF utilise par défaut user__username, ce qui casse avec un modèle
+    # User custom qui utilise l'email comme identifiant sans champ username.
+    search_fields = ("key", "user__email")
+
+
 # Now register the new UserAdmin...
 admin.site.register(User, UserAdmin)
 admin.site.register(ConsentRecord, ConsentRecordAdmin)
+admin.site.unregister(TokenProxy)
+admin.site.register(TokenProxy, TokenProxyAdmin)
 # ... and, since we're not using Django's built-in permissions,
 # unregister the Group model from admin.
 admin.site.unregister(Group)


### PR DESCRIPTION
## Contexte

La recherche de jeton génère une erreur 500.

L'affichage d'une page de détail est lente.

## Solution

Création d'une classe `TokenProxyAdmin` corrigeant ces problèmes.

Un jeton peut être recherché via la valeur du jeton lui-même ou par l'adresse email de l'utilisateur associé.

La page de détail est affichée sans lenteur et tous les champs sont en lecture seule.