### PR TITLE
fix: assurer que tous les params de l'url sont gardés après la redire…

### DIFF
--- a/front/src/lib/utils/misc.ts
+++ b/front/src/lib/utils/misc.ts
@@ -268,3 +268,21 @@ export function debounce<T extends (...args: any[]) => any>(
 export function sleep(milliseconds: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, milliseconds));
 }
+
+export function transferUrlParams({
+  targetUrl,
+  sourceUrl,
+  exclude = [],
+}: {
+  targetUrl: string;
+  sourceUrl: URL;
+  exclude?: string[];
+}): string {
+  const next = new URL(targetUrl, sourceUrl);
+  for (const [key, value] of sourceUrl.searchParams) {
+    if (!exclude.includes(key)) {
+      next.searchParams.set(key, value);
+    }
+  }
+  return next.toString();
+}

--- a/front/src/lib/utils/misc.ts
+++ b/front/src/lib/utils/misc.ts
@@ -274,12 +274,14 @@ export function transferUrlParams({
   sourceUrl,
   exclude = [],
 }: {
-  targetUrl: string;
-  sourceUrl: URL;
+  targetUrl: string | URL;
+  sourceUrl: string | URL;
   exclude?: string[];
 }): string {
-  const next = new URL(targetUrl, sourceUrl);
-  for (const [key, value] of sourceUrl.searchParams) {
+  const source = new URL(sourceUrl);
+  const next = new URL(targetUrl, source);
+
+  for (const [key, value] of source.searchParams) {
     if (!exclude.includes(key)) {
       next.searchParams.set(key, value);
     }

--- a/front/src/routes/(modeles-services)/services/[slug]/+page.server.ts
+++ b/front/src/routes/(modeles-services)/services/[slug]/+page.server.ts
@@ -4,6 +4,7 @@ import type { PageServerLoad } from "./$types";
 import { handleEmploisOrientation } from "$lib/requests/emplois-orientation";
 import { ORIENTATION_JWT_QUERY_PARAM } from "$lib/consts";
 import { TOKEN_KEY } from "$lib/utils/auth";
+import { transferUrlParams } from "$lib/utils/misc";
 
 export const load: PageServerLoad = async ({ url, params, cookies }) => {
   const opJwt = url.searchParams.get(ORIENTATION_JWT_QUERY_PARAM);
@@ -24,7 +25,14 @@ export const load: PageServerLoad = async ({ url, params, cookies }) => {
   if (response.ok) {
     const data = await response.json();
     if (data.nextUrl) {
-      redirect(302, data.nextUrl);
+      redirect(
+        302,
+        transferUrlParams({
+          targetUrl: data.nextUrl,
+          sourceUrl: url,
+          exclude: [ORIENTATION_JWT_QUERY_PARAM],
+        })
+      );
     }
   }
 };

--- a/front/src/routes/(modeles-services)/services/[slug]/orienter/+page.ts
+++ b/front/src/routes/(modeles-services)/services/[slug]/orienter/+page.ts
@@ -4,6 +4,7 @@ import {
   getOrientationBeneficiaryInfo,
   type OrientationBeneficiaryInfo,
 } from "$lib/requests/nexus";
+import { transferUrlParams } from "$lib/utils/misc";
 
 export const load = async ({ parent, url, params, fetch }) => {
   const data = await parent();
@@ -33,7 +34,14 @@ export const load = async ({ parent, url, params, fetch }) => {
       beneficiaryInfo = null;
     }
     if (beneficiaryInfo && "nextUrl" in beneficiaryInfo) {
-      redirect(302, beneficiaryInfo.nextUrl);
+      redirect(
+        302,
+        transferUrlParams({
+          targetUrl: beneficiaryInfo.nextUrl,
+          sourceUrl: url,
+          exclude: [ORIENTATION_JWT_QUERY_PARAM],
+        })
+      );
     }
   }
 

--- a/front/src/routes/auth/rattachement/+page.svelte
+++ b/front/src/routes/auth/rattachement/+page.svelte
@@ -15,6 +15,7 @@
   import CguCheckboxes from "../cgu-checkboxes.svelte";
   import { ORIENTATION_JWT_QUERY_PARAM, URL_HELP_SITE } from "$lib/consts";
   import { toast } from "@zerodevx/svelte-toast";
+  import { transferUrlParams } from "$lib/utils/misc";
 
   interface Props {
     data: PageData;
@@ -84,7 +85,10 @@
       result.data = await response.json();
       await refreshUserInfo();
       const redirectUrl = opJwt
-        ? `/services/${serviceSlug}${directToOrientationPage ? "/orienter" : ""}?${ORIENTATION_JWT_QUERY_PARAM}=${encodeURIComponent(opJwt)}`
+        ? transferUrlParams({
+            targetUrl: `/services/${serviceSlug}${directToOrientationPage ? "/orienter" : ""}`,
+            sourceUrl: $page.url,
+          })
         : `/structures/${result.data.slug}`;
       await goto(redirectUrl);
       loading = false;


### PR DESCRIPTION
Quand un utilisateur arrive chez Dora depuis les emplois, il y a un handler qui décide quelle est la bonne page pour l'atterrissage. Ce PR fait en sorte que les query params de l'url originel sont gardés. 

J'ai créé un helper pour transférer les params de l'url originel vers le nouvel url fourni par le back et je l'ai appliqué dans les trois endroits où une redirection spéciale arrive : 

1. le `load()` de la page de détail d'un service
2. le `load()` la première étape du formulaire d'une orientation
3. la redirection après que l'utilisateur se rattache à une structure

C'est nécessaire de garder ses params pour faire fonctionner le tracking de matomo qui penche sur les params qui comments avec `mtm`