### PR TITLE
fix: Création de faux départements pour les COM et TOM

### DIFF
--- a/back/dora/decoupage_administratif/migrations/0002_add_overseas_departments.py
+++ b/back/dora/decoupage_administratif/migrations/0002_add_overseas_departments.py
@@ -1,0 +1,78 @@
+from django.db import migrations
+
+OVERSEAS_DEPARTMENTS = [
+    {
+        "code": "975",
+        "name": "Saint-Pierre-et-Miquelon",
+        "normalized_name": "SAINT PIERRE ET MIQUELON",
+    },
+    {
+        "code": "977",
+        "name": "Saint-Barthélemy",
+        "normalized_name": "SAINT BARTHELEMY",
+    },
+    {
+        "code": "978",
+        "name": "Saint-Martin",
+        "normalized_name": "SAINT MARTIN",
+    },
+    {
+        "code": "984",
+        "name": "Terres australes et antarctiques françaises",
+        "normalized_name": "TERRES AUSTRALES ET ANTARCTIQUES FRANCAISES",
+    },
+    {
+        "code": "986",
+        "name": "Wallis-et-Futuna",
+        "normalized_name": "WALLIS ET FUTUNA",
+    },
+    {
+        "code": "987",
+        "name": "Polynésie française",
+        "normalized_name": "POLYNESIE FRANCAISE",
+    },
+    {
+        "code": "988",
+        "name": "Nouvelle-Calédonie",
+        "normalized_name": "NOUVELLE CALEDONIE",
+    },
+    {
+        "code": "989",
+        "name": "Île de Clipperton",
+        "normalized_name": "ILE DE CLIPPERTON",
+    },
+]
+
+
+def create_overseas_departments(apps, schema_editor):
+    Department = apps.get_model("decoupage_administratif", "Department")
+    for dept in OVERSEAS_DEPARTMENTS:
+        Department.objects.update_or_create(
+            code=dept["code"],
+            defaults={
+                "name": dept["name"],
+                "normalized_name": dept["normalized_name"],
+                # Les COMs n'ont pas de région au sens métropolitain :
+                # par convention INSEE, on réutilise le code du territoire.
+                "region": dept["code"],
+            },
+        )
+
+
+def delete_overseas_departments(apps, schema_editor):
+    Department = apps.get_model("decoupage_administratif", "Department")
+    codes = [dept["code"] for dept in OVERSEAS_DEPARTMENTS]
+    Department.objects.filter(code__in=codes).delete()
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("decoupage_administratif", "0001_initial"),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            create_overseas_departments,
+            reverse_code=delete_overseas_departments,
+        ),
+    ]

--- a/back/dora/decoupage_administratif/tests/test_get_departments.py
+++ b/back/dora/decoupage_administratif/tests/test_get_departments.py
@@ -11,6 +11,10 @@ class GetDepartmentsViewTests(TestCase):
     def setUpTestData(cls):
         cls.client = APIClient()
 
+        # Nettoyage des départements créés par les data-migrations
+        # (ex: COM et TOM) pour garantir un jeu de données contrôlé.
+        Department.objects.all().delete()
+
         cls.dept_75 = Department.objects.create(
             code="75",
             name="Paris",


### PR DESCRIPTION
Des communes et structures ont déjà des codes département correspondant à ceux-ci.

Cela permettra aux gestionnaires de territoire d'avoir accès à ces territoires dans le tableau de bord GT.

- 975 — Saint-Pierre-et-Miquelon : collectivité d'outre-mer (COM).
- 977 — Saint-Barthélemy : COM (séparée de la Guadeloupe depuis 2007).
- 978 — Saint-Martin : COM (séparée de la Guadeloupe depuis 2007).
- 984 — Terres australes et antarctiques françaises (TAAF) : territoire d'outre-mer (TOM) à statut particulier.
- 986 — Wallis-et-Futuna : COM.
- 987 — Polynésie française : COM (« pays d'outre-mer » selon son statut local).
- 988 — Nouvelle-Calédonie : collectivité sui generis (statut unique défini par le titre XIII de la Constitution).
- 989 — Île de Clipperton : île française inhabitée du Pacifique, sous l'autorité directe du gouvernement (souvent listée à part dans les nomenclatures INSEE).