### PR TITLE
feat: Prise en charge des données prescripteur des Emplois dans les orientations

### DIFF
--- a/back/dora/core/test_utils.py
+++ b/back/dora/core/test_utils.py
@@ -3,6 +3,7 @@ import random
 from django.utils import timezone
 from django.utils.crypto import get_random_string
 from model_bakery import baker
+from model_bakery.random_gen import gen_email
 
 from dora.services.enums import ServiceStatus
 from dora.services.models import ServiceCategory, ServiceSubCategory
@@ -195,5 +196,39 @@ def make_di_orientation(**kwargs):
         di_contact_phone=di_contact_phone,
         di_structure_name=di_structure_name,
         **kwargs,
+    )
+    return orientation
+
+
+def make_emplois_orientation(emplois_data=None, **kwargs):
+    orientation = make_orientation(prescriber=None, prescriber_structure=None, **kwargs)
+    defaults = {
+        "prescriber_email": gen_email,
+        "prescriber_first_name": "Jean",
+        "prescriber_last_name": "Prescripteur",
+        "structure_name": "Structure des Emplois",
+    }
+    baker.make(
+        "orientations.EmploisOrientationData",
+        orientation=orientation,
+        **{**defaults, **(emplois_data or {})},
+    )
+    return orientation
+
+
+def make_jwt_orientation(**kwargs):
+    orientation = make_orientation(**kwargs)
+    # Prescriber info comes from the DORA account (logged-in user); only the
+    # Emplois beneficiary_id / structure_id are kept, filled in by baker.
+    baker.make(
+        "orientations.EmploisOrientationData",
+        orientation=orientation,
+        prescriber_id=None,
+        prescriber_email="",
+        prescriber_first_name="",
+        prescriber_last_name="",
+        prescriber_phone="",
+        structure_name="",
+        structure_siret="",
     )
     return orientation

--- a/back/dora/orientations/admin.py
+++ b/back/dora/orientations/admin.py
@@ -93,9 +93,7 @@ class OrientationAdmin(admin.ModelAdmin):
 
     @admin.display(description="e-mail prescripteur")
     def prescriber_email(self, obj) -> str:
-        if p := obj.prescriber:
-            return p.email
-        return "-"
+        return obj.prescriber_info.email or "-"
 
     @admin.display(description="vérification")
     def orientation_checked(self, obj) -> bool:
@@ -122,7 +120,11 @@ class OrientationAdmin(admin.ModelAdmin):
                 "logitem_set",
             )
             .select_related(
-                "prescriber", "prescriber_structure", "service", "service__structure"
+                "prescriber",
+                "prescriber_structure",
+                "service",
+                "service__structure",
+                "emplois_orientation_data",
             )
         )
         return qs

--- a/back/dora/orientations/emails.py
+++ b/back/dora/orientations/emails.py
@@ -58,11 +58,11 @@ def send_orientation_created_to_structure(orientation, context=None):
         orientation.get_contact_email(),
         mjml2html(render_to_string("orientation-created-structure.mjml", context)),
         from_email=(
-            f"{orientation.prescriber.get_full_name()} via DORA",
+            f"{orientation.prescriber_info.full_name} via DORA",
             settings.DEFAULT_FROM_EMAIL,
         ),
         tags=["orientation"],
-        reply_to=[orientation.prescriber.email],
+        reply_to=[orientation.prescriber_info.email],
     )
 
 
@@ -72,7 +72,7 @@ def send_orientation_created_to_prescriber(orientation, context=None):
 
     send_mail(
         f"{'[Envoyée - Prescripteur] ' if debug else ''}Votre demande a bien été transmise !",
-        orientation.prescriber.email,
+        orientation.prescriber_info.email,
         mjml2html(render_to_string("orientation-created-prescriber.mjml", context)),
         tags=["orientation"],
         reply_to=[orientation.get_contact_email()],
@@ -85,14 +85,14 @@ def send_orientation_created_to_referent(orientation, context=None):
 
     if (
         orientation.referent_email
-        and orientation.referent_email != orientation.prescriber.email
+        and orientation.referent_email != orientation.prescriber_info.email
     ):
         send_mail(
             f"{'[Envoyée - Conseiller référent] ' if debug else ''}Notification d’une demande d’orientation",
             orientation.referent_email,
             mjml2html(render_to_string("orientation-created-referent.mjml", context)),
             tags=["orientation"],
-            reply_to=[orientation.prescriber.email],
+            reply_to=[orientation.prescriber_info.email],
         )
 
 
@@ -108,11 +108,11 @@ def send_orientation_created_to_beneficiary(orientation, context=None):
                 render_to_string("orientation-created-beneficiary.mjml", context)
             ),
             from_email=(
-                f"{orientation.prescriber.get_full_name()} via DORA",
+                f"{orientation.prescriber_info.full_name} via DORA",
                 settings.DEFAULT_FROM_EMAIL,
             ),
             tags=["orientation"],
-            reply_to=[orientation.prescriber.email],
+            reply_to=[orientation.prescriber_info.email],
         )
 
 
