### PR TITLE
feat: Export des données analytics de Dora vers la base de données Pilotage

### DIFF
--- a/analytics/sync-analytics.sh
+++ b/analytics/sync-analytics.sh
@@ -28,7 +28,7 @@ load_env_file_if_exists() {
 check_required_vars() {
     echo "💎 Vérification des variables d'environnement requises..."
 
-    required_vars=("DORA_DATABASE_URL" "DATABASE_URL" "S3_BUCKET_VARIANT" "S3_ACCESS_KEY" "S3_SECRET_KEY")
+    required_vars=("DORA_DATABASE_URL" "PILOTAGE_DATABASE_URL" "DATABASE_URL" "S3_BUCKET_VARIANT" "S3_ACCESS_KEY" "S3_SECRET_KEY")
     missing_vars=()
 
     for var in "${required_vars[@]}"; do
@@ -82,10 +82,14 @@ fetch_and_export_dora_data() {
     cat models/_sources.yml | grep '      - name' | cut -d':' -f2 >tables.txt
     xargs -I {} echo -n "-t {} " <tables.txt >args.txt
 
+    # Export des données de la base de données DORA dans un fichier dump
     time pg_dump "$DORA_DATABASE_URL" --jobs=8 --format=directory --compress=1 --clean --if-exists --no-owner --no-privileges --verbose $(cat args.txt) --file=/tmp/out.dump
-    time psql "$DATABASE_URL" -c "DROP SCHEMA public CASCADE; CREATE SCHEMA public; CREATE EXTENSION IF NOT EXISTS postgis;"
-    time pg_restore --dbname="$DATABASE_URL" --jobs=8 --format=directory --clean --if-exists --no-owner --no-privileges --verbose /tmp/out.dump
     
+    # Copie des données vers la base de données analytics.
+    # On purge aussi un éventuel raw_dora résiduel (cf. export pilotage plus bas)
+    time psql "$DATABASE_URL" -c "DROP SCHEMA IF EXISTS public CASCADE; DROP SCHEMA IF EXISTS raw_dora CASCADE; CREATE SCHEMA public; CREATE EXTENSION IF NOT EXISTS postgis;"
+    time pg_restore --dbname="$DATABASE_URL" --jobs=8 --format=directory --clean --if-exists --no-owner --no-privileges --verbose /tmp/out.dump
+
     # Clean the files created by the script as they now serve no purpose and could contains sensitive data
     rm tables.txt args.txt
     shred -u -z /tmp/out.dump/*
@@ -134,6 +138,21 @@ VACUUM FULL public.services_service;
 VACUUM FULL public.users_user;
 VACUUM FULL public.logs_actionlog
 SQL
+
+    # Copie des données (déjà nettoyées) vers la base pilotage, dans le schéma raw_dora.
+    # Renommage temporaire du schéma public en raw_dora.
+    psql "$DATABASE_URL" -c "ALTER SCHEMA public RENAME TO raw_dora;"
+    # En cas d'échec, on remet la base analytics dans son état attendu (schéma public).
+    trap 'psql "$DATABASE_URL" -c "ALTER SCHEMA raw_dora RENAME TO public;" >/dev/null 2>&1 || true' EXIT
+
+    # On restreint l'export au schéma raw_dora. --extension=postgis force l'inclusion
+    # de l'extension PostGIS (et donc du type geometry) que --schema seul omettrait
+    time psql "$PILOTAGE_DATABASE_URL" -c "DROP SCHEMA IF EXISTS raw_dora CASCADE;"
+    time pg_dump "$DATABASE_URL" --schema=raw_dora --extension=postgis --no-owner --no-privileges --verbose \
+        | psql "$PILOTAGE_DATABASE_URL" --set ON_ERROR_STOP=1
+
+    psql "$DATABASE_URL" -c "ALTER SCHEMA raw_dora RENAME TO public;"
+    trap - EXIT
 
     echo "✔️ Fait."
     echo ""

--- a/analytics/sync-analytics.sh
+++ b/analytics/sync-analytics.sh
@@ -79,7 +79,7 @@ fetch_and_export_dora_data() {
     fi
 
     # Generate the list of tables to be exported
-    cat models/_sources.yml | grep '      - name' | cut -d':' -f2 >tables.txt
+    cat models/_sources.yml | grep -E '^      - name' | cut -d':' -f2 >tables.txt
     xargs -I {} echo -n "-t {} " <tables.txt >args.txt
 
     # Export des données de la base de données DORA dans un fichier dump


### PR DESCRIPTION
## Objectif

`sync-analytics.sh` copie désormais aussi le jeu de données Dora dans la base Pilotage, dans un schéma dédié `raw_dora`, sans toucher au schéma public existant de Pilotage.

## Fonctionnement

`pg_restore` ne sait pas changer un objet de schéma, et le dump source est qualifié sur public. Plutôt que de réécrire le SQL à la volée (ce qui risquerait de corrompre toute donnée contenant la chaîne `public.`), on utilise la base `analytics` comme zone de transit jetable :

1. Suppression des colonnes sensibles avant l'export ;
2. Renommage temporaire du schéma `public` en `raw_dora` ;
3. Suppression et recréation du schéma `raw_data` sur la base Pilotage ;
4. Dump restreint à ce schéma (`pg_dump --schema=raw_dora --extension=postgis`) envoyé vers la base Pilotage ;
5. Renommage du schéma `raw_dora` en `public`.

En cas d'erreur, le schéma de la base `analytics` est renommé en `public`.

## Autre changement

Correction du grep de la liste des tables pour ne capturer que les tables et plus les colonnes.