### PR TITLE
fix: ne pas créer les rapports Sentry pour les logs

### DIFF
--- a/back/dora/notifications/tasks/invitations.py
+++ b/back/dora/notifications/tasks/invitations.py
@@ -111,11 +111,10 @@ class InvitedUsersTask(Task):
         if notification.is_complete:
             user = notification.owner_structureputativemember.user
 
-            logger.warning(
+            logger.info(
                 "Suppression d'utilisateur",
                 {
                     "legal": True,
-                    "userEmail": user.email,
                     "userId": str(user.pk),
                     "structureId": str(
                         notification.owner_structureputativemember.structure.pk

--- a/back/dora/notifications/tasks/users.py
+++ b/back/dora/notifications/tasks/users.py
@@ -85,11 +85,10 @@ class UsersWithoutStructureTask(Task):
             # - aucune autre invitation
             # - non membre d'une structure
             if not user.putative_membership.count() and not user.membership.count():
-                logger.warning(
+                logger.info(
                     "Suppression d'utilisateur",
                     {
                         "legal": True,
-                        "userEmail": user.email,
                         "userId": user.pk,
                         "reason": "Aucun rattachement ou invitation à une structure après relances",
                     },
@@ -146,11 +145,10 @@ class UserAccountDeletionTask(Task):
         if notification.is_complete:
             user = notification.owner_user
 
-            logger.warning(
+            logger.info(
                 "Suppression d'utilisateur",
                 {
                     "legal": True,
-                    "userEmail": user.email,
                     "userId": user.pk,
                     "reason": "Inactivité de longue durée",
                 },


### PR DESCRIPTION
Ce PR fait deux choses : 
1. Change le niveau des logs pour des opérations normales à `logger.info` pour ne plus créer des rapports Sentry comme https://inclusion.sentry.io/issues/51181657/?environment=production&project=4509599009144912&query=is%3Aunresolved&referrer=issue-stream
2. On n'ajoute plus les mails des utilisateurs aux logs qui est problématique niveau GDPR