### PR TITLE
fix: API DI : renvoie la valeur `tous-publics` si pas de publics

### DIFF
--- a/back/dora/api/serializers.py
+++ b/back/dora/api/serializers.py
@@ -1,4 +1,5 @@
 # from django.core.files.storage import default_storage
+from data_inclusion.schema.v1.publics import Public as DiPublic
 from rest_framework import serializers
 
 from dora.services.models import (
@@ -296,18 +297,26 @@ class ServiceSerializer(serializers.ModelSerializer):
         return obj.fee_details or None
 
     def get_profils(self, obj):
-        return [c.name for c in obj.publics.all()]
+        publics = obj.publics.all()
+        if not publics:
+            return [DiPublic.TOUS_PUBLICS.value]
+        return [p.name for p in publics]
 
     def get_publics(self, obj):
-        all_items = [
-            item
-            for public in obj.publics.all()
-            for item in public.corresponding_di_publics
-        ]
-        return list(dict.fromkeys(all_items))
+        publics = obj.publics.all()
+        if not publics:
+            return [DiPublic.TOUS_PUBLICS.value]
+        return list(
+            dict.fromkeys(
+                item for public in publics for item in public.corresponding_di_publics
+            )
+        )
 
     def get_publics_precisions(self, obj):
-        return ", ".join([p.name for p in obj.publics.all()])
+        publics = obj.publics.all()
+        if not publics:
+            return DiPublic.TOUS_PUBLICS.label
+        return ", ".join(p.name for p in publics)
 
     def get_pre_requis(self, obj):
         return [c.name for c in obj.requirements.all()]

--- a/back/dora/api/test_api.py
+++ b/back/dora/api/test_api.py
@@ -415,6 +415,20 @@ def test_service_serialization_exemple(authenticated_user, api_client, settings)
             assert data[key] == expected_val
 
 
+def test_service_serialization_without_publics_returns_tous_publics(
+    authenticated_user, api_client
+):
+    service = make_service(status=ServiceStatus.PUBLISHED)
+
+    response = api_client.get(f"/api/v2/services/{service.id}/")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["profils"] == ["tous-publics"]
+    assert data["publics"] == ["tous-publics"]
+    assert data["publics_precisions"] == "Tous publics"
+
+
 def test_service_serialization_formulaire_en_ligne(
     authenticated_user, api_client, settings
 ):


### PR DESCRIPTION
Conversation : https://gip-inclusion.slack.com/archives/C0890D48P2Q/p1781172010834619