### PR TITLE
fix: Formatage des emails anonymisées des services et structures

### DIFF
--- a/back/tools/datanymizer-config.yml
+++ b/back/tools/datanymizer-config.yml
@@ -34,12 +34,15 @@ tables:
           format: ""
 
   - name: services_service
+    rule_order:
+      - contact_name
+      - contact_email
     rules:
       contact_name:
         person_name: {}
       contact_email:
-        email:
-          kind: Safe
+        template:
+          format: "test+{{ final.contact_name | slugify }}.{{ prev.slug }}@dora.inclusion.beta.gouv.fr"
       contact_phone:
         phone:
           format: "9^########"
@@ -47,8 +50,8 @@ tables:
   - name: structures_structure
     rules:
       email:
-        email:
-          kind: Safe
+        template:
+          format: "test+{{ prev.slug }}@dora.inclusion.beta.gouv.fr"
       phone:
         phone:
           format: "9^########"


### PR DESCRIPTION
Afin de s'assurer qu'aucun email ne parte vers une adresse non-existante mais au contraire vers un alias de `test@dora.inclusion.beta.gouv.fr` :

- formatage des emails de contact des services en `test+<nom_contact>.<slug_service>@dora.inclusion.beta.gouv.fr` ;
- formatage des emails de contact des structures en `test+<slug_structure>@dora.inclusion.beta.gouv.fr`.