### PR TITLE
fix: supprimer le fichier du stockage quand l'utilisateur clique sur le bouton "poubelle"

### DIFF
--- a/back/config/urls.py
+++ b/back/config/urls.py
@@ -94,6 +94,7 @@ private_api_patterns = [
     path("structures-options/", dora.structures.views.options),
     path("upload/<slug:structure_slug>/<str:filename>/", dora.core.views.upload),
     path("safe-upload/<str:filename>/", dora.core.views.safe_upload),
+    path("delete-upload/<path:filename>/", dora.core.views.delete_upload),
     path("admin/", admin.site.urls),
     path("ping/", dora.core.views.ping),
     path("sentry-debug/", dora.core.views.trigger_error),

--- a/back/dora/core/tests/test_views.py
+++ b/back/dora/core/tests/test_views.py
@@ -100,3 +100,16 @@ class SafeFileUploadTestCase(APITestCase):
         self.assertEqual(mock_save.call_args[0][1].name, "test.pdf")
         self.assertEqual(response.status_code, 201)
         self.assertEqual(response.data["key"], "upload_key")
+
+
+class FileDeleteTestCase(APITestCase):
+    @patch("dora.core.views.default_storage.delete")
+    def test_delete_file(self, mock_delete):
+        self.user = make_user(is_active=True)
+        self.client.force_authenticate(user=self.user)
+
+        response = self.client.delete("/delete-upload/path/to/file/test.pdf/")
+
+        assert response.status_code == 204
+        assert mock_delete.call_count == 1
+        assert mock_delete.call_args[0][0] == "path/to/file/test.pdf"

--- a/back/dora/core/views.py
+++ b/back/dora/core/views.py
@@ -59,6 +59,13 @@ def safe_upload(request: Request, filename: str) -> Response:
     return Response({"key": result}, status=201)
 
 
+@api_view(["DELETE"])
+@permission_classes([IsAuthenticated])
+def delete_upload(request: Request, filename: str) -> Response:
+    default_storage.delete(filename)
+    return Response(status=204)
+
+
 @api_view()
 @permission_classes([permissions.AllowAny])
 def ping(request: Request) -> Response:

--- a/front/src/lib/components/inputs/uploader.svelte
+++ b/front/src/lib/components/inputs/uploader.svelte
@@ -6,6 +6,7 @@
   import { shortenString } from "$lib/utils/misc";
 
   import Alert from "../display/alert.svelte";
+  import { deleteFile } from "$lib/requests/upload";
 
   interface Props {
     id: string;
@@ -39,8 +40,12 @@
     fileKeys = newFiles;
   }
 
-  function handleRemove(fileKey: string) {
-    updateFiles(localFiles.filter((key) => key !== fileKey));
+  async function handleRemove(fileKey: string) {
+    const isFileDeleted = await deleteFile(fileKey);
+
+    if (isFileDeleted) {
+      updateFiles(localFiles.filter((key) => key !== fileKey));
+    }
   }
 
   function clearInput() {

--- a/front/src/lib/requests/upload.ts
+++ b/front/src/lib/requests/upload.ts
@@ -1,0 +1,18 @@
+import { getApiURL } from "$lib/utils/api";
+import { getToken } from "$lib/utils/auth";
+
+export async function deleteFile(fileName: string) {
+  const encodedFileName = encodeURIComponent(fileName);
+  const url = `${getApiURL()}/delete-upload/${encodedFileName}/`;
+
+  const method = "DELETE";
+  const res = await fetch(url, {
+    method,
+    headers: {
+      Accept: "application/json; version=1.0",
+      Authorization: `Token ${getToken()}`,
+    },
+  });
+
+  return res.ok;
+}


### PR DESCRIPTION
J'ai pas mis un message d'erreur quand la requête qui supprime le fichier échoue parce qu'il me semble d'être un niveau de complexité qui n'est pas nécessaire.

Fichier chargé sur le formulaire d'orientation : 

https://github.com/user-attachments/assets/b9a32ed5-d74b-4511-af1f-6e31ca49ea95

Fichier chargé pour un service : 

https://github.com/user-attachments/assets/16bd9267-ca94-45ad-8d5d-240e44f06a3d



