### PR TITLE
feat: Mise à niveau de PostgreSQL à la version 17 en environnement de dev

### DIFF
--- a/back/docker-compose.yml
+++ b/back/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   db:
-    image: postgis/postgis:16-3.4-alpine
+    image: postgis/postgis:18-3.6-alpine
     env_file:
       - envs/dev.env
       - envs/secrets.env


### PR DESCRIPTION
Cette PR fait passer l'image db de postgis/postgis:16-3.4-alpine à 17-3.6-alpine (PostgreSQL 17.9 + PostGIS 3.6.2, conforme à la production sur Scalingo).

Le format de stockage sur disque de PostgreSQL n'est pas compatible entre versions majeures. Il faut donc recréer le volume et restaurer la base de données.

```
# 1. Suppression de l'ancien conteneur db + son volume de données
docker compose rm -sf db
docker volume rm back_pgdata  # vérifiez le nom exact avec : docker volume ls | grep pgdata

# 2. Recréation du conteneur sur la nouvelle image
docker compose up -d db

# 3. Repeuplement de la base
python manage.py migrate
make populate_db   # ou restaurer un dump anonymisé (voir le README)
```