### PR TITLE
fix: corriger les redirections 308 et le décodage du contenu dans le proxy API

### DIFF
--- a/front/src/routes/api/[...path]/+server.ts
+++ b/front/src/routes/api/[...path]/+server.ts
@@ -32,6 +32,8 @@ async function proxyRequest(event: Parameters<RequestHandler>[0]) {
 
   const responseHeaders = new Headers(response.headers);
   responseHeaders.delete("set-cookie");
+  responseHeaders.delete("content-encoding");
+  responseHeaders.delete("content-length");
 
   return new Response(response.body, {
     status: response.status,

--- a/front/src/routes/api/[...path]/+server.ts
+++ b/front/src/routes/api/[...path]/+server.ts
@@ -2,6 +2,8 @@ import type { RequestHandler } from "@sveltejs/kit";
 import { API_URL } from "$lib/env";
 import { TOKEN_KEY } from "$lib/utils/auth";
 
+export const trailingSlash = "ignore";
+
 async function proxyRequest(event: Parameters<RequestHandler>[0]) {
   const { request, cookies, params } = event;
   const token = cookies.get(TOKEN_KEY);


### PR DESCRIPTION
 Contexte

  Le frontend SvelteKit dispose d'un proxy serveur (routes/api/[...path]/+server.ts) qui intercepte les requêtes relatives /api/... émises par les fonctions load côté serveur et les redirige vers l'API Django. Ce
  proxy n'est pas utilisé pour les appels API côté navigateur, qui partent directement vers VITE_API_URL.

  En environnement local, VITE_API_URL=http://localhost:8000 pointe directement vers Django sur un port différent. Les appels API côté navigateur sont donc cross-origin et le proxy n'est jamais sollicité. C'est 
  pourquoi ces bugs n'étaient pas visibles en local : pour les reproduire, il fallait pointer VITE_API_URL vers un environnement distant (staging/production), ce qui fait passer les appels par le proxy.

  Problème 1 — Redirect 308 (x-sveltekit-normalize)

  SvelteKit normalise automatiquement les URLs en supprimant les slashes finaux, et émet un redirect permanent 308 avant même que le handler de route ne s'exécute. Les requêtes vers /api/auth/user-info/ étaient
  donc redirigées vers /api/auth/user-info, empêchant le proxy de traiter la requête. Ce 308 étant permanent, les navigateurs le mettaient en cache indéfiniment.

  Correction : export const trailingSlash = "ignore" dans le fichier +server.ts du proxy. SvelteKit ne normalise plus les URLs sur cette route, et le handler s'exécute directement. La logique normalizedPath déjà
  présente dans le proxy se charge d'ajouter le slash final avant de transmettre la requête à Django.

  Problème 2 — ERR_CONTENT_DECODING_FAILED                                                                                                                           

  Le fetch Node.js (utilisé côté serveur par SvelteKit) décompresse automatiquement les réponses gzip/brotli de Django. Le proxy récupérait donc un body déjà décompressé, mais transmettait quand même les headers
  originaux de Django — notamment Content-Encoding: gzip et Content-Length — au navigateur. Ce dernier tentait alors de décompresser des données qui l'étaient déjà, provoquant l'erreur.

  Correction : suppression de content-encoding et content-length des headers de réponse avant de les transmettre au navigateur.
