### PR TITLE
fix: supprimer des documents inutiles stocké dans le s3

### DIFF
--- a/back/cron.json
+++ b/back/cron.json
@@ -31,6 +31,10 @@
     {
       "command": "0 6 * * * tools/anonymize-orientations.sh",
       "size": "S"
+    },
+    {
+      "command": "0 4 * * * tools/delete-orphaned-documents.sh",
+      "size": "S"
     }
   ]
 }

--- a/back/cron.json
+++ b/back/cron.json
@@ -33,7 +33,7 @@
       "size": "S"
     },
     {
-      "command": "0 4 * * * tools/delete-orphaned-documents.sh",
+      "command": "0 4 * * * tools/delete-orphaned-uploads.sh",
       "size": "S"
     }
   ]

--- a/back/dora/core/management/commands/delete_orphaned_uploads.py
+++ b/back/dora/core/management/commands/delete_orphaned_uploads.py
@@ -56,6 +56,18 @@ class Command(BaseCommand):
         service_form_paths = set(
             chain.from_iterable(Service.objects.values_list("forms", flat=True))
         )
+
+        if Orientation.objects.exists() and not orientation_paths:
+            self.logger.error(
+                "Abandon : orientations présentes en base mais aucun chemin extrait — suppression annulée par sécurité."
+            )
+            return
+        if Service.objects.exists() and not service_form_paths:
+            self.logger.error(
+                "Abandon : services présents en base mais aucun chemin extrait — suppression annulée par sécurité."
+            )
+            return
+
         documents_to_keep = orientation_paths | service_form_paths
 
         deleted = 0

--- a/back/dora/core/management/commands/delete_orphaned_uploads.py
+++ b/back/dora/core/management/commands/delete_orphaned_uploads.py
@@ -10,9 +10,9 @@ from dora.core.commands import BaseCommand
 from dora.orientations.models import Orientation
 from dora.services.models import Service
 
-ORPHAN_AGE_HOURS = 3
+ORPHAN_AGE_HOURS = 0
 
-# Matches orientation attachments (#orientations/) and service forms (structure UUID/).
+# Correspond aux préfixes des documents pour les orientations (#orientations/) ou les formulaires des services (structure UUID/).
 _MANAGED_KEY = re.compile(
     rf"^{re.escape(settings.ENVIRONMENT)}/"
     r"(#orientations/|[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/)"

--- a/back/dora/core/management/commands/delete_orphaned_uploads.py
+++ b/back/dora/core/management/commands/delete_orphaned_uploads.py
@@ -22,7 +22,7 @@ def _iter_objects():
 
 
 class Command(BaseCommand):
-    help = "Supprime les fichiers uploadés orphelins (non référencés en base) de plus de 6 heures"
+    help = f"Supprime les fichiers uploadés orphelins (non référencés en base) de plus de {ORPHAN_AGE_HOURS} heures"
 
     def add_arguments(self, parser):
         parser.add_argument(

--- a/back/dora/core/management/commands/delete_orphaned_uploads.py
+++ b/back/dora/core/management/commands/delete_orphaned_uploads.py
@@ -53,18 +53,20 @@ class Command(BaseCommand):
                 Orientation.objects.values_list("beneficiary_attachments", flat=True)
             )
         )
+
+        if not orientation_paths:
+            self.logger.error(
+                "Abandon : aucun chemin extrait pour les orientations — suppression annulée par sécurité."
+            )
+            return
+
         service_form_paths = set(
             chain.from_iterable(Service.objects.values_list("forms", flat=True))
         )
 
-        if Orientation.objects.exists() and not orientation_paths:
+        if not service_form_paths:
             self.logger.error(
-                "Abandon : orientations présentes en base mais aucun chemin extrait — suppression annulée par sécurité."
-            )
-            return
-        if Service.objects.exists() and not service_form_paths:
-            self.logger.error(
-                "Abandon : services présents en base mais aucun chemin extrait — suppression annulée par sécurité."
+                "Abandon : aucun chemin extrait pour les services — suppression annulée par sécurité."
             )
             return
 

--- a/back/dora/core/management/commands/delete_orphaned_uploads.py
+++ b/back/dora/core/management/commands/delete_orphaned_uploads.py
@@ -1,3 +1,4 @@
+import re
 from datetime import timedelta
 from itertools import chain
 
@@ -11,14 +12,25 @@ from dora.services.models import Service
 
 ORPHAN_AGE_HOURS = 3
 
+# Matches orientation attachments (#orientations/) and service forms (structure UUID/).
+_MANAGED_KEY = re.compile(
+    rf"^{re.escape(settings.ENVIRONMENT)}/"
+    r"(#orientations/|[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/)"
+)
+
 
 def _iter_objects():
     """Chercher le file path et la date de la dernière modification de tous les objets dans le bucket s3"""
     client = default_storage.connection.meta.client
     paginator = client.get_paginator("list_objects_v2")
