### PR TITLE
perf: ajouter select_related pour éviter n+1 sur DI structure query

### DIFF
--- a/back/dora/api/views.py
+++ b/back/dora/api/views.py
@@ -48,7 +48,7 @@ class StructureViewSet(viewsets.ReadOnlyModelViewSet):
 
     def get_queryset(self):
         structures = (
-            Structure.objects.select_related("source")
+            Structure.objects.select_related("source", "parent")
             .prefetch_related("national_labels")
             .filter(is_obsolete=False)
         )


### PR DESCRIPTION
Il y a un n+1 dans la route que DI utilise pour chercher les structures parce qu'une [méthode](https://github.com/gip-inclusion/dora/blob/9cfd27122300099e4debca68c189e163ba3c6864/back/dora/api/serializers.py#L148) du serializer a besoin de savoir le siret du parent. 

En ajoutant `select_related('parent')`, on diminue beaucoup les queries. 

Avant
<img width="178" height="179" alt="Screenshot 2026-04-23 at 11 57 29" src="https://github.com/user-attachments/assets/c3959135-5198-4a74-b5b9-9ba2af7d7e78" />

Après
<img width="178" height="179" alt="Screenshot 2026-04-23 at 11 57 23" src="https://github.com/user-attachments/assets/c38a8c4d-a11b-4355-9560-bef74d792c96" />