### PR TITLE
feat: Import de services : identification de structure par Siret OU slug

### DIFF
--- a/back/dora/services/admin.py
+++ b/back/dora/services/admin.py
@@ -313,7 +313,7 @@ class ServiceAdmin(BaseImportAdminMixin, admin.GISModelAdmin):
                         title_prefix,
                         format_html_join(
                             mark_safe("<br/>"),
-                            '• [{idx}] SIRET {siret} - il existe déjà un service avec le modèle {model_slug} et le courriel "{contact_email}"',
+                            '• [{idx}] Structure "{structure_siret_or_slug}" - il existe déjà un service avec le modèle {model_slug} et le courriel "{contact_email}"',
                             duplicated_services,
                         ),
                     ),

--- a/back/dora/services/csv_import.py
+++ b/back/dora/services/csv_import.py
@@ -5,7 +5,7 @@ from types import SimpleNamespace
 from typing import Any, Dict, List, Optional, Union
 
 from django.db import IntegrityError, transaction
-from django.db.models import QuerySet
+from django.db.models import Q, QuerySet
 from django.utils import timezone
 
 from dora.core.utils import get_geo_data, skip_csv_lines
@@ -91,9 +91,11 @@ class ImportServicesHelper:
 
                         data = self._extract_data_from_line(line)
 
-                        # Vérification que le SIRET de la structure est bien renseigné
-                        if not data.structure_siret:
-                            error_msg = f"[{idx}] SIRET manquant pour la structure."
+                        # Vérification que l'identifiant de la structure est fourni
+                        if not data.structure_siret_or_slug:
+                            error_msg = (
+                                f"[{idx}] SIRET ou slug de la structure manquant."
+                            )
                             logger.warning("❌ %s", error_msg)
                             self.errors.append(error_msg)
                             continue
@@ -101,10 +103,11 @@ class ImportServicesHelper:
                         # Vérification que la structure existe bien en BDD
                         try:
                             structure = Structure.objects.get(
-                                siret=data.structure_siret
+                                Q(siret=data.structure_siret_or_slug)
+                                | Q(slug=data.structure_siret_or_slug)
                             )
                         except Structure.DoesNotExist:
-                            error_msg = f"[{idx}] Structure avec le SIRET {data.structure_siret} introuvable."
+                            error_msg = f'[{idx}] Structure avec le SIRET ou le slug "{data.structure_siret_or_slug}" introuvable.'
                             logger.warning("❌ %s", error_msg)
                             self.errors.append(error_msg)
                             continue
