### PR TITLE
fix: on refuse la permission à l'orientation si le query_id_hash est expiré

### DIFF
--- a/back/dora/orientations/tests/test_orientation_endpoints.py
+++ b/back/dora/orientations/tests/test_orientation_endpoints.py
@@ -1,3 +1,5 @@
+from datetime import datetime
+
 import pytest
 from dateutil.relativedelta import relativedelta
 from django.core import mail
@@ -24,7 +26,7 @@ def test_query_refresh(api_client, orientation):
     assert response.status_code == 204
 
 
-def test_query_access(api_client, orientation):
+def test_access_refused_when_no_query_id_hash(api_client, orientation):
     url = f"/orientations/{orientation.query_id}/"
     response = api_client.get(url, follow=True)
 
@@ -35,6 +37,26 @@ def test_query_access(api_client, orientation):
     response = api_client.get(url, follow=True)
 
     assert response.status_code == 200
+
+
+@freeze_time("2026-01-01")
+def test_access_refused_when_query_id_hash_expired(api_client, orientation):
+    orientation.query_expires_at = datetime(year=2025, month=12, day=31)
+    orientation.save()
+
+    orientation.refresh_from_db()
+
+    response = api_client.get(
+        f"/orientations/{orientation.query_id}/?h={orientation.get_query_id_hash()}"
+    )
+
+    assert response.status_code == 401
+
+
+def test_access_refused_when_query_id_hash_invalid(api_client, orientation):
+    response = api_client.get(f"/orientations/{orientation.query_id}/?h=invalid")
+
+    assert response.status_code == 401
 
 
 @freeze_time("2022-01-01")

--- a/back/dora/orientations/views.py
+++ b/back/dora/orientations/views.py
@@ -1,4 +1,5 @@
 import functools
+import hmac
 import logging
 import time
 from math import ceil
@@ -71,7 +72,11 @@ class OrientationPermission(permissions.BasePermission):
         match request.method:
             case "GET" | "POST" | "PATCH":
                 if h := request.query_params.get("h"):
-                    return h == orientation.get_query_id_hash()
+                    if not hmac.compare_digest(h, orientation.get_query_id_hash()):
+                        return False
+                    if orientation.query_expired:
+                        return False
+                    return True
                 return False
             case _:
                 return False


### PR DESCRIPTION
Un ancien lien magique d'orientation (obtenu via transfert d'email, historique de navigation, referrer, ou logs) reste valide indéfiniment, donnant accès aux PII sensibles du bénéficiaire (nom, email, téléphone, date de naissance, pièces jointes) et permettant de valider ou rejeter l'orientation.

Le système d'orientation utilise un hash SHA-256 comme mécanisme d'accès anonyme. Bien qu'une propriété `query_expired` existe dans le modèle, elle n'est jamais consultée lors de la vérification des permissions, rendant les liens permanents. De plus, la comparaison du hash utilise `==` au lieu de `hmac.compare_digest`.