### PR TITLE
fix: API POST Orientation : Siret facultatif

### DIFF
--- a/back/dora/emplois/serializers.py
+++ b/back/dora/emplois/serializers.py
@@ -92,7 +92,9 @@ class EmploisOrientationDataSerializer(serializers.Serializer):
     beneficiary_id = serializers.UUIDField()
     structure_id = serializers.UUIDField()
     structure_name = serializers.CharField(max_length=140)
-    structure_siret = serializers.CharField(max_length=14, validators=[validate_siret])
+    structure_siret = serializers.CharField(
+        max_length=14, validators=[validate_siret], required=False, allow_blank=True
+    )
     prescriber_id = serializers.UUIDField()
     prescriber_email = serializers.EmailField()
     prescriber_first_name = serializers.CharField(max_length=140)

--- a/back/dora/emplois/tests/test_emplois_orientations.py
+++ b/back/dora/emplois/tests/test_emplois_orientations.py
@@ -177,7 +177,6 @@ def test_orientations_create_requires_mandatory_fields(
         "beneficiary_id",
         "structure_id",
         "structure_name",
-        "structure_siret",
         "prescriber_id",
         "prescriber_email",
         "prescriber_first_name",


### PR DESCRIPTION
Le Siret est maintenant facultatif lors du post d'une orientation par les Emplois.