@@ -174,7 +174,7 @@ def send_orientation_accepted_emails(
     # Prescripteur
     send_mail(
         f"{'[Validée - Prescripteur] ' if debug else ''}Votre demande a été acceptée ! 🎉",
-        orientation.prescriber.email,
+        orientation.prescriber_info.email,
         mjml2html(render_to_string("orientation-accepted-prescriber.mjml", context)),
         from_email=(
             f"{orientation.get_structure_name()} via DORA",
@@ -186,7 +186,7 @@ def send_orientation_accepted_emails(
     # Référent
     if (
         orientation.referent_email
-        and orientation.referent_email != orientation.prescriber.email
+        and orientation.referent_email != orientation.prescriber_info.email
     ):
         send_mail(
             f"{'[Validée - Conseiller référent] ' if debug else ''}Notification de l’acceptation d’une demande d’orientation",
@@ -197,7 +197,7 @@ def send_orientation_accepted_emails(
                 settings.DEFAULT_FROM_EMAIL,
             ),
             tags=["orientation"],
-            reply_to=[orientation.prescriber.email],
+            reply_to=[orientation.prescriber_info.email],
         )
     # Bénéficiaire
     if orientation.beneficiary_email:
@@ -240,12 +240,12 @@ def send_orientation_rejected_emails(orientation, message):
             settings.DEFAULT_FROM_EMAIL,
         ),
         tags=["orientation"],
-        reply_to=[orientation.prescriber.email],
+        reply_to=[orientation.prescriber_info.email],
     )
 
     send_mail(
         f"{'[Refusée - Prescripteur] ' if debug else ''}Votre demande d’orientation a été refusée",
-        [orientation.prescriber.email],
+        [orientation.prescriber_info.email],
         mjml2html(render_to_string("orientation-rejected-prescriber.mjml", context)),
         from_email=(
             f"{orientation.get_structure_name()} via DORA",
@@ -257,7 +257,7 @@ def send_orientation_rejected_emails(orientation, message):
 
     if (
         orientation.referent_email
-        and orientation.referent_email != orientation.prescriber.email
+        and orientation.referent_email != orientation.prescriber_info.email
     ):
         send_mail(
             f"{'[Refusée - Conseiller référent] ' if debug else ''}Votre demande d’orientation a été refusée",
@@ -283,7 +283,7 @@ def send_message_to_prescriber(orientation, message, cc):
     }
     send_mail(
         f"{'[Contact - Prescripteur] ' if debug else ''}Vous avez un nouveau message 📩",
-        orientation.prescriber.email,
+        orientation.prescriber_info.email,
         mjml2html(render_to_string("contact-prescriber.mjml", context)),
         from_email=(
             f"{orientation.get_structure_name()} via DORA",
@@ -342,13 +342,13 @@ def send_orientation_reminder_emails(orientation):
     cc = []
     if (
         orientation.referent_email
-        and orientation.referent_email != orientation.prescriber.email
+        and orientation.referent_email != orientation.prescriber_info.email
     ):
         cc.append(orientation.referent_email)
 
     send_mail(
         f"{'[Notification - Prescripteur] ' if debug else ''}Relance envoyée – Demande d’orientation en attente",
-        orientation.prescriber.email,
+        orientation.prescriber_info.email,
         mjml2html(render_to_string("notification-prescriber.mjml", context)),
         tags=["orientation"],
         cc=cc,
@@ -382,7 +382,7 @@ def send_orientation_expiration_emails(
         tags=["orientation"],
     )
 
-    for email in {orientation.prescriber.email, orientation.referent_email}:
+    for email in {orientation.prescriber_info.email, orientation.referent_email}:
         send_mail(
             "Votre demande d’orientation a expiré",
             email,

--- a/back/dora/orientations/models.py
+++ b/back/dora/orientations/models.py
@@ -1,6 +1,7 @@
 import hashlib
 import logging
 import uuid
+from dataclasses import dataclass
 
 from dateutil.relativedelta import relativedelta
 from django.conf import settings
@@ -53,6 +54,16 @@ class OrientationQuerySet(models.QuerySet):
             status__in=[OrientationStatus.ACCEPTED, OrientationStatus.REJECTED],
             processing_date__isnull=False,
         )
+
+
+@dataclass(frozen=True)
+class PrescriberInfo:
+    full_name: str = ""
+    first_name: str = ""
+    email: str = ""
+    structure_name: str = ""
+    structure_slug: str = ""
+    structure_url: str = ""
 
 
 class Orientation(models.Model):
@@ -347,6 +358,23 @@ class Orientation(models.Model):
         else:
             return ""
 
+    @property
+    def prescriber_info(self) -> PrescriberInfo:
+        user, structure = self.prescriber, self.prescriber_structure
+        if user is None and structure is None:
+            try:
+                return self.emplois_orientation_data.prescriber_info
+            except EmploisOrientationData.DoesNotExist:
+                return PrescriberInfo()
+        return PrescriberInfo(
+            full_name=user.get_full_name() if user else "",
+            first_name=user.get_short_name() if user else "",
+            email=user.email if user else "",
+            structure_name=structure.name if structure else "",
+            structure_slug=structure.slug if structure else "",
+            structure_url=structure.get_frontend_url() if structure else "",
+        )
+
     def refresh_query_expiration_date(self):
         # on ne régénère le lien que si il est expiré
         if self.query_expired:
@@ -441,6 +469,24 @@ class EmploisOrientationData(models.Model):
     class Meta:
         verbose_name = "Données Les Emplois"
         verbose_name_plural = "Données Les Emplois"
+
+    @property
+    def prescriber_full_name(self):
+        return (
+            f"{self.prescriber_first_name or ''} {self.prescriber_last_name or ''}".strip()
+            or self.prescriber_email
+        )
+
+    @property
+    def prescriber_info(self) -> PrescriberInfo:
+        return PrescriberInfo(
+            full_name=self.prescriber_full_name,
+            first_name=self.prescriber_first_name
+            or self.prescriber_last_name
+            or self.prescriber_email,
+            email=self.prescriber_email,
+            structure_name=self.structure_name,
+        )
 
 
 class ContactRecipient(models.TextChoices):

--- a/back/dora/orientations/serializers.py
+++ b/back/dora/orientations/serializers.py
@@ -104,24 +104,7 @@ class OrientationSerializer(serializers.ModelSerializer):
         bénéficiaire sont préremplies. Les identifiants Les Emplois (beneficiary_id, structure_id) sont
         stockés dans `_emplois_data` pour création ultérieure de l'objet EmploisOrientationData.
         """
-        # Préremplissage depuis le JWT des Emplois
-        op_jwt = orientation.pop("op_jwt", None)
-        if not self.instance and op_jwt:
-            try:
-                claims = decode_token(op_jwt)
-            except ValueError:
-                raise ValidationError({"op_jwt": "Token JWT invalide ou expiré."})
-            orientation["beneficiary_first_name"] = claims["beneficiary"]["first_name"]
-            orientation["beneficiary_last_name"] = claims["beneficiary"]["last_name"]
-            orientation["beneficiary_email"] = claims["beneficiary"]["email"]
-            orientation["beneficiary_phone"] = claims["beneficiary"]["phone"]
-            orientation["beneficiary_france_travail_number"] = claims["beneficiary"][
-                "france_travail_id"
-            ]
-            orientation["_emplois_data"] = {
-                "beneficiary_id": claims["beneficiary"]["uid"],
-                "structure_id": claims["prescriber"]["organization"]["uid"],
-            }
+        self._prefill_from_emplois_jwt(orientation)
 
         # Validation de l'engagement de protection des données
         if not self.instance and not orientation.get("data_protection_commitment"):
@@ -179,6 +162,28 @@ class OrientationSerializer(serializers.ModelSerializer):
 
         return orientation
 
+    def _prefill_from_emplois_jwt(self, attrs):
+        op_jwt = attrs.pop("op_jwt", None)
+        if self.instance or not op_jwt:
+            return
+        try:
+            claims = decode_token(op_jwt)
+        except ValueError:
+            raise serializers.ValidationError(
+                {"op_jwt": "Token JWT invalide ou expiré."}
+            )
+        beneficiary = claims["beneficiary"]
+        attrs["beneficiary_first_name"] = beneficiary["first_name"]
+        attrs["beneficiary_last_name"] = beneficiary["last_name"]
+        attrs["beneficiary_email"] = beneficiary["email"]
+        attrs["beneficiary_phone"] = beneficiary["phone"]
+        attrs["beneficiary_france_travail_number"] = beneficiary["france_travail_id"]
+        organization = claims["prescriber"]["organization"]
+        attrs["_emplois_data"] = {
+            "beneficiary_id": beneficiary["uid"],
+            "structure_id": organization["uid"],
+        }
+
     def create(self, validated_data):
         emplois_data = validated_data.pop("_emplois_data", None)
         with transaction.atomic():
@@ -203,20 +208,16 @@ class OrientationSerializer(serializers.ModelSerializer):
         }
 
     def get_prescriber_structure(self, orientation):
+        prescriber = orientation.prescriber_info
         return {
-            "name": orientation.prescriber_structure.name
-            if orientation.prescriber_structure
-            else "",
-            "slug": orientation.prescriber_structure.slug
-            if orientation.prescriber_structure
-            else "",
+            "name": prescriber.structure_name,
+            "slug": prescriber.structure_slug,
+            "url": prescriber.structure_url or None,
         }
 
     def get_prescriber(self, orientation):
-        return {
-            "name": orientation.prescriber.get_full_name(),
-            "email": orientation.prescriber.email,
-        }
+        prescriber = orientation.prescriber_info
+        return {"name": prescriber.full_name, "email": prescriber.email}
 
     def get_beneficiary_attachments_details(self, orientation):
         return [
@@ -249,9 +250,7 @@ class SentOrientationExportSerializer(serializers.ModelSerializer):
 
     @staticmethod
     def get_prescriber_name(obj: Orientation) -> str:
-        return (
-            obj.prescriber.get_full_name() if obj.prescriber else "Utilisateur supprimé"
-        )
+        return obj.prescriber_info.full_name or "Utilisateur supprimé"
 
     @staticmethod
     def get_structure_name(obj: Orientation) -> str:
@@ -295,11 +294,7 @@ class ReceivedOrientationExportSerializer(SentOrientationExportSerializer):
 
     @staticmethod
     def get_prescriber_structure_name(obj: Orientation) -> str:
-        return (
-            obj.prescriber_structure.name
-            if obj.prescriber_structure
-            else "Pas de prescripteur"
-        )
+        return obj.prescriber_info.structure_name or "Pas de prescripteur"
 
     @staticmethod
     def get_detail_page_url(obj: Orientation) -> str:

--- a/back/dora/orientations/templates/notification-prescriber.mjml
+++ b/back/dora/orientations/templates/notification-prescriber.mjml
@@ -10,7 +10,7 @@
 
 {% block content %}
   <p>
-    <strong>Bonjour {{ data.prescriber.get_short_name }},</strong>
+    <strong>Bonjour {{ data.prescriber_info.first_name }},</strong>
   </p>
 
   <p>

--- a/back/dora/orientations/templates/notification-structure.mjml
+++ b/back/dora/orientations/templates/notification-structure.mjml
@@ -18,10 +18,7 @@
   </p>
   <p>
     Cette demande concerne {{ data.get_beneficiary_full_name }}, qui vous a été adressé
-    par {{ data.prescriber.get_full_name }} de la structure
-    <a href="{{ data.prescriber_structure.get_frontend_url }}">
-      {{ data.prescriber_structure.name }}
-    </a>.
+    par {{ data.prescriber_info.full_name }} de la structure {% include "partials/prescriber-structure-name.html" %}.
     Le service concerné : {% include "partials/service-link.html" %}.
   </p>
 {% endblock %}

--- a/back/dora/orientations/templates/orientation-accepted-beneficiary.mjml
+++ b/back/dora/orientations/templates/orientation-accepted-beneficiary.mjml
@@ -1,7 +1,7 @@
 {% extends "orientation-email-base.mjml" %}
 
 {% block preview %}
-  La demande réalisée par {{ data.prescriber.get_full_name }} à été acceptée !
+  La demande réalisée par {{ data.prescriber_info.full_name }} à été acceptée !
 {% endblock %}
 
 {% block title %}

--- a/back/dora/orientations/templates/orientation-accepted-structure.mjml
+++ b/back/dora/orientations/templates/orientation-accepted-structure.mjml
@@ -13,9 +13,7 @@
     <strong>Bonjour,</strong>
   </p>
   <p>
-    {{ data.prescriber.get_full_name }} de la structure
-    <a href="{{ data.prescriber_structure.get_frontend_url }}">{{ data.prescriber_structure.name }}
-    </a> vous a adressé un bénéficiaire pour le service {% include "partials/service-link.html" %},
+    {{ data.prescriber_info.full_name }} de la structure {% include "partials/prescriber-structure-name.html" %} vous a adressé un bénéficiaire pour le service {% include "partials/service-link.html" %},
     le {{ data.creation_date|date:"j F Y" }}.
   </p>
   <p>

--- a/back/dora/orientations/templates/orientation-created-beneficiary.mjml
+++ b/back/dora/orientations/templates/orientation-created-beneficiary.mjml
@@ -2,7 +2,7 @@
 {% load orientation_extras %}
 
 {% block preview %}
-  {{ data.prescriber.get_full_name }} vous a orienté vers un service solidaire
+  {{ data.prescriber_info.full_name }} vous a orienté vers un service solidaire
 {% endblock %}
 
 {% block title %}
@@ -14,19 +14,16 @@
     <strong>Bonjour,</strong>
   </p>
   <p>
-    {{ data.prescriber.get_full_name }} de la structure
-    <a
-      href="{{ data.prescriber_structure.get_frontend_url }}">{{ data.prescriber_structure.name }}
-    </a>
+    {{ data.prescriber_info.full_name }} de la structure {% include "partials/prescriber-structure-name.html" %}
     a réalisé une prescription en votre nom, pour le service {% include "partials/service-link.html" %}, ayant lieu au&#8239;: {{ service_address }}.
   </p>
 
   <p><strong>Pour des questions concernant cette demande, veuillez contacter le prescripteur ou la prescriptrice&#8239;:</strong></p>
 
-  {% if data.prescriber.email !=  data.referent_email %}
+  {% if data.prescriber_info.email !=  data.referent_email %}
     <ul>
-      <li>{{ data.prescriber.get_full_name }}</li>
-      <li>{{ data.prescriber.email }}</li>
+      <li>{{ data.prescriber_info.full_name }}</li>
+      <li>{{ data.prescriber_info.email }}</li>
     </ul>
     <p>ou bien votre conseillèr·e référent·e&#8239;:</p>
   {% endif %}

--- a/back/dora/orientations/templates/orientation-created-prescriber.mjml
+++ b/back/dora/orientations/templates/orientation-created-prescriber.mjml
@@ -11,7 +11,7 @@
 
 {% block content %}
   <p>
-    <strong>Bonjour {{ data.prescriber.get_short_name }},</strong>
+    <strong>Bonjour {{ data.prescriber_info.first_name }},</strong>
   </p>
   <p>
     Votre demande d’orientation pour le service {% include "partials/service-link.html" %} ayant lieu au&#8239;: {{ service_address }}, porté par la structure

--- a/back/dora/orientations/templates/orientation-created-referent.mjml
+++ b/back/dora/orientations/templates/orientation-created-referent.mjml
@@ -14,10 +14,7 @@
     <strong>Bonjour,</strong>
   </p>
   <p>
-    {{ data.prescriber.get_full_name }} de la structure
-    <a
-      href="{{ data.prescriber_structure.get_frontend_url }}">{{ data.prescriber_structure.name }}
-    </a>
+    {{ data.prescriber_info.full_name }} de la structure {% include "partials/prescriber-structure-name.html" %}
     a orienté
     {{ data.get_beneficiary_full_name }} vers le
     service {% include "partials/service-link.html" %}, ayant lieu au&#8239;: {{ service_address }}.

--- a/back/dora/orientations/templates/orientation-created-structure.mjml
+++ b/back/dora/orientations/templates/orientation-created-structure.mjml
@@ -13,9 +13,7 @@
     <strong>Bonjour,</strong>
   </p>
   <p>
-    {{ data.prescriber.get_full_name }} de la structure
-    <a href="{{ data.prescriber_structure.get_frontend_url }}">{{ data.prescriber_structure.name }}
-    </a>
+    {{ data.prescriber_info.full_name }} de la structure {% include "partials/prescriber-structure-name.html" %}
     vous a adressé un bénéficiaire pour le service {% include "partials/service-link.html" %}.
   </p>
 {% endblock %}

--- a/back/dora/orientations/templates/orientation-expired-beneficiary.mjml
+++ b/back/dora/orientations/templates/orientation-expired-beneficiary.mjml
@@ -14,7 +14,7 @@
     <strong>Bonjour,</strong>
   </p>
   <p>
-    {{ data.prescriber.get_full_name }} de la structure {{ data.prescriber_structure.name }} a envoyé une demande d’orientation en votre nom, auprès du service «&#8239;{{ data.get_service_name }}&#8239;», le {{ start_date }}.
+    {{ data.prescriber_info.full_name }} de la structure {{ data.prescriber_info.structure_name }} a envoyé une demande d’orientation en votre nom, auprès du service «&#8239;{{ data.get_service_name }}&#8239;», le {{ start_date }}.
   </p>
 
   <p>Le service n’a pas répondu à la demande dans le délai limite des {{ expiration_period_days }} jours. Par conséquent, la demande a été automatiquement annulée.</p>
@@ -22,10 +22,10 @@
   <p><strong>Vous n’avez rien à faire</strong>&#8239;: l’accompagnateur de la structure {{ data.get_structure_name }} a également été informé.</p>
 
   <p><strong>Des questions&#8239;?</strong> Contactez la personne qui vous accompagne&#8239;:</p>
-  {% if data.prescriber.email !=  data.referent_email %}
+  {% if data.prescriber_info.email !=  data.referent_email %}
     <ul>
-      <li>{{ data.prescriber.get_full_name }}</li>
-      <li>{{ data.prescriber.email }}</li>
+      <li>{{ data.prescriber_info.full_name }}</li>
+      <li>{{ data.prescriber_info.email }}</li>
     </ul>
     <p>ou bien votre conseillèr·e référent·e&#8239;:</p>
   {% endif %}

--- a/back/dora/orientations/templates/orientation-expired-service.mjml
+++ b/back/dora/orientations/templates/orientation-expired-service.mjml
@@ -13,7 +13,7 @@
     <strong>Bonjour,</strong>
   </p>
   <p>
-    {{ data.prescriber.get_full_name }} de la structure {{ data.prescriber_structure.name }} vous a adressé un bénéficiaire pour le service «&#8239;{{ data.get_service_name }}&#8239;», le {{ start_date }}.
+    {{ data.prescriber_info.full_name }} de la structure {{ data.prescriber_info.structure_name }} vous a adressé un bénéficiaire pour le service «&#8239;{{ data.get_service_name }}&#8239;», le {{ start_date }}.
   </p>
 
   <p>N’ayant pas reçu de réponses de votre part dans le délai limite des {{ expiration_period_days }} jours, cette demande a été automatiquement annulée.</p>

--- a/back/dora/orientations/templates/orientation-rejected-beneficiary.mjml
+++ b/back/dora/orientations/templates/orientation-rejected-beneficiary.mjml
@@ -15,8 +15,7 @@
   </p>
 
   <p>
-    {{ data.prescriber.get_full_name }} de la structure <a href="{{ data.prescriber_structure.get_frontend_url }}">
-      {{ data.prescriber_structure.name }}</a> a envoyé une demande d’orientation en votre nom, auprès du service
+    {{ data.prescriber_info.full_name }} de la structure {% include "partials/prescriber-structure-name.html" %} a envoyé une demande d’orientation en votre nom, auprès du service
     {% include "partials/service-link.html" %}, le {{ data.creation_date|date:"j F Y" }}.
   </p>
 
@@ -25,10 +24,10 @@
   </p>
 
   <p><strong>Des questions&#8239;?</strong> Contactez la personne qui vous accompagne&#8239;:</p>
-  {% if data.prescriber.email !=  data.referent_email %}
+  {% if data.prescriber_info.email !=  data.referent_email %}
     <ul>
-      <li>{{ data.prescriber.get_full_name }}</li>
-      <li>{{ data.prescriber.email }}</li>
+      <li>{{ data.prescriber_info.full_name }}</li>
+      <li>{{ data.prescriber_info.email }}</li>
     </ul>
     <p>ou bien votre conseillèr·e référent·e&#8239;:</p>
   {% endif %}

--- a/back/dora/orientations/templates/orientation-rejected-structure.mjml
+++ b/back/dora/orientations/templates/orientation-rejected-structure.mjml
@@ -14,9 +14,7 @@
   </p>
 
   <p>
-    {{ data.prescriber.get_full_name }} de la structure
-    <a href="{{ data.prescriber_structure.get_frontend_url }}">{{ data.prescriber_structure.name }}
-    </a> vous a adressé un bénéficiaire pour le service {% include "partials/service-link.html" %},
+    {{ data.prescriber_info.full_name }} de la structure {% include "partials/prescriber-structure-name.html" %} vous a adressé un bénéficiaire pour le service {% include "partials/service-link.html" %},
     le {{ data.creation_date }}.
   </p>
 

--- a/back/dora/orientations/templates/partials/block-prescriber.html
+++ b/back/dora/orientations/templates/partials/block-prescriber.html
@@ -2,10 +2,10 @@
 
 <h2>Prescripteur ou prescriptrice&nbsp;:</h2>
 
-{% if data.prescriber.email !=  data.referent_email %}
+{% if data.prescriber_info.email !=  data.referent_email %}
   <ul>
-    <li>{{ data.prescriber.get_full_name }}</li>
-    <li>{{ data.prescriber.email }}</li>
+    <li>{{ data.prescriber_info.full_name }}</li>
+    <li>{{ data.prescriber_info.email }}</li>
   </ul>
 
   <h2>Conseiller ou conseillère référente&nbsp;:</h2>

--- a/back/dora/orientations/templates/partials/prescriber-structure-name.html
+++ b/back/dora/orientations/templates/partials/prescriber-structure-name.html
@@ -1,0 +1,5 @@
+{% if data.prescriber_info.structure_url %}
+  <a href="{{ data.prescriber_info.structure_url }}">{{ data.prescriber_info.structure_name }}</a>
+{% else %}
+  {{ data.prescriber_info.structure_name }}
+{% endif %}

--- a/back/dora/orientations/tests/conftest.py
+++ b/back/dora/orientations/tests/conftest.py
@@ -1,16 +1,24 @@
 import pytest
 from model_bakery.random_gen import gen_email
 
-from dora.core.test_utils import make_di_orientation, make_orientation
+from dora.core.test_utils import (
+    make_di_orientation,
+    make_emplois_orientation,
+    make_jwt_orientation,
+    make_orientation,
+)
 
 from ..models import Orientation
 
 
-@pytest.fixture
-def orientation() -> Orientation:
+@pytest.fixture(
+    params=[make_orientation, make_jwt_orientation, make_emplois_orientation],
+    ids=["dora", "jwt", "emplois"],
+)
+def orientation(request) -> Orientation:
     # l'e-mail bénéficiaire est optionel dans la génération,
     # mais on veut vérifier l'envoi d'e-mail vers tous les destinataires
-    return make_orientation(beneficiary_email=gen_email)
+    return request.param(beneficiary_email=gen_email())
 
 
 @pytest.fixture

--- a/back/dora/orientations/tests/test_close_expired_orientations.py
+++ b/back/dora/orientations/tests/test_close_expired_orientations.py
@@ -92,7 +92,7 @@ class CloseExpiredOrientationsTestCase(TransactionTestCase):
         self.assertEqual(len(self.expired_orientation_2.beneficiary_attachments), 0)
 
         self.assertEqual(mock_send_emails.call_count, 2)
-        self.assertEqual(
+        self.assertCountEqual(
             mock_send_emails.call_args_list,
             [
                 call(self.expired_orientation_1, self.orientation_1_start_date),

--- a/back/dora/orientations/tests/test_emplois_orientation_data.py
+++ b/back/dora/orientations/tests/test_emplois_orientation_data.py
@@ -1,0 +1,28 @@
+import pytest
+
+from dora.orientations.models import EmploisOrientationData
+
+
+@pytest.mark.parametrize(
+    "first_name,last_name,email,expected",
+    [
+        (
+            "Jean-Prescripteur",
+            "des Emplois",
+            "jean-prescripteur.des-emplois@example.com",
+            "Jean-Prescripteur des Emplois",
+        ),
+        ("Jean", "", "jean@example.com", "Jean"),
+        ("", "Prescripteur", "prescripteur@example.com", "Prescripteur"),
+        ("", "", "jp@example.com", "jp@example.com"),
+    ],
+)
+def test_emplois_orientation_data_prescriber_full_name(
+    first_name, last_name, email, expected
+):
+    data = EmploisOrientationData(
+        prescriber_first_name=first_name,
+        prescriber_last_name=last_name,
+        prescriber_email=email,
+    )
+    assert data.prescriber_full_name == expected

--- a/back/dora/orientations/tests/test_orientation_admin.py
+++ b/back/dora/orientations/tests/test_orientation_admin.py
@@ -3,8 +3,11 @@ from django.urls import reverse
 from django.utils.html import format_html
 from pytest_django.asserts import assertMessages
 
+from dora.core.test_utils import make_orientation
 
-def test_check_orientation(admin_client, orientation):
+
+def test_check_orientation(admin_client):
+    orientation = make_orientation()
     response = admin_client.get(
         reverse(
             "admin:orientations_orientation_change",

--- a/back/dora/orientations/tests/test_orientation_emails.py
+++ b/back/dora/orientations/tests/test_orientation_emails.py
@@ -1,0 +1,62 @@
+import pytest
+from django.core import mail
+from django.utils import timezone
+
+from dora.orientations.emails import (
+    send_orientation_accepted_emails,
+    send_orientation_created_emails,
+    send_orientation_expiration_emails,
+    send_orientation_rejected_emails,
+    send_orientation_reminder_emails,
+)
+
+pytestmark = pytest.mark.django_db
+
+
+EMAIL_SENDERS = [
+    pytest.param(lambda o: send_orientation_created_emails(o), True, id="created"),
+    pytest.param(
+        lambda o: send_orientation_accepted_emails(
+            o, "message presc.", "message bénéf."
+        ),
+        True,
+        id="accepted",
+    ),
+    pytest.param(
+        lambda o: send_orientation_rejected_emails(o, message="Refus"),
+        True,
+        id="rejected",
+    ),
+    pytest.param(lambda o: send_orientation_reminder_emails(o), True, id="reminder"),
+    pytest.param(
+        lambda o: send_orientation_expiration_emails(o, start_date=timezone.now()),
+        False,
+        id="expired",
+    ),
+]
+
+
+@pytest.mark.parametrize("send_email, displays_structure_link", EMAIL_SENDERS)
+def test_structure_email_displays_prescriber_info(
+    orientation, send_email, displays_structure_link
+):
+    prescriber = orientation.prescriber_info
+
+    send_email(orientation)
+
+    structure_email = mail.outbox[0]
+    assert structure_email.to == [orientation.get_contact_email()]
+    assert prescriber.full_name in structure_email.body
+    assert prescriber.structure_name in structure_email.body
+    if displays_structure_link and prescriber.structure_url:
+        assert prescriber.structure_url in structure_email.body
+
+
+@pytest.mark.parametrize("send_email, displays_structure_link", EMAIL_SENDERS)
+def test_prescriber_email_sent_to_correct_address(
+    orientation, send_email, displays_structure_link
+):
+    send_email(orientation)
+
+    recipients = [address for email in mail.outbox for address in email.to]
+    assert orientation.prescriber_info.email in recipients

--- a/back/dora/orientations/tests/test_orientation_endpoints.py
+++ b/back/dora/orientations/tests/test_orientation_endpoints.py
@@ -9,6 +9,7 @@ from model_bakery import baker
 from rest_framework.test import APITestCase
 
 from dora.core.test_utils import (
+    make_emplois_orientation,
     make_orientation,
     make_service,
     make_structure,
@@ -82,7 +83,7 @@ def test_query_validate(api_client, orientation):
     # (vérifier le contenu n'est pas pertinent dans cette série de tests)
     assert len(mail.outbox) == 4
     assert mail.outbox[0].to == [orientation.get_contact_email()]
-    assert mail.outbox[1].to == [orientation.prescriber.email]
+    assert mail.outbox[1].to == [orientation.prescriber_info.email]
     assert mail.outbox[2].to == [orientation.referent_email]
     assert mail.outbox[3].to == [orientation.beneficiary_email]
 
@@ -133,7 +134,7 @@ def test_query_reject(api_client, orientation):
     assert len(mail.outbox) == 4
     assert mail.outbox[0].to == [orientation.get_contact_email()]
     assert mail.outbox[1].to == [orientation.beneficiary_email]
-    assert mail.outbox[2].to == [orientation.prescriber.email]
+    assert mail.outbox[2].to == [orientation.prescriber_info.email]
     assert mail.outbox[3].to == [orientation.referent_email]
 
 
@@ -176,7 +177,33 @@ def test_contact_prescriber(api_client, orientation):
     # on vérifie qu'un e-mail a bien été envoyé au bon destinataire
     # (vérifier le contenu n'est pas pertinent dans cette série de tests)
     assert len(mail.outbox) == 1
-    assert mail.outbox[0].to == [orientation.prescriber.email]
+    assert mail.outbox[0].to == [orientation.prescriber_info.email]
+
+
+def test_contact_beneficiary_cc_prescriber(api_client, orientation):
+    url = (
+        f"/orientations/{orientation.query_id}/contact/beneficiary/"
+        f"?h={orientation.get_query_id_hash()}"
+    )
+    response = api_client.post(
+        url, data={"message": "test", "cc_prescriber": "true"}, follow=True
+    )
+
+    assert response.status_code == 204
+    assert mail.outbox[0].cc == [orientation.prescriber_info.email]
+
+
+def test_contact_beneficiary_cc_referent(api_client, orientation):
+    url = (
+        f"/orientations/{orientation.query_id}/contact/beneficiary/"
+        f"?h={orientation.get_query_id_hash()}"
+    )
+    response = api_client.post(
+        url, data={"message": "test", "cc_referent": "true"}, follow=True
+    )
+
+    assert response.status_code == 204
+    assert mail.outbox[0].cc == [orientation.referent_email]
 
 
 @pytest.mark.parametrize(
@@ -367,7 +394,7 @@ def test_query_create_does_not_trigger_moderation(api_client, get_new_orientatio
 
     assert len(mail.outbox) == 4
     assert mail.outbox[0].to == [orientation.get_contact_email()]
-    assert mail.outbox[1].to == [orientation.prescriber.email]
+    assert mail.outbox[1].to == [orientation.prescriber_info.email]
     assert mail.outbox[2].to == [orientation.referent_email]
     assert mail.outbox[3].to == [orientation.beneficiary_email]
 
@@ -663,6 +690,34 @@ class OrientationsExportTestCase(APITestCase):
                     "detail_page_url": orientation_2.get_magic_link(),
                 },
             ],
+        )
+
+    def test_get_export_of_received_orientations_from_emplois(self):
+        orientation = make_emplois_orientation(
+            service=self.service,
+            status=OrientationStatus.ACCEPTED,
+            emplois_data={
+                "prescriber_first_name": "Jean-Prescripteur",
+                "prescriber_last_name": "des Emplois",
+                "structure_name": "Structure des Emplois",
+            },
+        )
+
+        with self.assertNumQueries(3):
+            response = self.client.get(
+                f"/structures/{self.structure.slug}/orientations/export/?type=received"
+            )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.data), 1)
+        self.assertEqual(
+            response.data[0]["prescriber_name"], "Jean-Prescripteur des Emplois"
+        )
+        self.assertEqual(
+            response.data[0]["prescriber_structure_name"], "Structure des Emplois"
+        )
+        self.assertEqual(
+            response.data[0]["detail_page_url"], orientation.get_magic_link()
         )
 
     def test_raise_403_if_user_not_structure_member(self):

--- a/back/dora/orientations/tests/test_orientation_serializer_prescriber.py
+++ b/back/dora/orientations/tests/test_orientation_serializer_prescriber.py
@@ -1,0 +1,96 @@
+import pytest
+
+from dora.core.test_utils import (
+    make_emplois_orientation,
+    make_jwt_orientation,
+    make_orientation,
+)
+from dora.orientations.serializers import OrientationSerializer
+
+pytestmark = pytest.mark.django_db
+
+
+def test_get_prescriber_uses_emplois_data_when_present():
+    orientation = make_emplois_orientation(
+        emplois_data={
+            "prescriber_first_name": "Jean-Prescripteur",
+            "prescriber_last_name": "des Emplois",
+            "prescriber_email": "jean-prescripteur.des-emplois@example.com",
+        }
+    )
+
+    prescriber = OrientationSerializer().get_prescriber(orientation)
+
+    assert prescriber == {
+        "name": "Jean-Prescripteur des Emplois",
+        "email": "jean-prescripteur.des-emplois@example.com",
+    }
+
+
+def test_get_prescriber_structure_uses_emplois_data_when_present():
+    orientation = make_emplois_orientation(
+        emplois_data={
+            "structure_name": "Structure des Emplois",
+        }
+    )
+
+    prescriber_structure = OrientationSerializer().get_prescriber_structure(orientation)
+
+    assert prescriber_structure == {
+        "name": "Structure des Emplois",
+        "slug": "",
+        "url": None,
+    }
+
+
+def test_get_prescriber_falls_back_to_dora_prescriber():
+    orientation = make_orientation()
+
+    prescriber = OrientationSerializer().get_prescriber(orientation)
+
+    assert prescriber == {
+        "name": orientation.prescriber.get_full_name(),
+        "email": orientation.prescriber.email,
+    }
+
+
+def test_get_prescriber_structure_falls_back_to_dora_structure():
+    orientation = make_orientation()
+
+    prescriber_structure = OrientationSerializer().get_prescriber_structure(orientation)
+
+    assert prescriber_structure == {
+        "name": orientation.prescriber_structure.name,
+        "slug": orientation.prescriber_structure.slug,
+        "url": orientation.prescriber_structure.get_frontend_url(),
+    }
+
+
+def test_get_prescriber_uses_dora_data_for_jwt_orientation():
+    orientation = make_jwt_orientation()
+
+    assert OrientationSerializer().get_prescriber(orientation) == {
+        "name": orientation.prescriber.get_full_name(),
+        "email": orientation.prescriber.email,
+    }
+    assert OrientationSerializer().get_prescriber_structure(orientation) == {
+        "name": orientation.prescriber_structure.name,
+        "slug": orientation.prescriber_structure.slug,
+        "url": orientation.prescriber_structure.get_frontend_url(),
+    }
+
+
+def test_serialized_prescriber_matches_prescriber_info(orientation):
+    prescriber = orientation.prescriber_info
+
+    data = OrientationSerializer(orientation).data
+
+    assert data["prescriber"] == {
+        "name": prescriber.full_name,
+        "email": prescriber.email,
+    }
+    assert data["prescriber_structure"] == {
+        "name": prescriber.structure_name,
+        "slug": prescriber.structure_slug,
+        "url": prescriber.structure_url or None,
+    }

--- a/back/dora/orientations/tests/test_prescriber_info.py
+++ b/back/dora/orientations/tests/test_prescriber_info.py
@@ -1,0 +1,62 @@
+import pytest
+
+from dora.core.test_utils import (
+    make_emplois_orientation,
+    make_jwt_orientation,
+    make_orientation,
+)
+from dora.orientations.models import PrescriberInfo
+
+pytestmark = pytest.mark.django_db
+
+
+def test_dora_orientation_uses_prescriber_account():
+    orientation = make_orientation()
+
+    assert orientation.prescriber_info == PrescriberInfo(
+        full_name=orientation.prescriber.get_full_name(),
+        first_name=orientation.prescriber.get_short_name(),
+        email=orientation.prescriber.email,
+        structure_name=orientation.prescriber_structure.name,
+        structure_slug=orientation.prescriber_structure.slug,
+        structure_url=orientation.prescriber_structure.get_frontend_url(),
+    )
+
+
+def test_emplois_orientation_uses_emplois_data():
+    orientation = make_emplois_orientation()
+    data = orientation.emplois_orientation_data
+
+    assert orientation.prescriber_info == PrescriberInfo(
+        full_name=f"{data.prescriber_first_name} {data.prescriber_last_name}",
+        first_name=data.prescriber_first_name,
+        email=data.prescriber_email,
+        structure_name=data.structure_name,
+        structure_slug="",
+    )
+
+
+def test_jwt_orientation_uses_prescriber_account():
+    orientation = make_jwt_orientation()
+
+    assert orientation.prescriber_info.full_name == (
+        orientation.prescriber.get_full_name()
+    )
+    assert orientation.prescriber_info.email == orientation.prescriber.email
+
+
+def test_deleted_prescriber_yields_empty_info():
+    orientation = make_orientation(prescriber=None, prescriber_structure=None)
+
+    assert orientation.prescriber_info == PrescriberInfo()
+
+
+def test_deleted_prescriber_keeps_structure_info():
+    orientation = make_orientation(prescriber=None)
+
+    assert orientation.prescriber_info.full_name == ""
+    assert orientation.prescriber_info.email == ""
+    assert (
+        orientation.prescriber_info.structure_name
+        == orientation.prescriber_structure.name
+    )

--- a/back/dora/orientations/views.py
+++ b/back/dora/orientations/views.py
@@ -195,12 +195,12 @@ class OrientationViewSet(
         cc = []
 
         if cc_prescriber:
-            cc.append(orientation.prescriber.email)
+            cc.append(orientation.prescriber_info.email)
             sent_contact_emails.append(ContactRecipient.PRESCRIBER)
         if (
             cc_referent
             and orientation.referent_email
-            and orientation.referent_email != orientation.prescriber.email
+            and orientation.referent_email != orientation.prescriber_info.email
         ):
             cc.append(orientation.referent_email)
             sent_contact_emails.append(ContactRecipient.REFERENT)
@@ -234,7 +234,7 @@ class OrientationViewSet(
         if (
             cc_referent
             and orientation.referent_email
-            and orientation.referent_email != orientation.prescriber.email
+            and orientation.referent_email != orientation.prescriber_info.email
         ):
             cc.append(orientation.referent_email)
             sent_contact_emails.append(ContactRecipient.REFERENT)
@@ -346,7 +346,12 @@ class StructureOrientationsView(APIView):
             orientations = (
                 self.sent_orientations(structure)
                 .order_by("-creation_date")
-                .select_related("service__structure", "prescriber")
+                .select_related(
+                    "service__structure",
+                    "prescriber_structure",
+                    "prescriber",
+                    "emplois_orientation_data",
+                )
             )
             return Response(
                 SentOrientationExportSerializer(orientations, many=True).data
@@ -357,7 +362,10 @@ class StructureOrientationsView(APIView):
                 self.received_orientations(structure)
                 .order_by("-creation_date")
                 .select_related(
-                    "service__structure", "prescriber_structure", "prescriber"
+                    "service__structure",
+                    "prescriber_structure",
+                    "prescriber",
+                    "emplois_orientation_data",
                 )
             )
             return Response(

--- a/front/src/lib/types.ts
+++ b/front/src/lib/types.ts
@@ -708,7 +708,7 @@ export interface Orientation {
   creationDate: string;
   prescriberStructure?: {
     name: string;
-    slug: string;
+    url?: string;
   };
   processingDate?: string;
   status: "OUVERTE" | "VALIDÉE" | "REFUSÉE" | "EXPIRÉE";

--- a/front/src/routes/orientations/+page.svelte
+++ b/front/src/routes/orientations/+page.svelte
@@ -287,7 +287,8 @@
                         <ContactListItem
                           icon={HomeSmile2LineBuildings}
                           text={orientation.prescriberStructure?.name}
-                          link={`/structures/${orientation.prescriberStructure?.slug}`}
+                          link={orientation.prescriberStructure?.url ??
+                            undefined}
                         />
                       {/if}
 


### PR DESCRIPTION
Affiche et utilise le nom, l'e-mail et la structure du prescripteur selon la source de l'orientation (flux Dora, flux JWT, ou API des Emplois via `EmploisOrientationData`).

La résolution est centralisée au niveau du modèle (`PrescriberInfo` + `Orientation.prescriber_info`) : sérialiseurs, e-mails, export et contact se contentent de lire `prescriber_info`.

Changements :

- Sérialiseur d'orientation : expose le prescripteur et la structure selon la source ;
- E-mails à la structure : affichage du nom du prescripteur et du lien vers la structure selon la source et les e-mails partent à la bonne adresse de prescripteur ;
- Export des orientations reçues :  nom du prescripteur et de sa structure selon la source ;
- Contact du bénéficiaire : mise en copie du prescripteur à la bonne adresse selon la source ;
- Page orientation : lien vers la structure des Emplois.