### PR TITLE
feat: Proposer un formulaire d'orientation intégré avec fichiers

### DIFF
--- a/back/README.md
+++ b/back/README.md
@@ -58,7 +58,7 @@ brew install graphviz
 ```
 Pour Linux:
 ```bash
-sudo apt install graphviz
+sudo apt install graphviz graphviz-dev
 ```
 
 Les consignes d'installation sont [ici](https://graphviz.org/download/).'

--- a/back/dora/core/tests/test_views.py
+++ b/back/dora/core/tests/test_views.py
@@ -80,9 +80,9 @@ class SafeFileUploadTestCase(APITestCase):
 
         self.client.force_authenticate(user=self.user)
 
-    @patch("dora.core.views.validate_upload")
-    @patch("dora.core.views.get_random_string", return_value="random_string")
-    @patch("dora.core.views.default_storage.save", return_value="upload_key")
+    @patch("dora.core.uploads.validate_upload")
+    @patch("dora.core.uploads.get_random_string", return_value="random_string")
+    @patch("dora.core.uploads.default_storage.save", return_value="upload_key")
     def test_safe_file_upload(self, mock_save, mock_random_string, mock_validate):
         response = self.client.post(
             self.url, {"file": self.file_mock}, format="multipart"

--- a/back/dora/core/uploads.py
+++ b/back/dora/core/uploads.py
@@ -1,0 +1,16 @@
+from django.conf import settings
+from django.core.files.storage import default_storage
+from django.core.files.uploadedfile import UploadedFile
+from django.utils.crypto import get_random_string
+from django.utils.text import get_valid_filename
+
+from dora.core.file_upload_validators import validate_upload
+
+
+def save_orientation_attachment(filename: str, file_obj: UploadedFile) -> str:
+    validate_upload(filename, file_obj)
+    path = (
+        f"{settings.ENVIRONMENT}/#orientations/"
+        f"{get_random_string(32)}/{get_valid_filename(filename)}"
+    )
+    return default_storage.save(path, file_obj)

--- a/back/dora/core/views.py
+++ b/back/dora/core/views.py
@@ -3,7 +3,6 @@ import logging
 from django.conf import settings
 from django.core.files.storage import default_storage
 from django.shortcuts import get_object_or_404
-from django.utils.crypto import get_random_string
 from django.utils.text import get_valid_filename
 from rest_framework import permissions
 from rest_framework.decorators import (
@@ -20,6 +19,7 @@ from rest_framework.response import Response
 
 from dora.core.file_upload_validators import validate_upload
 from dora.core.throttling import StructureUploadThrottle, UploadRateThrottle
+from dora.core.uploads import save_orientation_attachment
 from dora.services.models import Service
 from dora.structures.models import Structure
 
@@ -53,9 +53,8 @@ def upload(request: Request, filename: str, structure_slug: str) -> Response:
 @throttle_classes([UploadRateThrottle])
 def safe_upload(request: Request, filename: str) -> Response:
     file_obj = request.data["file"]
-    validate_upload(filename, file_obj)
-    clean_filename = f"{settings.ENVIRONMENT}/#orientations/{get_random_string(32)}/{get_valid_filename(filename)}"
-    result = default_storage.save(clean_filename, file_obj)
+    # coupled to "orientations" bucket for now
+    result = save_orientation_attachment(filename, file_obj)
     return Response({"key": result}, status=201)
 
 

--- a/back/dora/emplois/serializers.py
+++ b/back/dora/emplois/serializers.py
@@ -160,6 +160,12 @@ class EmploisOrientationSerializer(OrientationSerializer):
             },
         }
 
+    def validate_beneficiary_attachments(self, value):
+        raise serializers.ValidationError(
+            "Ce champ est renseigné à partir des fichiers joints "
+            "et ne peut pas être fourni directement."
+        )
+
     def create(self, validated_data):
         emplois_data = validated_data.pop("emplois_data")
         with transaction.atomic():

--- a/back/dora/emplois/tests/test_emplois_orientations.py
+++ b/back/dora/emplois/tests/test_emplois_orientations.py
@@ -1,8 +1,12 @@
+import json
 import uuid
+from unittest.mock import patch
 
 import pytest
+from django.core.files.uploadedfile import SimpleUploadedFile
 from django.urls import reverse
 from model_bakery import baker
+from rest_framework.exceptions import ValidationError
 
 from dora.core.test_utils import make_service
 from dora.orientations.models import (
@@ -26,11 +30,14 @@ EMPLOIS_DATA = {
 }
 
 
-def post_orientation(api_client, payload):
+def post_orientation(api_client, payload, attachments=None):
+    data = {"data": json.dumps(payload)}
+    if attachments:
+        data["attachments"] = list(attachments)
     return api_client.post(
         reverse(ORIENTATION_URL),
-        data=payload,
-        format="json",
+        data=data,
+        format="multipart",
     )
 
 
@@ -259,3 +266,130 @@ def test_orientations_create_rejects_invalid_structure_siret(
     assert response.status_code == 400
     assert "emplois_data" in response.data
     assert "structure_siret" in response.data["emplois_data"]
+
+
+def test_orientations_create_without_attachments_stores_empty_list(
+    emplois_api_client, valid_payload
+):
+    response = post_orientation(emplois_api_client, valid_payload)
+
+    assert response.status_code == 201, response.data
+    orientation = Orientation.objects.get(di_service_id=DEFAULT_DI_SERVICE_ID)
+    assert orientation.beneficiary_attachments == []
+
+
+def test_orientations_create_rejects_client_supplied_attachment_paths(
+    emplois_api_client, valid_payload
+):
+    payload = {**valid_payload, "beneficiary_attachments": ["malicious/path.pdf"]}
+    response = post_orientation(emplois_api_client, payload)
+
+    assert response.status_code == 400
+    assert "beneficiary_attachments" in response.data
+    assert Orientation.objects.count() == 0
+
+
+@patch("dora.emplois.views.save_orientation_attachment")
+def test_orientations_create_with_attachments_uploads_in_one_call(
+    mock_save_orientation_attachment,
+    emplois_api_client,
+    valid_payload,
+):
+    mock_save_orientation_attachment.side_effect = [
+        "orientations/justificatif.pdf",
+        "orientations/cv.pdf",
+    ]
+    attachments = [
+        SimpleUploadedFile("justificatif.pdf", b"%PDF-1.4 fake"),
+        SimpleUploadedFile("cv.pdf", b"%PDF-1.4 fake"),
+    ]
+
+    response = post_orientation(
+        emplois_api_client, valid_payload, attachments=attachments
+    )
+
+    assert response.status_code == 201, response.data
+    assert mock_save_orientation_attachment.call_count == 2
+
+    expected_paths = ["orientations/justificatif.pdf", "orientations/cv.pdf"]
+    orientation = Orientation.objects.get(di_service_id=DEFAULT_DI_SERVICE_ID)
+    assert orientation.beneficiary_attachments == expected_paths
+    assert response.data["beneficiary_attachments"] == expected_paths
+
+
+@patch(
+    "dora.emplois.views.save_orientation_attachment",
+    return_value="orientations/justificatif.pdf",
+)
+@patch("dora.emplois.views.default_storage.delete")
+def test_orientations_create_validates_before_uploading(
+    mock_delete,
+    mock_save_orientation_attachment,
+    emplois_api_client,
+    base_payload,
+):
+    # di_service_id manquant -> la validation du serializer échoue AVANT tout
+    # upload : aucun fichier n'est envoyé ni supprimé sur S3.
+    attachments = [SimpleUploadedFile("justificatif.pdf", b"%PDF-1.4 fake")]
+
+    response = post_orientation(
+        emplois_api_client, base_payload, attachments=attachments
+    )
+
+    assert response.status_code == 400
+    assert mock_save_orientation_attachment.call_count == 0
+    assert mock_delete.call_count == 0
+    assert Orientation.objects.count() == 0
+
+
+@patch("dora.emplois.views.save_orientation_attachment")
+@patch("dora.emplois.views.default_storage.delete")
+def test_orientations_create_cleans_up_uploads_when_an_upload_fails(
+    mock_delete,
+    mock_save_orientation_attachment,
+    emplois_api_client,
+    valid_payload,
+):
+    # if 2nd upload fails, the first file is deleted
+    mock_save_orientation_attachment.side_effect = [
+        "orientations/cv.pdf",
+        ValidationError("FILE_TOO_BIG"),
+    ]
+    attachments = [
+        SimpleUploadedFile("cv.pdf", b"%PDF-1.4 fake"),
+        SimpleUploadedFile("too-big.pdf", b"%PDF-1.4 fake"),
+    ]
+
+    response = post_orientation(
+        emplois_api_client, valid_payload, attachments=attachments
+    )
+
+    assert response.status_code == 400
+    assert mock_save_orientation_attachment.call_count == 2
+    mock_delete.assert_called_once_with("orientations/cv.pdf")
+    assert Orientation.objects.count() == 0
+
+
+def test_orientations_create_rejects_missing_data_part(emplois_api_client):
+    response = emplois_api_client.post(
+        reverse(ORIENTATION_URL),
+        data={
+            # no JSON
+            "attachments": [SimpleUploadedFile("justificatif.pdf", b"%PDF-1.4 fake")]
+        },
+        format="multipart",
+    )
+
+    assert response.status_code == 400
+    assert "data" in response.data
+
+
+def test_orientations_create_rejects_invalid_data_json(emplois_api_client):
+    response = emplois_api_client.post(
+        reverse(ORIENTATION_URL),
+        data={"data": "{not valid json"},
+        format="multipart",
+    )
+
+    assert response.status_code == 400
+    assert "data" in response.data

--- a/back/dora/emplois/views.py
+++ b/back/dora/emplois/views.py
@@ -1,8 +1,12 @@
+import json
+
 from django.conf import settings
+from django.core.files.storage import default_storage
 from django.db.models import CharField, Prefetch, Value
 from rest_framework import mixins, permissions, status, viewsets
 from rest_framework.decorators import api_view, permission_classes, renderer_classes
 from rest_framework.exceptions import ValidationError
+from rest_framework.parsers import FormParser, MultiPartParser
 from rest_framework.renderers import JSONRenderer
 from rest_framework.response import Response
 from rest_framework.versioning import NamespaceVersioning
@@ -11,6 +15,8 @@ from dora.core.pagination import (
     DefaultPageNumberPagination,
     OptionalPageNumberPagination,
 )
+from dora.core.throttling import UploadRateThrottle
+from dora.core.uploads import save_orientation_attachment
 from dora.orientations.models import Orientation
 from dora.services.models import (
     BeneficiaryAccessMode,
@@ -29,6 +35,8 @@ from .serializers import (
     ReferenceDataSerializer,
     ServiceSerializer,
 )
+
+MAX_ORIENTATION_ATTACHMENTS = 20  # we have a few cases with ~10 files
 
 PREFETCH_RELATED_SERVICE_LIST = [
     "publics",
@@ -137,13 +145,43 @@ class OrientationViewSet(
 ):
     permission_classes = (OrientationAPIPermission,)
     serializer_class = EmploisOrientationSerializer
+    parser_classes = (MultiPartParser, FormParser)
     renderer_classes = (JSONRenderer,)
+    throttle_classes = (UploadRateThrottle,)
 
     def create(self, request, *args, **kwargs):
-        serializer = self.get_serializer(data=request.data)
+        try:
+            payload = json.loads(request.data["data"])
+        except (LookupError, TypeError, ValueError):
+            raise ValidationError({"data": "Invalid or missing 'data' field."})
+
+        serializer = self.get_serializer(data=payload)
         serializer.is_valid(raise_exception=True)
-        self.perform_create(serializer)
-        return Response(serializer.initial_data, status=status.HTTP_201_CREATED)
+
+        attachments = request.FILES.getlist("attachments")
+        if len(attachments) > MAX_ORIENTATION_ATTACHMENTS:
+            raise ValidationError(
+                {
+                    "attachments": f"Vous ne pouvez pas joindre plus de {MAX_ORIENTATION_ATTACHMENTS} fichiers."
+                }
+            )
+
+        saved_paths = []
+        try:
+            for file_obj in attachments:
+                saved_paths.append(save_orientation_attachment(file_obj.name, file_obj))
+
+            serializer.validated_data["beneficiary_attachments"] = saved_paths
+            self.perform_create(serializer)
+        except Exception:  # we want to delete files if any error occurs
+            for path in saved_paths:
+                default_storage.delete(path)
+            raise
+
+        response_data = dict(serializer.initial_data)
+        if saved_paths:
+            response_data["beneficiary_attachments"] = saved_paths
+        return Response(response_data, status=status.HTTP_201_CREATED)
 
     def perform_create(self, serializer):
         serializer.save(


### PR DESCRIPTION
## Objectif

Le POST sur l'API orientations des Emplois était un passage de données JSON brutes, présupposant l'upload préalable de documents justificatifs (via safe_upload) et nécessitant en particulier un ramasse miettes.

Ici nous proposons une approche un peu différente:
- le prescripteur finalise tranquillement son funnel d'orientation sur les Emplois
- il "uploade" les fichiers via l'upload classique des Emplois, qui valide taille et extension
- les fichiers sont envoyés et reellement uploadés vers le S3 de DORA à la soumission finale

Pas de safe upload séparé, pas de cron nécessaire, mais aussi pas besoin de gérer l'ajout suppression en "live" dans la page de formulaire coté emplois.
