### PR TITLE
feat(emplois): Pagination systématique de la liste des services

### DIFF
--- a/back/dora/core/pagination.py
+++ b/back/dora/core/pagination.py
@@ -12,3 +12,10 @@ class OptionalPageNumberPagination(pagination.PageNumberPagination):
         if self.page_size_query_param in request.query_params:
             return super().get_page_size(request)
         return None
+
+
+class DefaultPageNumberPagination(OptionalPageNumberPagination):
+    default_page_size = 50
+
+    def get_page_size(self, request):
+        return super().get_page_size(request) or self.default_page_size

--- a/back/dora/emplois/tests/__snapshots__/test_emplois_views.ambr
+++ b/back/dora/emplois/tests/__snapshots__/test_emplois_views.ambr
@@ -266,8 +266,32 @@
 # ---
 # name: test_services_api_list_orientation_queries_are_bounded
   dict({
-    'num_queries': 11,
+    'num_queries': 12,
     'queries': list([
+      dict({
+        'origin': list([
+          'Paginator.count[<site-packages>/django/core/paginator.py]',
+          'ServiceViewSet.list[emplois/views.py]',
+          'test_services_api_list_orientation_queries_are_bounded[emplois/tests/test_emplois_views.py]',
+        ]),
+        'sql': '''
+          SELECT COUNT(*) AS "__count"
+          FROM "services_service"
+          INNER JOIN "structures_structure" ON ("services_service"."structure_id" = "structures_structure"."id")
+          WHERE (NOT "services_service"."is_model"
+                 AND "services_service"."status" = %s
+                 AND NOT ("structures_structure"."is_obsolete")
+                 AND NOT ("services_service"."structure_id" IN
+                            (SELECT U0."id"
+                             FROM "structures_structure" U0
+                             LEFT OUTER JOIN "structures_structuremember" U1 ON (U0."id" = U1."structure_id")
+                             LEFT OUTER JOIN "structures_structureputativemember" U2 ON (U0."id" = U2."structure_id")
+                             WHERE (U1."id" IS NULL
+                                    AND U2."id" IS NULL)))
+                 AND NOT ("services_service"."suspension_date" < %s
+                          AND "services_service"."suspension_date" IS NOT NULL))
+        ''',
+      }),
       dict({
         'origin': list([
           'ServiceViewSet.list[emplois/views.py]',
@@ -382,6 +406,7 @@
                  AND NOT ("services_service"."suspension_date" < %s
                           AND "services_service"."suspension_date" IS NOT NULL))
           ORDER BY "services_service"."id" ASC
+          LIMIT 5
         ''',
       }),
       dict({
@@ -581,8 +606,32 @@
 # ---
 # name: test_services_api_list_queries_are_bounded
   dict({
-    'num_queries': 11,
+    'num_queries': 12,
     'queries': list([
+      dict({
+        'origin': list([
+          'Paginator.count[<site-packages>/django/core/paginator.py]',
+          'ServiceViewSet.list[emplois/views.py]',
+          'test_services_api_list_queries_are_bounded[emplois/tests/test_emplois_views.py]',
+        ]),
+        'sql': '''
+          SELECT COUNT(*) AS "__count"
+          FROM "services_service"
+          INNER JOIN "structures_structure" ON ("services_service"."structure_id" = "structures_structure"."id")
+          WHERE (NOT "services_service"."is_model"
+                 AND "services_service"."status" = %s
+                 AND NOT ("structures_structure"."is_obsolete")
+                 AND NOT ("services_service"."structure_id" IN
+                            (SELECT U0."id"
+                             FROM "structures_structure" U0
+                             LEFT OUTER JOIN "structures_structuremember" U1 ON (U0."id" = U1."structure_id")
+                             LEFT OUTER JOIN "structures_structureputativemember" U2 ON (U0."id" = U2."structure_id")
+                             WHERE (U1."id" IS NULL
+                                    AND U2."id" IS NULL)))
+                 AND NOT ("services_service"."suspension_date" < %s
+                          AND "services_service"."suspension_date" IS NOT NULL))
+        ''',
+      }),
       dict({
         'origin': list([
           'ServiceViewSet.list[emplois/views.py]',
@@ -697,6 +746,7 @@
                  AND NOT ("services_service"."suspension_date" < %s
                           AND "services_service"."suspension_date" IS NOT NULL))
           ORDER BY "services_service"."id" ASC
+          LIMIT 5
         ''',
       }),
       dict({

--- a/back/dora/emplois/tests/test_emplois_views.py
+++ b/back/dora/emplois/tests/test_emplois_views.py
@@ -90,9 +90,10 @@ def test_services_api_list(emplois_user, api_client):
     published_service = make_published_service()
     list_response = api_client.get(reverse("emplois:service-list"))
     assert list_response.status_code == 200
-    assert len(list_response.data) == 1
+    assert list_response.data["count"] == 1
+    assert len(list_response.data["results"]) == 1
 
-    data = list_response.data[0]
+    data = list_response.data["results"][0]
     assert data["id"] == str(published_service.id)
     assert data["short_desc"] == published_service.short_desc
 
@@ -147,7 +148,8 @@ def test_services_api_list_queries_are_bounded(
         response = api_client.get(reverse("emplois:service-list"))
 
     assert response.status_code == 200
-    assert len(response.data) == 5
+    assert response.data["count"] == 5
+    assert len(response.data["results"]) == 5
 
 
 def test_services_api_detail_queries_are_bounded(
@@ -178,7 +180,8 @@ def test_services_api_list_orientation_queries_are_bounded(
         response = api_client.get(reverse("emplois:service-list"))
 
     assert response.status_code == 200
-    assert len(response.data) == 5
+    assert response.data["count"] == 5
+    assert len(response.data["results"]) == 5
 
 
 @pytest.mark.parametrize(

--- a/back/dora/emplois/views.py
+++ b/back/dora/emplois/views.py
@@ -5,7 +5,10 @@ from rest_framework.renderers import JSONRenderer
 from rest_framework.response import Response
 from rest_framework.versioning import NamespaceVersioning
 
-from dora.core.pagination import OptionalPageNumberPagination
+from dora.core.pagination import (
+    DefaultPageNumberPagination,
+    OptionalPageNumberPagination,
+)
 from dora.orientations.models import Orientation
 from dora.services.models import (
     BeneficiaryAccessMode,
@@ -80,11 +83,14 @@ class ReferenceDataViewSet(viewsets.ReadOnlyModelViewSet):
 
 
 class ServiceViewSet(viewsets.ReadOnlyModelViewSet):
+    class ServicePagination(DefaultPageNumberPagination):
+        default_page_size = 1000
+
     versioning_class = NamespaceVersioning
     permission_classes = (APIPermission,)
     serializer_class = ServiceSerializer
     renderer_classes = (JSONRenderer,)
-    pagination_class = OptionalPageNumberPagination
+    pagination_class = ServicePagination
 
     def get_queryset(self):
         return (


### PR DESCRIPTION
- Création d'une classe de pagination `DefaultPageNumberPagination` forçant une pagination ;
- Utilisation de cette classe dans `ServiceViewSet` pour que les services soient toujours paginés même quand le paramètre `page` n'est pas fourni.