-    for page in paginator.paginate(Bucket=settings.AWS_STORAGE_BUCKET_NAME):
+    for page in paginator.paginate(
+        Bucket=settings.AWS_STORAGE_BUCKET_NAME,
+        Prefix=f"{settings.ENVIRONMENT}/",
+    ):
         for obj in page.get("Contents", ()):
-            yield obj["Key"], obj["LastModified"]
+            key = obj["Key"]
+            if _MANAGED_KEY.match(key):
+                yield key, obj["LastModified"]
 
 
 class Command(BaseCommand):

--- a/back/dora/core/management/commands/delete_orphaned_uploads.py
+++ b/back/dora/core/management/commands/delete_orphaned_uploads.py
@@ -1,0 +1,81 @@
+from datetime import timedelta
+from itertools import chain
+
+from django.conf import settings
+from django.core.files.storage import default_storage
+from django.utils import timezone
+
+from dora.core.commands import BaseCommand
+from dora.orientations.models import Orientation
+from dora.services.models import Service
+
+ORPHAN_AGE_HOURS = 3
+
+
+def _iter_objects():
+    """Chercher le file path et la date de la dernière modification de tous les objets dans le bucket s3"""
+    client = default_storage.connection.meta.client
+    paginator = client.get_paginator("list_objects_v2")
+    for page in paginator.paginate(Bucket=settings.AWS_STORAGE_BUCKET_NAME):
+        for obj in page.get("Contents", ()):
+            yield obj["Key"], obj["LastModified"]
+
+
+class Command(BaseCommand):
+    help = "Supprime les fichiers uploadés orphelins (non référencés en base) de plus de 6 heures"
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--wet-run",
+            action="store_true",
+            default=False,
+            help="Effectue les suppressions (sinon dry-run)",
+        )
+
+    def handle(self, *args, **options):
+        wet_run = options["wet_run"]
+        cutoff = timezone.now() - timedelta(hours=ORPHAN_AGE_HOURS)
+
+        orientation_paths = set(
+            chain.from_iterable(
+                Orientation.objects.values_list("beneficiary_attachments", flat=True)
+            )
+        )
+        service_form_paths = set(
+            chain.from_iterable(Service.objects.values_list("forms", flat=True))
+        )
+        documents_to_keep = orientation_paths | service_form_paths
+
+        deleted = 0
+        skipped_recent = 0
+        skipped_referenced = 0
+
+        for file_path, last_modified in _iter_objects():
+            if file_path in documents_to_keep:
+                skipped_referenced += 1
+                continue
+
+            if last_modified > cutoff:
+                skipped_recent += 1
+                continue
+
+            if wet_run:
+                try:
+                    default_storage.delete(file_path)
+                    deleted += 1
+                    self.logger.info("Supprimé: %s", file_path)
+                except Exception as e:
+                    self.logger.warning(
+                        "Erreur lors de la suppression de %s: %s", file_path, e
+                    )
+            else:
+                self.logger.info("[dry-run] Serait supprimé: %s", file_path)
+                deleted += 1
+
+        self.logger.info(
+            "%d fichiers %s, %d récents ignorés, %d référencés ignorés.",
+            deleted,
+            "supprimés" if wet_run else "seraient supprimés",
+            skipped_recent,
+            skipped_referenced,
+        )

--- a/back/dora/core/management/commands/delete_orphaned_uploads.py
+++ b/back/dora/core/management/commands/delete_orphaned_uploads.py
@@ -10,7 +10,7 @@ from dora.core.commands import BaseCommand
 from dora.orientations.models import Orientation
 from dora.services.models import Service
 
