### PR TITLE
refactor: Retirer DataInclusionClient.list_services

### DIFF
--- a/back/dora/data_inclusion/client.py
+++ b/back/dora/data_inclusion/client.py
@@ -78,19 +78,6 @@ class DataInclusionClient:
                 return data
 
     @log_conn_error
-    def list_services(self, source: Optional[str] = None) -> Optional[list[dict]]:
-        url = self.base_url.copy()
-        url = url / "services"
-
-        if source is not None:
-            url.args["source"] = source
-
-        try:
-            return self._get_pages(url)
-        except requests.HTTPError:
-            return None
-
-    @log_conn_error
     def retrieve_service(
         self,
         id: str,

--- a/back/dora/data_inclusion/test_utils.py
+++ b/back/dora/data_inclusion/test_utils.py
@@ -87,9 +87,6 @@ class FakeDataInclusionClient:
     def __init__(self, services: Optional[list[dict]] = None) -> None:
         self.services = services if services is not None else []
 
-    def list_services(self, source: Optional[str] = None) -> Optional[list[dict]]:
-        raise NotImplementedError()
-
     def retrieve_service(
         self,
         id: str,


### PR DESCRIPTION
Cette méthode n’est jamais utilisée.