### PR TITLE
feat: Mise en cohérence des statuts des structures entre la page et l'export

### DIFF
--- a/front/src/lib/requests/admin.ts
+++ b/front/src/lib/requests/admin.ts
@@ -1,5 +1,5 @@
 import type {
-  AdminShortStructure,
+  AdminStructure,
   ModerationStatus,
   Service,
   Structure,
@@ -10,19 +10,19 @@ import { fetchData } from "$lib/utils/misc";
 
 export async function getStructuresAdmin(
   departmentCode
-): Promise<AdminShortStructure[]> {
+): Promise<AdminStructure[]> {
   let url = `${getApiURL()}/structures-admin/`;
 
   if (departmentCode) {
     url += `?department=${departmentCode}`;
   }
-  return (await fetchData<AdminShortStructure[]>(url)).data;
+  return (await fetchData<AdminStructure[]>(url)).data;
 }
 
 export async function getStructureAdmin(
   slug: string,
   fetchFunction = fetch
-): Promise<AdminShortStructure> {
+): Promise<AdminStructure> {
   const url = `${getApiURL()}/structures-admin/${slug}/`;
   return (await fetchData<Structure>(url, fetchFunction)).data;
 }

--- a/front/src/lib/types.ts
+++ b/front/src/lib/types.ts
@@ -110,12 +110,17 @@ export interface ShortStructure {
 
 export interface AdminShortStructure {
   adminAlreadyInvited: boolean;
+  awaitingActivation: boolean;
+  awaitingModeration: boolean;
+  awaitingUpdate: boolean;
   categories: ServiceCategory[];
   city: string;
   department: string;
   email: string;
   hasAdmin: boolean;
   isObsolete: boolean;
+  isOrphan: boolean;
+  isWaiting: boolean;
   latitude: number;
   longitude: number;
   moderationDate: string;

--- a/front/src/lib/types.ts
+++ b/front/src/lib/types.ts
@@ -108,7 +108,7 @@ export interface ShortStructure {
   servicesToUpdate: { name: string; slug: string }[];
 }
 
-export interface AdminShortStructure {
+export interface AdminStructure {
   adminAlreadyInvited: boolean;
   awaitingActivation: boolean;
   awaitingModeration: boolean;

--- a/front/src/routes/admin/structures/+page.svelte
+++ b/front/src/routes/admin/structures/+page.svelte
@@ -13,7 +13,7 @@
   import { CANONICAL_URL } from "$lib/env";
   import AddFillSystem from "svelte-remix/AddFillSystem.svelte";
   import { getStructuresAdmin } from "$lib/requests/admin";
-  import type { AdminShortStructure, GeoApiValue } from "$lib/types";
+  import type { AdminStructure, GeoApiValue } from "$lib/types";
 
   import type { PageData } from "./$types";
   import DepartmentList from "./department-list.svelte";
@@ -34,8 +34,8 @@
   let searchStatus: StatusFilter = $state("all");
   let filterDefinition: string | undefined = $state();
   let filterActions: string | undefined = $state();
-  let structures: AdminShortStructure[] = $state([]);
-  let filteredStructures: AdminShortStructure[] = $state([]);
+  let structures: AdminStructure[] = $state([]);
+  let filteredStructures: AdminStructure[] = $state([]);
   let selectedStructureSlug: string | null = $state(null);
   let loading = $state(false);
 

--- a/front/src/routes/admin/structures/+page.svelte
+++ b/front/src/routes/admin/structures/+page.svelte
@@ -20,7 +20,7 @@
   import Filters from "./filters.svelte";
   import StructuresMap from "./structures-map.svelte";
   import StructuresTable from "./structures-table.svelte";
-  import { getStructureStatus, STATUS_LABELS } from "./structures-filters";
+  import { getStructureStatus, getStatusLabel } from "./structures-filters";
   import type { StatusFilter } from "./types";
   import { generateSpreadsheet } from "$lib/utils/spreadsheet";
 
@@ -82,7 +82,7 @@
 
     const sheetData = filteredStructures.map((structure) => {
       const structStatus = getStructureStatus(structure);
-      const status = structStatus ? STATUS_LABELS[structStatus] : "";
+      const status = structStatus ? getStatusLabel(structStatus) : "";
 
       // prettier-ignore
       return {

--- a/front/src/routes/admin/structures/+page.svelte
+++ b/front/src/routes/admin/structures/+page.svelte
@@ -82,7 +82,7 @@
 
     const sheetData = filteredStructures.map((structure) => {
       const structStatus = getStructureStatus(structure);
-      const status = structStatus ? getStatusLabel(structStatus) : "";
+      const status = getStatusLabel(structStatus);
 
       // prettier-ignore
       return {

--- a/front/src/routes/admin/structures/+page.svelte
+++ b/front/src/routes/admin/structures/+page.svelte
@@ -20,14 +20,7 @@
   import Filters from "./filters.svelte";
   import StructuresMap from "./structures-map.svelte";
   import StructuresTable from "./structures-table.svelte";
-  import {
-    isOrphan,
-    toActivate,
-    waiting,
-    isObsolete,
-    toUpdate,
-    toModerate,
-  } from "./structures-filters";
+  import { getStructureStatus, STATUS_LABELS } from "./structures-filters";
   import type { StatusFilter } from "./types";
   import { generateSpreadsheet } from "$lib/utils/spreadsheet";
 
@@ -38,7 +31,7 @@
   let { data }: Props = $props();
 
   let selectedDepartment = $state(data.department);
-  let searchStatus: StatusFilter = $state("toutes");
+  let searchStatus: StatusFilter = $state("all");
   let filterDefinition: string | undefined = $state();
   let filterActions: string | undefined = $state();
   let structures: AdminShortStructure[] = $state([]);
@@ -50,14 +43,14 @@
     function isOrphanOrWaitingOrToActivateSIAE(struct) {
       return (
         ["ETTI", "ACI", "AI", "EI"].includes(struct.typology) &&
-        (isOrphan(struct) || waiting(struct) || toActivate(struct))
+        (struct.isOrphan || struct.isWaiting || struct.awaitingActivation)
       );
     }
 
     return structs.filter(
       (struct) =>
-        isObsolete(struct) ||
-        toModerate(struct) ||
+        struct.isObsolete ||
+        struct.awaitingModeration ||
         !isOrphanOrWaitingOrToActivateSIAE(struct)
     );
   }
@@ -88,20 +81,8 @@
     }
 
     const sheetData = filteredStructures.map((structure) => {
-      let status = "";
-      if (isObsolete(structure)) {
-        status = "obsolète";
-      } else if (isOrphan(structure)) {
-        status = "orpheline";
-      } else if (waiting(structure)) {
-        status = "en attente";
-      } else if (toModerate(structure)) {
-        status = "à modérer";
-      } else if (toActivate(structure)) {
-        status = "à activer";
-      } else if (toUpdate(structure)) {
-        status = "à actualiser";
-      }
+      const structStatus = getStructureStatus(structure);
+      const status = structStatus ? STATUS_LABELS[structStatus] : "";
 
       // prettier-ignore
       return {
@@ -248,7 +229,7 @@
               secondary
               disabled={!filteredStructures.length}
             />
-            {#if searchStatus !== "toutes" && filterDefinition}
+            {#if searchStatus !== "all" && filterDefinition}
               <Notice type="info" title={filterDefinition}>
                 <div>
                   {#if filterActions}

--- a/front/src/routes/admin/structures/filters.svelte
+++ b/front/src/routes/admin/structures/filters.svelte
@@ -6,7 +6,7 @@
   import Select from "$lib/components/inputs/select/select.svelte";
   import Tooltip from "$lib/components/ui/tooltip.svelte";
   import type {
-    AdminShortStructure,
+    AdminStructure,
     ServiceCategory,
     ServicesOptions,
     StructuresOptions,
@@ -22,8 +22,8 @@
     filterActions?: string;
     servicesOptions: ServicesOptions;
     structuresOptions: StructuresOptions;
-    structures?: AdminShortStructure[];
-    filteredStructures: AdminShortStructure[];
+    structures?: AdminStructure[];
+    filteredStructures: AdminStructure[];
   }
 
   let {
@@ -137,7 +137,7 @@
   }
 
   function filterAndSortEntities(
-    structs: AdminShortStructure[],
+    structs: AdminStructure[],
     params: SearchParams,
     status: StatusFilter
   ) {

--- a/front/src/routes/admin/structures/filters.svelte
+++ b/front/src/routes/admin/structures/filters.svelte
@@ -13,15 +13,7 @@
     Typology,
   } from "$lib/types";
 
-  import {
-    adminAlreadyInvited,
-    isOrphan,
-    isObsolete,
-    toActivate,
-    toModerate,
-    toUpdate,
-    waiting,
-  } from "./structures-filters";
+  import { getStructureStatus, STATUS_LABELS } from "./structures-filters";
   import type { StatusFilter } from "./types";
 
   interface Props {
@@ -46,61 +38,53 @@
 
   const statusFilterSettings: {
     status: StatusFilter;
-    label: string;
     definition: string;
     actions?: string;
   }[] = [
-    { status: "toutes", label: "Toutes", definition: "Toutes les structures" },
+    { status: "all", definition: "Toutes les structures" },
     {
-      status: "orphelines",
-      label: "Sans utilisateur",
+      status: "orphan",
       definition:
         "Structures référencées mais sans utilisateur actif ou invité",
       actions:
         "Identifier un responsable et l’inviter à devenir administrateur de la structure.",
     },
     {
-      status: "en_attente",
-      label: "Administrateur invité",
+      status: "waiting",
       definition:
         "Structures où un administrateur invité n’a pas encore accepté l’invitation",
       actions:
         "Relancer l’administrateur via le tableau de bord, puis par mail/téléphone, ou identifier un autre administrateur en dernier recours.",
     },
     {
-      status: "invitation_expirée",
-      label: "Invitation expirée",
+      status: "expiredInvitation",
       definition:
         "Structures où un administrateur a été invité mais supprimé au bout de 120 jours (RGPD) en l’absence de réponse à l’invitation",
       actions: "Identifier un autre administrateur.",
     },
     {
-      status: "à_modérer",
-      label: "À valider",
+      status: "awaitingModeration",
       definition:
         "Structures nouvelles ou ayant un 1er administrateur, nécessitant une validation de conformité",
       actions:
         "Vérifier la conformité de la structure et si les administrateurs font bien partie de ses effectifs. En cas de doute, contacter l’équipe DORA.",
     },
     {
-      status: "à_activer",
-      label: "Sans service",
+      status: "awaitingActivation",
       definition:
         "Structures avec un administrateur validé sans services publiés",
       actions:
         "Télécharger la liste des structures à activer, copier-coller les emails des administrateurs pour envoyer un mail groupé les invitant à référencer leurs services sur DORA. Les SIAE sont à exclure car elles n’ont pas vocation à référencer des services supplémentaires.",
     },
     {
-      status: "à_actualiser",
-      label: "Services à actualiser",
+      status: "awaitingUpdate",
       definition:
         "Structures ayant un ou des services publiés qui nécessitent une actualisation",
       actions:
         "Télécharger la liste des structures à activer, copier-coller les emails des administrateurs pour envoyer un mail groupé les invitant à actualiser leur services.",
     },
     {
-      status: "obsolète",
-      label: "Non conforme",
+      status: "obsolete",
       definition:
         "Structures désactivées - qui n’existent plus ou qui ne respectent pas la charte DORA",
     },
@@ -188,52 +172,10 @@
         );
       })
       .filter((struct) => {
-        if (status === "obsolète") {
-          return isObsolete(struct);
-        } else if (status === "orphelines") {
-          return (
-            !isObsolete(struct) &&
-            isOrphan(struct) &&
-            !adminAlreadyInvited(struct)
-          );
-        } else if (status === "en_attente") {
-          return !isObsolete(struct) && !isOrphan(struct) && waiting(struct);
-        } else if (status === "invitation_expirée") {
-          return (
-            !isObsolete(struct) &&
-            isOrphan(struct) &&
-            adminAlreadyInvited(struct)
-          );
-        } else if (status === "à_modérer") {
-          return (
-            !isObsolete(struct) &&
-            !isOrphan(struct) &&
-            !waiting(struct) &&
-            toModerate(struct)
-          );
-        } else if (status === "à_activer") {
-          return (
-            !isObsolete(struct) &&
-            !isOrphan(struct) &&
-            !waiting(struct) &&
-            !toModerate(struct) &&
-            toActivate(struct)
-          );
-        } else if (status === "à_actualiser") {
-          return (
-            !isObsolete(struct) &&
-            !isOrphan(struct) &&
-            !waiting(struct) &&
-            !toModerate(struct) &&
-            !toActivate(struct) &&
-            toUpdate(struct)
-          );
-        } else if (status === "toutes") {
-          // exclusion des structures obsolètes de l'affichage complet
-          return !isObsolete(struct);
+        if (status === "all") {
+          return getStructureStatus(struct) !== "obsolete";
         }
-        console.error("Statut de recherche inconnu");
-        return false;
+        return getStructureStatus(struct) === status;
       })
       .sort((structure1, structure2) => {
         // Fait un premier tri par nom
@@ -263,7 +205,7 @@
 
   function resetSearchParams() {
     searchParams = emptySearchParams;
-    searchStatus = "toutes";
+    searchStatus = "all";
   }
 
   $effect(() => {
@@ -278,7 +220,7 @@
 <div class="mb-s8 font-bold">Structures nécessitant une action&#8239;:</div>
 
 <div class="mb-s8 gap-s8 flex flex-wrap">
-  {#each statusFilterSettings as { status, label, definition, actions }}
+  {#each statusFilterSettings as { status, definition, actions }}
     <Tooltip>
       <Button
         onclick={() => {
@@ -287,7 +229,7 @@
           filterDefinition = definition;
           filterActions = actions;
         }}
-        label="{label}{status !== 'toutes'
+        label="{STATUS_LABELS[status]}{status !== 'all'
           ? ` (${filterAndSortEntities(structures, searchParams, status).length})`
           : ''}"
         secondary={searchStatus !== status}

--- a/front/src/routes/admin/structures/filters.svelte
+++ b/front/src/routes/admin/structures/filters.svelte
@@ -13,7 +13,7 @@
     Typology,
   } from "$lib/types";
 
-  import { getStructureStatus, STATUS_LABELS } from "./structures-filters";
+  import { getStructureStatus, getStatusLabel } from "./structures-filters";
   import type { StatusFilter } from "./types";
 
   interface Props {
@@ -229,7 +229,7 @@
           filterDefinition = definition;
           filterActions = actions;
         }}
-        label="{STATUS_LABELS[status]}{status !== 'all'
+        label="{getStatusLabel(status)}{status !== 'all'
           ? ` (${filterAndSortEntities(structures, searchParams, status).length})`
           : ''}"
         secondary={searchStatus !== status}

--- a/front/src/routes/admin/structures/structure-modal.svelte
+++ b/front/src/routes/admin/structures/structure-modal.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import Modal from "$lib/components/hoc/modal.svelte";
   import { getStructureAdmin } from "$lib/requests/admin";
-  import type { AdminShortStructure } from "$lib/types";
+  import type { AdminStructure } from "$lib/types";
   import ModerationButtonMenu from "../moderation-button-menu.svelte";
   import StructureContacts from "../structure-contacts.svelte";
 
@@ -17,7 +17,7 @@
     onRefresh,
   }: Props = $props();
 
-  let structure: AdminShortStructure | null = $state(null);
+  let structure: AdminStructure | null = $state(null);
 
   async function handleRefresh() {
     structure = structureSlug ? await getStructureAdmin(structureSlug) : null;

--- a/front/src/routes/admin/structures/structures-filters.ts
+++ b/front/src/routes/admin/structures/structures-filters.ts
@@ -1,4 +1,4 @@
-import type { AdminShortStructure } from "$lib/types";
+import type { AdminStructure } from "$lib/types";
 import type { StatusFilter } from "./types";
 
 const STATUS_LABELS: Record<StatusFilter, string> = {
@@ -13,7 +13,7 @@ const STATUS_LABELS: Record<StatusFilter, string> = {
 };
 
 export function getStructureStatus(
-  struct: AdminShortStructure
+  struct: AdminStructure
 ): Exclude<StatusFilter, "all"> | undefined {
   // ⚠️ L'ordre des conditions est important
   if (struct.isObsolete) {

--- a/front/src/routes/admin/structures/structures-filters.ts
+++ b/front/src/routes/admin/structures/structures-filters.ts
@@ -1,27 +1,37 @@
-export function isOrphan(struct) {
-  return struct.isOrphan;
-}
+import type { AdminShortStructure } from "$lib/types";
+import type { StatusFilter } from "./types";
 
-export function isObsolete(struct) {
-  return struct.isObsolete;
-}
+export const STATUS_LABELS: Record<StatusFilter, string> = {
+  all: "Toutes",
+  orphan: "Sans utilisateur",
+  waiting: "Administrateur invité",
+  expiredInvitation: "Invitation expirée",
+  awaitingModeration: "À valider",
+  awaitingActivation: "Sans service",
+  awaitingUpdate: "Services à actualiser",
+  obsolete: "Non conforme",
+};
 
-export function waiting(struct) {
-  return struct.isWaiting;
-}
-
-export function adminAlreadyInvited(struct) {
-  return struct.adminAlreadyInvited;
-}
-
-export function toModerate(struct) {
-  return struct.awaitingModeration;
-}
-
-export function toActivate(struct) {
-  return struct.awaitingActivation;
-}
-
-export function toUpdate(struct) {
-  return struct.awaitingUpdate;
+export function getStructureStatus(
+  struct: AdminShortStructure
+): Exclude<StatusFilter, "all"> | undefined {
+  if (struct.isObsolete) {
+    return "obsolete";
+  }
+  if (struct.isOrphan) {
+    return struct.adminAlreadyInvited ? "expiredInvitation" : "orphan";
+  }
+  if (struct.isWaiting) {
+    return "waiting";
+  }
+  if (struct.awaitingModeration) {
+    return "awaitingModeration";
+  }
+  if (struct.awaitingActivation) {
+    return "awaitingActivation";
+  }
+  if (struct.awaitingUpdate) {
+    return "awaitingUpdate";
+  }
+  return undefined;
 }

--- a/front/src/routes/admin/structures/structures-filters.ts
+++ b/front/src/routes/admin/structures/structures-filters.ts
@@ -37,6 +37,9 @@ export function getStructureStatus(
   return undefined;
 }
 
-export function getStatusLabel(status: StatusFilter): string {
-  return STATUS_LABELS[status];
+export function getStatusLabel(status?: StatusFilter): string {
+  if (!status) {
+    return "";
+  }
+  return STATUS_LABELS[status] ?? "";
 }

--- a/front/src/routes/admin/structures/structures-filters.ts
+++ b/front/src/routes/admin/structures/structures-filters.ts
@@ -1,7 +1,7 @@
 import type { AdminShortStructure } from "$lib/types";
 import type { StatusFilter } from "./types";
 
-export const STATUS_LABELS: Record<StatusFilter, string> = {
+const STATUS_LABELS: Record<StatusFilter, string> = {
   all: "Toutes",
   orphan: "Sans utilisateur",
   waiting: "Administrateur invité",
@@ -35,4 +35,8 @@ export function getStructureStatus(
     return "awaitingUpdate";
   }
   return undefined;
+}
+
+export function getStatusLabel(status: StatusFilter): string {
+  return STATUS_LABELS[status];
 }

--- a/front/src/routes/admin/structures/structures-filters.ts
+++ b/front/src/routes/admin/structures/structures-filters.ts
@@ -15,6 +15,7 @@ export const STATUS_LABELS: Record<StatusFilter, string> = {
 export function getStructureStatus(
   struct: AdminShortStructure
 ): Exclude<StatusFilter, "all"> | undefined {
+  // ⚠️ L'ordre des conditions est important
   if (struct.isObsolete) {
     return "obsolete";
   }

--- a/front/src/routes/admin/structures/structures-map.svelte
+++ b/front/src/routes/admin/structures/structures-map.svelte
@@ -4,10 +4,10 @@
   import * as mlgl from "maplibre-gl";
 
   import Map from "$lib/components/display/map.svelte";
-  import type { AdminShortStructure } from "$lib/types";
+  import type { AdminStructure } from "$lib/types";
 
   interface Props {
-    filteredStructures?: AdminShortStructure[];
+    filteredStructures?: AdminStructure[];
     selectedStructureSlug: string | null;
   }
 
@@ -23,7 +23,7 @@
     );
   }
 
-  function zoomToStructures(features: AdminShortStructure[]) {
+  function zoomToStructures(features: AdminStructure[]) {
     if (!map) {
       return;
     }
@@ -33,7 +33,7 @@
         features[0].latitude,
       ];
       const bounds = features.reduce(
-        function (acc: mlgl.LngLatBounds, feature: AdminShortStructure) {
+        function (acc: mlgl.LngLatBounds, feature: AdminStructure) {
           return acc.extend([feature.longitude, feature.latitude]);
         },
         new mlgl.LngLatBounds(firstCoordinates, firstCoordinates)
@@ -143,7 +143,7 @@
     zoomToStructures(filteredStructures);
   }
 
-  function updateMapContent(structures: AdminShortStructure[]) {
+  function updateMapContent(structures: AdminStructure[]) {
     if (!map) {
       return;
     }

--- a/front/src/routes/admin/structures/structures-table.svelte
+++ b/front/src/routes/admin/structures/structures-table.svelte
@@ -7,14 +7,14 @@
   import Button from "$lib/components/display/button.svelte";
   import LinkButton from "$lib/components/display/link-button.svelte";
   import { modifyStructure } from "$lib/requests/structures";
-  import type { AdminShortStructure } from "$lib/types";
+  import type { AdminStructure } from "$lib/types";
   import { userInfo } from "$lib/utils/auth";
   import { capitalize, shortenString } from "$lib/utils/misc";
 
   import StructureModal from "./structure-modal.svelte";
 
   interface Props {
-    filteredStructures: AdminShortStructure[];
+    filteredStructures: AdminStructure[];
     selectedStructureSlug: string | null;
     onRefresh: any;
   }
@@ -26,10 +26,10 @@
   }: Props = $props();
 
   let isStructureModalOpen = $state(false);
-  let currentStructure: AdminShortStructure | null = $state(null);
+  let currentStructure: AdminStructure | null = $state(null);
 
   async function updateStructureObsolete(
-    structure: AdminShortStructure,
+    structure: AdminStructure,
     isObsolete: boolean
   ) {
     structure.isObsolete = isObsolete;

--- a/front/src/routes/admin/structures/types.ts
+++ b/front/src/routes/admin/structures/types.ts
@@ -1,9 +1,9 @@
 export type StatusFilter =
-  | "orphelines"
-  | "en_attente"
-  | "invitation_expirée"
-  | "à_modérer"
-  | "à_activer"
-  | "à_actualiser"
-  | "obsolète"
-  | "toutes";
+  | "orphan"
+  | "waiting"
+  | "expiredInvitation"
+  | "awaitingModeration"
+  | "awaitingActivation"
+  | "awaitingUpdate"
+  | "obsolete"
+  | "all";


### PR DESCRIPTION
## Contexte

Les statuts de l'export ne correspondent pas aux statuts du nouveau tableau de bord GT.

## Solution

Utiliser le même algorithme d'assignation des statuts aux structures et les mêmes noms de statuts sur la page et dans l'export.

## Changements

- Mise en commun de l'algorithme d'assignation des statuts et des noms des statuts dans `structures-filters.ts` ;
- Mise en cohérence des identificateurs ;
- Simplification du code ;
- Amélioration du typage.