@@ -122,15 +125,15 @@ class ImportServicesHelper:
                             continue
 
                         should_service_be_created = (
-                            self._check_if_service_is_duplicated(data, idx)
+                            self._check_if_service_is_duplicated(data, idx, structure)
                         )
 
                         if not should_service_be_created:
                             continue
 
                         logger.info(
-                            "Création d'un nouveau service pour la structure avec le SIRET '%s'.",
-                            data.structure_siret,
+                            "Création d'un nouveau service pour la structure '%s'.",
+                            data.structure_siret_or_slug,
                         )
                         new_service = instantiate_service_from_model(
                             model, structure, self.importing_user
@@ -236,7 +239,9 @@ class ImportServicesHelper:
     def _extract_data_from_line(self, line: Dict[str, str]) -> SimpleNamespace:
         data = SimpleNamespace(
             modele_slug=line.get("modele_slug").strip(),
-            structure_siret=line.get("structure_siret").replace(" ", "").strip(),
+            structure_siret_or_slug=line.get("structure_siret_or_slug")
+            .replace(" ", "")
+            .strip(),
             contact_name=line.get("contact_name").strip(),
             contact_email=line.get("contact_email").strip(),
             contact_phone=line.get("contact_phone").replace(" ", "").strip(),
@@ -322,9 +327,11 @@ class ImportServicesHelper:
         )
         self.source = source
 
-    def _check_if_service_is_duplicated(self, data: SimpleNamespace, idx: int) -> bool:
+    def _check_if_service_is_duplicated(
+        self, data: SimpleNamespace, idx: int, structure
+    ) -> bool:
         base_filter = {
-            "structure__siret": data.structure_siret,
+            "structure": structure,
             "model__slug": data.modele_slug,
             "contact_email": data.contact_email,
         }
@@ -343,20 +350,16 @@ class ImportServicesHelper:
         if has_location_data and Service.objects.filter(**full_filter).exists():
             error_msg = (
                 f'[{idx}] Le même service avec le modèle "{data.modele_slug}", le référent "{data.contact_email}" '
-                f"et la même adresse existe déjà pour la structure "
-                f'dont le Siret est "{data.structure_siret}".'
+                f'et la même adresse existe déjà pour la structure "{data.structure_siret_or_slug}".'
             )
-
             self.errors.append(error_msg)
-            logger.warning(
-                error_msg,
-            )
+            logger.warning(error_msg)
             return False
 
         self.duplicated_services.append(
             {
                 "idx": idx,
-                "siret": data.structure_siret,
+                "structure_siret_or_slug": data.structure_siret_or_slug,
                 "model_slug": data.modele_slug,
                 "contact_email": data.contact_email,
             }
@@ -389,7 +392,7 @@ class ImportServicesHelper:
 
     CSV_HEADERS = [
         "modele_slug",
-        "structure_siret",
+        "structure_siret_or_slug",
         "contact_email",
         "diffusion_zone_type",
         "labels_financement",

--- a/back/dora/services/tests/__snapshots__/test_import_services.ambr
+++ b/back/dora/services/tests/__snapshots__/test_import_services.ambr
@@ -6,7 +6,7 @@
       
       Traitement de la ligne 2 :
     ''',
-    "Création d'un nouveau service pour la structure avec le SIRET '12345678901234'.",
+    "Création d'un nouveau service pour la structure '12345678901234'.",
     '✅ Service créé.',
   ])
 # ---
@@ -34,7 +34,7 @@
       
       Traitement de la ligne 2 :
     ''',
-    "Création d'un nouveau service pour la structure avec le SIRET '12345678901234'.",
+    "Création d'un nouveau service pour la structure '12345678901234'.",
     '✅ Service créé.',
   ])
 # ---

--- a/back/dora/services/tests/test_admin_import_view.py
+++ b/back/dora/services/tests/test_admin_import_view.py
@@ -203,14 +203,14 @@ class ImportServicesViewTestCase(APITestCase):
             "duplicated_services": [
                 {
                     "idx": 2,
-                    "siret": "1234",
+                    "structure_siret_or_slug": "1234",
                     "name": "Service A",
                     "model_slug": "slug_1",
                     "contact_email": "a@a.com",
                 },
                 {
                     "idx": 3,
-                    "siret": "3456",
+                    "structure_siret_or_slug": "3456",
                     "model_slug": "slug_2",
                     "name": "Service B",
                     "contact_email": "b@b.com",
@@ -231,8 +231,8 @@ class ImportServicesViewTestCase(APITestCase):
                 "level": "warning",
                 "message": mark_safe(
                     "<b>Import réalisé - Doublons potentiels détectés</b><br/>Nous avons détecté des similitudes avec des services existants. Nous vous recommandons de vérifier :<br/>"
-                    '• [2] SIRET 1234 - il existe déjà un service avec le modèle slug_1 et le courriel "a@a.com"<br/>'
-                    '• [3] SIRET 3456 - il existe déjà un service avec le modèle slug_2 et le courriel "b@b.com"'
+                    '• [2] Structure "1234" - il existe déjà un service avec le modèle slug_1 et le courriel "a@a.com"<br/>'
+                    '• [3] Structure "3456" - il existe déjà un service avec le modèle slug_2 et le courriel "b@b.com"'
                 ),
             },
         )
@@ -289,14 +289,14 @@ class ImportServicesViewTestCase(APITestCase):
             "duplicated_services": [
                 {
                     "idx": 2,
-                    "siret": "1234",
+                    "structure_siret_or_slug": "1234",
                     "name": "Service A",
                     "model_slug": "slug_1",
                     "contact_email": "a@a.com",
                 },
                 {
                     "idx": 3,
-                    "siret": "3456",
+                    "structure_siret_or_slug": "3456",
                     "name": "Service B",
                     "model_slug": "slug_2",
                     "contact_email": "b@b.com",
@@ -334,8 +334,8 @@ class ImportServicesViewTestCase(APITestCase):
                 "level": "warning",
                 "message": mark_safe(
                     "<b>Doublons potentiels détectés</b><br/>Nous avons détecté des similitudes avec des services existants. Nous vous recommandons de vérifier :<br/>"
-                    '• [2] SIRET 1234 - il existe déjà un service avec le modèle slug_1 et le courriel "a@a.com"<br/>'
-                    '• [3] SIRET 3456 - il existe déjà un service avec le modèle slug_2 et le courriel "b@b.com"'
+                    '• [2] Structure "1234" - il existe déjà un service avec le modèle slug_1 et le courriel "a@a.com"<br/>'
+                    '• [3] Structure "3456" - il existe déjà un service avec le modèle slug_2 et le courriel "b@b.com"'
                 ),
             },
         )
@@ -367,14 +367,14 @@ class ImportServicesViewTestCase(APITestCase):
             "duplicated_services": [
                 {
                     "idx": 2,
-                    "siret": "1234",
+                    "structure_siret_or_slug": "1234",
                     "name": "Service A",
                     "model_slug": "slug_1",
                     "contact_email": "a@a.com",
                 },
                 {
                     "idx": 3,
-                    "siret": "3456",
+                    "structure_siret_or_slug": "3456",
                     "name": "Service B",
                     "model_slug": "slug_2",
                     "contact_email": "b@b.com",
@@ -405,8 +405,8 @@ class ImportServicesViewTestCase(APITestCase):
                 "level": "warning",
                 "message": mark_safe(
                     "<b>Import réalisé - Doublons potentiels détectés</b><br/>Nous avons détecté des similitudes avec des services existants. Nous vous recommandons de vérifier :<br/>"
-                    '• [2] SIRET 1234 - il existe déjà un service avec le modèle slug_1 et le courriel "a@a.com"<br/>'
-                    '• [3] SIRET 3456 - il existe déjà un service avec le modèle slug_2 et le courriel "b@b.com"'
+                    '• [2] Structure "1234" - il existe déjà un service avec le modèle slug_1 et le courriel "a@a.com"<br/>'
+                    '• [3] Structure "3456" - il existe déjà un service avec le modèle slug_2 et le courriel "b@b.com"'
                 ),
             },
         )

--- a/back/dora/services/tests/test_import_services.py
+++ b/back/dora/services/tests/test_import_services.py
@@ -32,7 +32,7 @@ def test_management_command(caplog, capsys, tmp_path, snapshot, wet_run):
     csv_file.write_text(
         "\n".join(
             [
-                "modele_slug,structure_siret,contact_email,labels_financement,contact_name,contact_phone,location_kinds,location_city,location_address,location_complement,location_postal_code,diffusion_zone_type,is_contact_info_public",
+                "modele_slug,structure_siret_or_slug,contact_email,labels_financement,contact_name,contact_phone,location_kinds,location_city,location_address,location_complement,location_postal_code,diffusion_zone_type,is_contact_info_public",
                 f"{service_model.slug},{structure.siret},referent@email.com,{funding_label.value},Test Person,0123456789,,,,,,city,",
             ]
         )
@@ -57,8 +57,10 @@ def test_management_command(caplog, capsys, tmp_path, snapshot, wet_run):
 class ImportServicesTestCase(TestCase):
     def setUp(self):
         self.importing_user = baker.make("users.User")
-        self.csv_headers = "modele_slug,structure_siret,contact_email,labels_financement,contact_name,contact_phone,location_kinds,location_city,location_address,location_complement,location_postal_code,diffusion_zone_type,is_contact_info_public"
-        self.structure = baker.make("Structure", siret="12345678901234")
+        self.csv_headers = "modele_slug,structure_siret_or_slug,contact_email,labels_financement,contact_name,contact_phone,location_kinds,location_city,location_address,location_complement,location_postal_code,diffusion_zone_type,is_contact_info_public"
+        self.structure = baker.make(
+            "Structure", siret="12345678901234", slug="ma-structure"
+        )
 
         self.service_model = baker.make(
             "Service",
@@ -148,10 +150,10 @@ class ImportServicesTestCase(TestCase):
             Service.objects.filter(contact_email="referent@email.com").exists()
         )
 
-    def test_missing_siret(self):
+    def test_missing_siret_or_slug(self):
         csv_content = (
             f"{self.csv_headers}\n"
-            f"{self.service_model.slug},,referent@email.com,{self.funding_label.value},,,,,,,,,"
+            f"{self.service_model.slug},,referent@email.com,{self.funding_label.value},,,,,,,,"
         )
 
         reader = csv.reader(io.StringIO(csv_content))
@@ -161,12 +163,31 @@ class ImportServicesTestCase(TestCase):
         )
 
         self.assertEqual(result["created_count"], 0)
-        self.assertEqual(result["errors"][0], "[2] SIRET manquant pour la structure.")
+        self.assertEqual(
+            result["errors"][0], "[2] SIRET ou slug de la structure manquant."
+        )
 
-    def test_invalid_structure_siret(self):
+    def test_import_with_structure_slug(self):
         csv_content = (
             f"{self.csv_headers}\n"
-            f"{self.service_model.slug},'invalid-siret',referent@email.com,{self.funding_label.value},,,,,,,,,"
+            f"{self.service_model.slug},{self.structure.slug},referent@email.com,{self.funding_label.value},Test Person,0123456789,,,,,,city,"
+        )
+
+        reader = csv.reader(io.StringIO(csv_content))
+
+        result = self.import_services_helper.import_services(
+            reader, self.importing_user, self.source_info, wet_run=True
+        )
+
+        self.assertEqual(result["created_count"], 1)
+        self.assertEqual(result["errors"], [])
+        created_service = Service.objects.filter(creator=self.importing_user).last()
+        self.assertEqual(created_service.structure, self.structure)
+
+    def test_invalid_structure_slug(self):
+        csv_content = (
+            f"{self.csv_headers}\n"
+            f"{self.service_model.slug},invalid-slug,referent@email.com,{self.funding_label.value},,,,,,,,,"
         )
 
         reader = csv.reader(io.StringIO(csv_content))
@@ -178,7 +199,40 @@ class ImportServicesTestCase(TestCase):
         self.assertEqual(result["created_count"], 0)
         self.assertEqual(
             result["errors"][0],
-            "[2] Structure avec le SIRET 'invalid-siret' introuvable.",
+            '[2] Structure avec le SIRET ou le slug "invalid-slug" introuvable.',
+        )
+
+    def test_missing_structure_siret_or_slug_column(self):
+        headers_without_structure = "modele_slug,contact_email,labels_financement,contact_name,contact_phone,location_kinds,location_city,location_address,location_complement,location_postal_code,diffusion_zone_type,is_contact_info_public"
+        csv_content = (
+            f"{headers_without_structure}\n"
+            f"{self.service_model.slug},referent@email.com,{self.funding_label.value},,,,,,,,,"
+        )
+
+        reader = csv.reader(io.StringIO(csv_content))
+
+        result = self.import_services_helper.import_services(
+            reader, self.importing_user, self.source_info, wet_run=True
+        )
+
+        self.assertIn("structure_siret_or_slug", result["missing_headers"])
+
+    def test_invalid_structure_siret(self):
+        csv_content = (
+            f"{self.csv_headers}\n"
+            f"{self.service_model.slug},99999999999999,referent@email.com,{self.funding_label.value},,,,,,,,,"
+        )
+
+        reader = csv.reader(io.StringIO(csv_content))
+
+        result = self.import_services_helper.import_services(
+            reader, self.importing_user, self.source_info, wet_run=True
+        )
+
+        self.assertEqual(result["created_count"], 0)
+        self.assertEqual(
+            result["errors"][0],
+            '[2] Structure avec le SIRET ou le slug "99999999999999" introuvable.',
         )
 
     def test_invalid_service_model_slug(self):
@@ -699,7 +753,7 @@ class ImportServicesTestCase(TestCase):
                 "contact_email": "referent@email.com",
                 "idx": 2,
                 "model_slug": "test-service-model",
-                "siret": "12345678901234",
+                "structure_siret_or_slug": self.structure.siret,
             },
         )
 