-ORPHAN_AGE_HOURS = 0
+ORPHAN_AGE_HOURS = 3
 
 # Correspond aux préfixes des documents pour les orientations (#orientations/) ou les formulaires des services (structure UUID/).
 _MANAGED_KEY = re.compile(

--- a/back/dora/core/tests/test_delete_orphaned_uploads.py
+++ b/back/dora/core/tests/test_delete_orphaned_uploads.py
@@ -85,8 +85,10 @@ def test_skips_recent_file(mock_iter, mock_delete):
 @patch(BUCKET_OBJECTS)
 def test_deletes_only_old_orphans(mock_iter, mock_delete):
     make_orientation(beneficiary_attachments=["referenced.pdf"])
+    make_service(forms=["form.pdf"])
     mock_iter.return_value = [
         s3_object("referenced.pdf", age_hours=10),
+        s3_object("form.pdf", age_hours=10),
         s3_object("recent_orphan.pdf", age_hours=1),
         s3_object("old_orphan.pdf", age_hours=10),
     ]

--- a/back/dora/core/tests/test_delete_orphaned_uploads.py
+++ b/back/dora/core/tests/test_delete_orphaned_uploads.py
@@ -96,6 +96,32 @@ def test_deletes_only_old_orphans(mock_iter, mock_delete):
     mock_delete.assert_called_once_with("old_orphan.pdf")
 
 
+@pytest.mark.django_db
+@patch(STORAGE_DELETE)
+@patch(BUCKET_OBJECTS)
+def test_aborts_when_orientations_exist_but_have_no_attachments(mock_iter, mock_delete):
+    make_orientation(beneficiary_attachments=[])
+    make_service(forms=["form.pdf"])
+    mock_iter.return_value = [s3_object("orphan.pdf")]
+
+    call_cmd(wet_run=True)
+
+    mock_delete.assert_not_called()
+
+
+@pytest.mark.django_db
+@patch(STORAGE_DELETE)
+@patch(BUCKET_OBJECTS)
+def test_aborts_when_services_exist_but_have_no_forms(mock_iter, mock_delete):
+    make_orientation(beneficiary_attachments=["attachment.pdf"])
+    make_service(forms=[])
+    mock_iter.return_value = [s3_object("orphan.pdf")]
+
+    call_cmd(wet_run=True)
+
+    mock_delete.assert_not_called()
+
+
 @patch("dora.core.management.commands.delete_orphaned_uploads.default_storage")
 def test_iter_objects_skips_unmanaged_path(mock_storage):
     now = timezone.now()

--- a/back/dora/core/tests/test_delete_orphaned_uploads.py
+++ b/back/dora/core/tests/test_delete_orphaned_uploads.py
@@ -8,9 +8,10 @@ from django.utils import timezone
 
 from dora.core.test_utils import make_orientation, make_service
 
-
 BUCKET_OBJECTS = "dora.core.management.commands.delete_orphaned_uploads._iter_objects"
-STORAGE_DELETE = "dora.core.management.commands.delete_orphaned_uploads.default_storage.delete"
+STORAGE_DELETE = (
+    "dora.core.management.commands.delete_orphaned_uploads.default_storage.delete"
+)
 
 
 def s3_object(key, age_hours=10):

--- a/back/dora/core/tests/test_delete_orphaned_uploads.py
+++ b/back/dora/core/tests/test_delete_orphaned_uploads.py
@@ -38,7 +38,14 @@ def test_dry_run_does_not_delete(mock_iter, mock_delete):
 @patch(STORAGE_DELETE)
 @patch(BUCKET_OBJECTS)
 def test_wet_run_deletes_orphan(mock_iter, mock_delete):
-    mock_iter.return_value = [s3_object("orphan.pdf")]
+    make_orientation(beneficiary_attachments=["orientation.pdf"])
+    make_service(forms=["service.pdf"])
+
+    mock_iter.return_value = [
+        s3_object("orphan.pdf"),
+        s3_object("orientation.pdf"),
+        s3_object("service.pdf"),
+    ]
 
     call_cmd(wet_run=True)
 

--- a/back/dora/core/tests/test_delete_orphaned_uploads.py
+++ b/back/dora/core/tests/test_delete_orphaned_uploads.py
@@ -6,6 +6,7 @@ import pytest
 from django.core.management import call_command
 from django.utils import timezone
 
+from dora.core.management.commands.delete_orphaned_uploads import _iter_objects
 from dora.core.test_utils import make_orientation, make_service
 
 BUCKET_OBJECTS = "dora.core.management.commands.delete_orphaned_uploads._iter_objects"
@@ -93,3 +94,22 @@ def test_deletes_only_old_orphans(mock_iter, mock_delete):
     call_cmd(wet_run=True)
 
     mock_delete.assert_called_once_with("old_orphan.pdf")
+
+
+@patch("dora.core.management.commands.delete_orphaned_uploads.default_storage")
+def test_iter_objects_skips_unmanaged_path(mock_storage):
+    now = timezone.now()
+    mock_page = {
+        "Contents": [
+            {"Key": "local/#orientations/abc/file.pdf", "LastModified": now},
+            {"Key": "local/some-other-prefix/file.pdf", "LastModified": now},
+        ]
+    }
+    mock_storage.connection.meta.client.get_paginator.return_value.paginate.return_value = [
+        mock_page
+    ]
+
+    keys = [key for key, _ in _iter_objects()]
+
+    assert "local/#orientations/abc/file.pdf" in keys
+    assert "local/some-other-prefix/file.pdf" not in keys

--- a/back/dora/core/tests/test_delete_orphaned_uploads.py
+++ b/back/dora/core/tests/test_delete_orphaned_uploads.py
@@ -1,0 +1,94 @@
+from datetime import timedelta
+from io import StringIO
+from unittest.mock import patch
+
+import pytest
+from django.core.management import call_command
+from django.utils import timezone
+
+from dora.core.test_utils import make_orientation, make_service
+
+
+BUCKET_OBJECTS = "dora.core.management.commands.delete_orphaned_uploads._iter_objects"
+STORAGE_DELETE = "dora.core.management.commands.delete_orphaned_uploads.default_storage.delete"
+
+
+def s3_object(key, age_hours=10):
+    return (key, timezone.now() - timedelta(hours=age_hours))
+
+
+def call_cmd(**kwargs):
+    call_command("delete_orphaned_uploads", stdout=StringIO(), **kwargs)
+
+
+@pytest.mark.django_db
+@patch(STORAGE_DELETE)
+@patch(BUCKET_OBJECTS)
+def test_dry_run_does_not_delete(mock_iter, mock_delete):
+    mock_iter.return_value = [s3_object("orphan.pdf")]
+
+    call_cmd()
+
+    mock_delete.assert_not_called()
+
+
+@pytest.mark.django_db
+@patch(STORAGE_DELETE)
+@patch(BUCKET_OBJECTS)
+def test_wet_run_deletes_orphan(mock_iter, mock_delete):
+    mock_iter.return_value = [s3_object("orphan.pdf")]
+
+    call_cmd(wet_run=True)
+
+    mock_delete.assert_called_once_with("orphan.pdf")
+
+
+@pytest.mark.django_db
+@patch(STORAGE_DELETE)
+@patch(BUCKET_OBJECTS)
+def test_skips_orientation_attachment(mock_iter, mock_delete):
+    make_orientation(beneficiary_attachments=["referenced.pdf"])
+    mock_iter.return_value = [s3_object("referenced.pdf")]
+
+    call_cmd(wet_run=True)
+
+    mock_delete.assert_not_called()
+
+
+@pytest.mark.django_db
+@patch(STORAGE_DELETE)
+@patch(BUCKET_OBJECTS)
+def test_skips_service_form(mock_iter, mock_delete):
+    make_service(forms=["referenced_form.pdf"])
+    mock_iter.return_value = [s3_object("referenced_form.pdf")]
+
+    call_cmd(wet_run=True)
+
+    mock_delete.assert_not_called()
+
+
+@pytest.mark.django_db
+@patch(STORAGE_DELETE)
+@patch(BUCKET_OBJECTS)
+def test_skips_recent_file(mock_iter, mock_delete):
+    mock_iter.return_value = [s3_object("recent.pdf", age_hours=1)]
+
+    call_cmd(wet_run=True)
+
+    mock_delete.assert_not_called()
+
+
+@pytest.mark.django_db
+@patch(STORAGE_DELETE)
+@patch(BUCKET_OBJECTS)
+def test_deletes_only_old_orphans(mock_iter, mock_delete):
+    make_orientation(beneficiary_attachments=["referenced.pdf"])
+    mock_iter.return_value = [
+        s3_object("referenced.pdf", age_hours=10),
+        s3_object("recent_orphan.pdf", age_hours=1),
+        s3_object("old_orphan.pdf", age_hours=10),
+    ]
+
+    call_cmd(wet_run=True)
+
+    mock_delete.assert_called_once_with("old_orphan.pdf")

--- a/back/tools/delete-orphaned-documents.sh
+++ b/back/tools/delete-orphaned-documents.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+echo "Suppression des documents inutiles dans le stockage s3"
+python /app/manage.py delete_orphaned_documents --wet-run

--- a/back/tools/delete-orphaned-uploads.sh
+++ b/back/tools/delete-orphaned-uploads.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 echo "Suppression des documents inutiles dans le stockage s3"
-python /app/manage.py delete_orphaned_documents --wet-run
+python /app/manage.py delete_orphaned_uploads --wet-run

--- a/back/tools/delete-orphaned-uploads.sh
+++ b/back/tools/delete-orphaned-uploads.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-echo "Suppression des documents inutiles dans le stockage s3"
+echo "Suppression des documents orphelins dans le stockage s3"
 python /app/manage.py delete_orphaned_uploads --wet-run


### PR DESCRIPTION
Ce PR crée une nouvelle commande `delete_orphaned_documents` qui cherche tous les documents stockés dans le s3 et les comparent à tous les documents attachés aux services et aux orientations. Ceux qui n'ont pas d'attachement (et qui ont été créés il y a 3 heures) sont supprimés. 

Cette commande sera tournée tous les jours dans un cron job. 