### PR TITLE
fix: Authentification obligatoire pour la vue `siret_was_claimed`

### DIFF
--- a/back/dora/structures/views.py
+++ b/back/dora/structures/views.py
@@ -352,7 +352,7 @@ class StructurePutativeMemberViewset(viewsets.ModelViewSet):
 
 
 @api_view()
-@permission_classes([permissions.AllowAny])
+@permission_classes([permissions.IsAuthenticated])
 def siret_was_claimed(request, siret):
     structure = get_object_or_404(Structure.objects.all(), siret=siret)
     serializer = StructureSerializer(structure, context={"request": request})

--- a/front/src/lib/requests/structures.ts
+++ b/front/src/lib/requests/structures.ts
@@ -32,31 +32,14 @@ function structureToFront(structure: Structure): Structure {
 
 export async function siretWasAlreadyClaimed(siret: string) {
   const url = `${getApiURL()}/siret-claimed/${siret}`;
-  const res = await fetch(url, {
-    headers: {
-      Accept: "application/json; version=1.0",
-    },
-  });
-
-  const result = {
-    ok: res.ok,
-    status: res.status,
-    result: undefined,
-    error: undefined,
-  };
-
-  if (res.ok) {
-    result.result = await res.json();
+  const result = await fetchData<Structure>(url);
+  if (result.ok) {
+    return result.data;
+  } else if (result.status === 404) {
+    return null;
   } else {
-    if (res.status !== 404) {
-      try {
-        result.error = await res.json();
-      } catch (err) {
-        console.error(err);
-      }
-    }
+    throw Error(result.statusText);
   }
-  return result;
 }
 
 export async function getManagedStructures(

--- a/front/src/lib/utils/misc.ts
+++ b/front/src/lib/utils/misc.ts
@@ -37,12 +37,33 @@ export function htmlToMarkdown(html: string) {
   return "";
 }
 
+export type FetchDataSuccess<T> = {
+  ok: true;
+  data: T;
+  error: null;
+  status: number;
+  statusText: string;
+};
+
+export type FetchDataError = {
+  ok: false;
+  data: null;
+  error: string;
+  status: number;
+  statusText: string;
+};
+
+export type FetchDataResult<T> = FetchDataSuccess<T> | FetchDataError;
+
 export async function fetchData<T>(
   url: string,
   fetchFunction = fetch,
   customHeaders: Record<string, string> = {}
-) {
-  const headers = { Accept: defaultAcceptHeader, ...customHeaders };
+): Promise<FetchDataResult<T>> {
+  const headers: Record<string, string> = {
+    Accept: defaultAcceptHeader,
+    ...customHeaders,
+  };
   const currentToken = getToken();
 
   if (currentToken) {
@@ -53,10 +74,20 @@ export async function fetchData<T>(
     headers,
   });
 
+  if (response.ok) {
+    return {
+      ok: true,
+      data: (await response.json()) as T,
+      error: null,
+      status: response.status,
+      statusText: response.statusText,
+    };
+  }
+
   return {
-    ok: response.ok,
-    data: response.ok ? ((await response.json()) as T) : null,
-    error: response.ok ? null : response.statusText,
+    ok: false,
+    data: null,
+    error: response.statusText,
     status: response.status,
     statusText: response.statusText,
   };

--- a/front/src/routes/admin/structures/creer/+page.svelte
+++ b/front/src/routes/admin/structures/creer/+page.svelte
@@ -83,21 +83,13 @@
     structure = JSON.parse(JSON.stringify(defaultStructure));
   }
 
-  async function establishmentAlreadyCreated(siret: string) {
-    const result = await siretWasAlreadyClaimed(siret);
-    if (result.ok) {
-      return result.result as unknown as Structure;
-    }
-    return null;
-  }
-
   async function handleEstablishmentChange(
     establishment: Establishment | null
   ) {
     alreadyClaimedEstablishment = null;
     structure = JSON.parse(JSON.stringify(defaultStructure));
     if (establishment) {
-      alreadyClaimedEstablishment = await establishmentAlreadyCreated(
+      alreadyClaimedEstablishment = await siretWasAlreadyClaimed(
         establishment.siret
       );
       if (!alreadyClaimedEstablishment) {

--- a/front/src/routes/admin/structures/creer/+page.svelte
+++ b/front/src/routes/admin/structures/creer/+page.svelte
@@ -43,6 +43,7 @@
   let requesting = $state(false);
   let structure = $state(JSON.parse(JSON.stringify(defaultStructure)));
   let alreadyClaimedEstablishment: Structure | null = $state(null);
+  let errorCheckingAlreadyClaimedEstablishment = $state(false);
   let structureAdded = $state(false);
 
   function resetForm() {
@@ -89,9 +90,15 @@
     alreadyClaimedEstablishment = null;
     structure = JSON.parse(JSON.stringify(defaultStructure));
     if (establishment) {
-      alreadyClaimedEstablishment = await siretWasAlreadyClaimed(
-        establishment.siret
-      );
+      errorCheckingAlreadyClaimedEstablishment = false;
+      try {
+        alreadyClaimedEstablishment = await siretWasAlreadyClaimed(
+          establishment.siret
+        );
+      } catch (err) {
+        errorCheckingAlreadyClaimedEstablishment = true;
+        throw err;
+      }
       if (!alreadyClaimedEstablishment) {
         structure.siret = establishment.siret;
         structure.name = establishment.name;
@@ -140,6 +147,19 @@
         onEstablishmentChange={handleEstablishmentChange}
         onCityChange={handleCityChange}
       />
+
+      {#if errorCheckingAlreadyClaimedEstablishment}
+        <div class="mt-s24"></div>
+        <Notice
+          title="Erreur lors de la vérification de la structure"
+          type="error"
+        >
+          <p>
+            Une erreur est survenue lors de la vérification de la structure.
+            Veuillez réessayer plus tard.
+          </p>
+        </Notice>
+      {/if}
 
       {#if alreadyClaimedEstablishment}
         <div class="mt-s24"></div>

--- a/front/src/routes/admin/structures/creer/+page.svelte
+++ b/front/src/routes/admin/structures/creer/+page.svelte
@@ -16,6 +16,7 @@
   import { formErrors } from "$lib/validation/validation";
   import { getToken } from "$lib/utils/auth";
   import type { Establishment, Structure } from "$lib/types";
+  import { logException } from "$lib/utils/logger";
 
   const schema = {
     email: {
@@ -97,7 +98,7 @@
         );
       } catch (err) {
         errorCheckingAlreadyClaimedEstablishment = true;
-        throw err;
+        logException(err);
       }
       if (!alreadyClaimedEstablishment) {
         structure.siret = establishment.siret;


### PR DESCRIPTION
## Contexte

`siret_was_claimed` expose les données complètes de structure sans authentification.

Cette vue n'est utilisée que par les gestionnaires de territoire, et donc, pas des utilisateurs authentifiés.

## Solution

Accès à la vue limitée aux utilisateurs authentifiés.

Utilisation de `fetchData()` pour passer le header `Authorization`.

J'en ai profité pour préciser le typage de `fetchData()` selon la valeur de `response.ok`.