@@ -728,8 +782,7 @@ class ImportServicesTestCase(TestCase):
         self.assertEqual(
             result["errors"][0],
             f'[2] Le même service avec le modèle "{self.service_model.slug}", le référent "referent@email.com" '
-            f"et la même adresse existe déjà pour la structure "
-            f'dont le Siret est "{self.structure.siret}".',
+            f'et la même adresse existe déjà pour la structure "{self.structure.siret}".',
         )
         self.assertEqual(len(result["duplicated_services"]), 0)
 
@@ -785,7 +838,7 @@ class ImportServicesTestCase(TestCase):
         self.assertEqual(created_service.source, existing_source)
 
     def test_missing_headers(self):
-        missing_headers = "modele_slug,structure_siret,contact_email,diffusion_zone_type,labels_financement,contact_name,contact_phone,location_kinds,location_city,location_address,location_complement"
+        missing_headers = "modele_slug,structure_siret_or_slug,contact_email,diffusion_zone_type,labels_financement,contact_name,contact_phone,location_kinds,location_city,location_address,location_complement"
         csv_content = (
             f"{missing_headers}\n"
             f"{self.service_model.slug},{self.structure.siret},referent@email.com,"


### PR DESCRIPTION
## Contexte

L'import de service nécessite le Siret de la structure associée. Or, les antennes n'ont pas forcément de Siret. L'import de services pour ces antennes n'est donc pas possible.

## Solution

Renommage de la colonne `structure_siret` en `structure_siret_or_slug` et acceptation d'un Siret ou d'un slug.

## Changements

Adaptation du code d'import des services et tests associés pour prendre en compte la possibilité du slug..

Le template a été modifié pour renommer la colonne en `structure_siret_or_slug`.