### PR TITLE
fix: Correction d'un bug d'affichage des modalités d'orientation avec formulaire Dora désactivé

### DIFF
--- a/front/src/routes/(modeles-services)/services/service-edition-form.svelte
+++ b/front/src/routes/(modeles-services)/services/service-edition-form.svelte
@@ -170,14 +170,16 @@
     modelSlugTmp = null;
   }
 
-  $effect(() => {
-    if (structure?.noDoraForm) {
-      servicesOptions.coachOrientationModes =
-        servicesOptions.coachOrientationModes.filter(
-          (mode) => mode.value !== "formulaire-dora"
-        );
-    }
-  });
+  const modalitiesServicesOptions = $derived(
+    structure?.noDoraForm
+      ? {
+          ...servicesOptions,
+          coachOrientationModes: servicesOptions.coachOrientationModes.filter(
+            (mode) => mode.value !== "formulaire-dora"
+          ),
+        }
+      : servicesOptions
+  );
 </script>
 
 <FormErrors />
@@ -281,7 +283,11 @@
 
           <FieldsPublics bind:service {servicesOptions} {model} />
 
-          <FieldsModalities bind:service {servicesOptions} {model} />
+          <FieldsModalities
+            bind:service
+            servicesOptions={modalitiesServicesOptions}
+            {model}
+          />
 
           <FieldsDocuments bind:service {servicesOptions} {model} />
 


### PR DESCRIPTION
Dans le cas où le formulaire Dora est désactivé, le `$effect` mutait la liste originale au lieu de la dériver, ce qui laissait apparaître l'option formulaire Dora dans certains cas.