### PR TITLE
fix: Correction du plantage de l'éditeur de texte riche qui figeait les formulaires

### DIFF
--- a/front/src/lib/components/inputs/rich-text/editor.svelte
+++ b/front/src/lib/components/inputs/rich-text/editor.svelte
@@ -68,9 +68,9 @@
       ],
       content: markdownToHTML(initialContent),
       injectCSS: false,
-      onTransaction: () => {
+      onTransaction: ({ editor: editorInstance }) => {
         // force re-render so `editor.isActive` works as expected
-        htmlContent = htmlToMarkdown(editor.getHTML());
+        htmlContent = htmlToMarkdown(editorInstance.getHTML());
       },
       editorProps: {
         attributes: {


### PR DESCRIPTION
## Contexte

La réactivité est cassée sur les formulaires d'édition des service et structure depuis la mise à jour de dépendances dans fed134a4adcb3f0000fb5589f71676d44f014916.

## Explication

L'instance de l'éditeur était lue depuis la variable `editor`, encore `undefined` lors de la première transaction déclenchée de façon synchrone par TipTap pendant `new Editor(...)`. L'exception levée durant le flush des effets Svelte interrompait tout le lot réactif, rendant statiques tous les formulaires contenant un champ de texte riche (services, structures).

## Solution

On utilise désormais l'instance fournie en argument de la callback `onTransaction()`.

## Test

Aller sur le formulaire de création/édition de structure ou de service et tester les comportements réactifs :

- pliage et dépliage des sous-champs lors de la sélection de _Via notre propre formulaire en ligne/site internet_ ou _Autre modalité (préciser)_ ;
- pliage et dépliage des sections avec le bouton _Aide_ ;
- enregistrement du formulaire.

**Avant :** aucune réactivité, tout reste statique.
**Après :** les comportement réactifs fonctionnent bien.

<img width="502" height="334" alt="image" src="https://github.com/user-attachments/assets/4da06a9d-c6bc-4d3b-af83-f0edbf4b2efa" />
 
<img width="94" height="57" alt="image" src="https://github.com/user-attachments/assets/9e125a55-ab8d-430d-a3cd-d38954fdb554" />
