### PR TITLE
refactor: Importer ValidationError depuis rest_framework.exceptions

### DIFF
--- a/back/dora/emplois/serializers.py
+++ b/back/dora/emplois/serializers.py
@@ -2,7 +2,7 @@ import uuid
 
 from django.db import transaction
 from rest_framework import serializers
-from rest_framework.exceptions import NotFound
+from rest_framework.exceptions import NotFound, ValidationError
 
 from dora.core.validators import validate_siret
 from dora.orientations.models import EmploisOrientationData
@@ -167,7 +167,7 @@ class EmploisOrientationSerializer(OrientationSerializer):
     def validate(self, attrs):
         # Validation de l'engagement de protection des données
         if not self.instance and not attrs.get("data_protection_commitment"):
-            raise serializers.ValidationError(
+            raise ValidationError(
                 {
                     "data_protection_commitment": "Vous devez accepter l’engagement de protection des données."
                 }
@@ -176,7 +176,7 @@ class EmploisOrientationSerializer(OrientationSerializer):
         # Validation de l'identifiant de service DI
         di_service_id = attrs["di_service_id"]
         if "--" not in di_service_id:
-            raise serializers.ValidationError(
+            raise ValidationError(
                 {
                     "di_service_id": "Format d'identifiant invalide (attendu : « source--id »)."
                 }

--- a/back/dora/orientations/serializers.py
+++ b/back/dora/orientations/serializers.py
@@ -3,6 +3,7 @@ from django.core.files.storage import default_storage
 from django.db import transaction
 from itoutils.django.nexus.token import decode_token
 from rest_framework import serializers
+from rest_framework.exceptions import ValidationError
 
 import dora.data_inclusion.client
 from dora.data_inclusion.mappings import map_service
@@ -109,9 +110,7 @@ class OrientationSerializer(serializers.ModelSerializer):
             try:
                 claims = decode_token(op_jwt)
             except ValueError:
-                raise serializers.ValidationError(
-                    {"op_jwt": "Token JWT invalide ou expiré."}
-                )
+                raise ValidationError({"op_jwt": "Token JWT invalide ou expiré."})
             orientation["beneficiary_first_name"] = claims["beneficiary"]["first_name"]
             orientation["beneficiary_last_name"] = claims["beneficiary"]["last_name"]
             orientation["beneficiary_email"] = claims["beneficiary"]["email"]
@@ -126,7 +125,7 @@ class OrientationSerializer(serializers.ModelSerializer):
 
         # Validation de l'engagement de protection des données
         if not self.instance and not orientation.get("data_protection_commitment"):
-            raise serializers.ValidationError(
+            raise ValidationError(
                 {
                     "data_protection_commitment": "Vous devez accepter l’engagement de protection des données."
                 }
@@ -172,7 +171,7 @@ class OrientationSerializer(serializers.ModelSerializer):
 
         # Si le service nécessite des documents mais qu'aucun n'est fourni, une erreur est levée.
         if requires_attachments and not orientation.get("beneficiary_attachments"):
-            raise serializers.ValidationError(
+            raise ValidationError(
                 {
                     "beneficiary_attachments": "Pour valider l’envoi de votre demande, vous devez ajouter les documents demandés."
                 }
@@ -314,10 +313,10 @@ class OrientationBeneficiaryInfoInputSerializer(serializers.Serializer):
         try:
             claims = decode_token(value)
         except ValueError:
-            raise serializers.ValidationError("Token JWT invalide.")
+            raise ValidationError("Token JWT invalide.")
 
         if "beneficiary" not in claims:
-            raise serializers.ValidationError("Données bénéficiaire absentes du token.")
+            raise ValidationError("Données bénéficiaire absentes du token.")
 
         return claims
 

--- a/back/dora/orientations/tests/test_orientation_attachments.py
+++ b/back/dora/orientations/tests/test_orientation_attachments.py
@@ -5,7 +5,7 @@ import pytest
 import requests
 from django.core.files.base import ContentFile
 from django.core.files.storage import default_storage
-from rest_framework import serializers
+from rest_framework.exceptions import ValidationError
 
 from dora.core.test_utils import make_orientation, make_published_service
 from dora.orientations.models import Orientation, OrientationStatus
@@ -149,7 +149,7 @@ def test_validate_dora_service_with_credentials_requires_attachments():
         "data_protection_commitment": True,
     }
 
-    with pytest.raises(serializers.ValidationError) as exc_info:
+    with pytest.raises(ValidationError) as exc_info:
         serializer.validate(data)
 
     assert "beneficiary_attachments" in exc_info.value.detail
@@ -170,7 +170,7 @@ def test_validate_dora_service_with_forms_requires_attachments():
             "data_protection_commitment": True,
         }
 
-        with pytest.raises(serializers.ValidationError) as exc_info:
+        with pytest.raises(ValidationError) as exc_info:
             serializer.validate(data)
 
         assert "beneficiary_attachments" in exc_info.value.detail
@@ -233,7 +233,7 @@ def test_validate_di_service_with_credentials_requires_attachments(
         "data_protection_commitment": True,
     }
 
-    with pytest.raises(serializers.ValidationError) as exc_info:
+    with pytest.raises(ValidationError) as exc_info:
         serializer.validate(data)
 
     assert "beneficiary_attachments" in exc_info.value.detail
@@ -354,7 +354,7 @@ def test_validate_existing_instance_service():
         "data_protection_commitment": True,
     }
 
-    with pytest.raises(serializers.ValidationError) as exc_info:
+    with pytest.raises(ValidationError) as exc_info:
         serializer.validate(data)
 
     assert "beneficiary_attachments" in exc_info.value.detail

--- a/back/dora/orientations/tests/test_orientation_serializer_prefill_from_op_jwt.py
+++ b/back/dora/orientations/tests/test_orientation_serializer_prefill_from_op_jwt.py
@@ -1,7 +1,7 @@
 from unittest.mock import patch
 
 import pytest
-from rest_framework import serializers
+from rest_framework.exceptions import ValidationError
 
 from dora.core.test_utils import make_published_service
 from dora.orientations.models import Orientation
@@ -72,7 +72,7 @@ def test_validate_with_invalid_op_jwt_raises_error(monkeypatch):
         "op_jwt": "invalid-token",
     }
 
-    with pytest.raises(serializers.ValidationError) as exc_info:
+    with pytest.raises(ValidationError) as exc_info:
         serializer.validate(data)
 
     assert "op_jwt" in exc_info.value.detail

--- a/back/dora/orientations/views.py
+++ b/back/dora/orientations/views.py
@@ -6,13 +6,15 @@ from math import ceil
 from urllib.parse import urlencode
 
 from django.conf import settings
-from django.core.exceptions import PermissionDenied, ValidationError
+from django.core.exceptions import PermissionDenied
+from django.core.exceptions import ValidationError as DjangoValidationError
 from django.db import transaction
 from django.db.models import Count, Exists, OuterRef, Q
 from django.shortcuts import get_object_or_404
 from itoutils.django.nexus.token import decode_token, generate_token
-from rest_framework import mixins, permissions, serializers, viewsets
+from rest_framework import mixins, permissions, viewsets
 from rest_framework.decorators import action, api_view, permission_classes
+from rest_framework.exceptions import ValidationError
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.request import Request
 from rest_framework.response import Response
@@ -122,15 +124,15 @@ class OrientationViewSet(
             sanitized_prescriber_message = sanitize_user_input_injected_in_email(
                 prescriber_message
             )
-        except ValidationError as error:
-            raise serializers.ValidationError({"message": error.messages})
+        except DjangoValidationError as error:
+            raise ValidationError({"message": error.messages})
 
         try:
             sanitized_beneficiary_message = sanitize_user_input_injected_in_email(
                 beneficiary_message
             )
-        except ValidationError as error:
-            raise serializers.ValidationError({"beneficiary_message": error.messages})
+        except DjangoValidationError as error:
+            raise ValidationError({"beneficiary_message": error.messages})
 
         if orientation.service:
             # L'objet service et les durées n'existent pas dans le cas des services DI
@@ -158,8 +160,8 @@ class OrientationViewSet(
 
         try:
             sanitized_message = sanitize_user_input_injected_in_email(message)
-        except ValidationError as error:
-            raise serializers.ValidationError({"message": error.messages})
+        except DjangoValidationError as error:
+            raise ValidationError({"message": error.messages})
 
         with transaction.atomic():
             orientation.delete_attachments()
@@ -184,7 +186,7 @@ class OrientationViewSet(
     def contact_beneficiary(self, request, query_id=None):
         orientation = self.get_object()
         if not orientation.beneficiary_email:
-            raise serializers.ValidationError("Adresse email du bénéficiaire inconnue")
+            raise ValidationError("Adresse email du bénéficiaire inconnue")
         message = self.request.data.get("message")
         cc_prescriber = self.request.data.get("cc_prescriber") in TRUTHY_VALUES
         cc_referent = self.request.data.get("cc_referent") in TRUTHY_VALUES
@@ -362,7 +364,7 @@ class StructureOrientationsView(APIView):
                 ReceivedOrientationExportSerializer(orientations, many=True).data
             )
 
-        raise serializers.ValidationError(
+        raise ValidationError(
             {"type": "Le paramètre 'type' doit être 'sent' ou 'received'."}
         )
 

--- a/back/dora/rest_auth/serializers.py
+++ b/back/dora/rest_auth/serializers.py
@@ -1,5 +1,6 @@
 from django.db.models import Prefetch
 from rest_framework import serializers
+from rest_framework.exceptions import ValidationError
 
 from dora.services.models import Bookmark, SavedSearch, Service
 from dora.services.serializers import BookmarkListSerializer, SavedSearchSerializer
@@ -114,7 +115,7 @@ class JoinStructureSerializer(serializers.Serializer):
         siret = data.get("siret")
         structure_slug = data.get("structure_slug")
         if siret and structure_slug:
-            raise serializers.ValidationError(
+            raise ValidationError(
                 "`siret` et `structure_slug` ne peuvent être présents simultanément"
             )
         if siret:
@@ -124,7 +125,7 @@ class JoinStructureSerializer(serializers.Serializer):
             except Establishment.DoesNotExist:
                 # The field is hidden on the frontend, so display this error globally
                 # TODO: Ideally it should be the frontend role to display the message anyway
-                raise serializers.ValidationError({"non_field_errors": "SIRET inconnu"})
+                raise ValidationError({"non_field_errors": "SIRET inconnu"})
         else:
             try:
                 structure = Structure.objects.get(slug=structure_slug)
@@ -132,7 +133,5 @@ class JoinStructureSerializer(serializers.Serializer):
             except Structure.DoesNotExist:
                 # The field is hidden on the frontend, so display this error globally
                 # TODO: Ideally it should be the frontend role to display the message anyway
-                raise serializers.ValidationError(
-                    {"non_field_errors": "structure inconnue"}
-                )
+                raise ValidationError({"non_field_errors": "structure inconnue"})
         return super().validate(data)

--- a/back/dora/services/serializers.py
+++ b/back/dora/services/serializers.py
@@ -4,10 +4,11 @@ from datetime import timedelta
 
 import requests
 from django.conf import settings
-from django.core.exceptions import ValidationError
+from django.core.exceptions import ValidationError as DjangoValidationError
 from django.core.files.storage import default_storage
 from django.utils.timezone import now
 from rest_framework import exceptions, serializers
+from rest_framework.exceptions import ValidationError
 from rest_framework.relations import PrimaryKeyRelatedField
 
 import dora.data_inclusion.client
@@ -56,10 +57,10 @@ class CreatablePrimaryKeyRelatedField(PrimaryKeyRelatedField):
 
         name = data.strip()
         if name == "":
-            raise ValidationError("Cette valeur est vide")
+            raise DjangoValidationError("Cette valeur est vide")
 
         if self.max_length is not None and len(name) > self.max_length:
-            raise ValidationError(
+            raise DjangoValidationError(
                 f"Cette valeur doit avoir moins de {self.max_length} caractères"
             )
 
@@ -69,7 +70,7 @@ class CreatablePrimaryKeyRelatedField(PrimaryKeyRelatedField):
             structure_slug = self.root.initial_data["structure"]
             structure = Structure.objects.get(slug=structure_slug)
         if not structure:
-            raise ValidationError("La structure ne peut pas être vide")
+            raise DjangoValidationError("La structure ne peut pas être vide")
         queryset = self.queryset
 
         # find if it already exists in the same structure
@@ -457,7 +458,7 @@ class ServiceSerializer(serializers.ModelSerializer):
         values = data[field]
         for val in values:
             if val.structure_id is not None and val.structure_id != structure.id:
-                raise serializers.ValidationError(
+                raise ValidationError(
                     {field: "Ce choix n'est pas disponible dans cette structure"},
                     "unallowed_custom_choices_bad_struc",
                 )

--- a/back/dora/services/tests/test_search.py
+++ b/back/dora/services/tests/test_search.py
@@ -2,7 +2,7 @@ from unittest import mock
 
 import pytest
 from model_bakery import baker
-from rest_framework import serializers
+from rest_framework.exceptions import ValidationError
 
 from dora.core.test_utils import (
     make_published_service,
@@ -160,7 +160,7 @@ class TestValidateSearchCategoriesAndSubcategories:
         """Teste que les catégories invalides sont rejetées."""
         baker.make("ServiceCategory", value="cat1", label="Catégorie 1")
 
-        with pytest.raises(serializers.ValidationError) as exc_info:
+        with pytest.raises(ValidationError) as exc_info:
             _validate_search_categories_and_subcategories(
                 categories_list=["invalid_cat"], subcategories_list=None
             )
@@ -171,7 +171,7 @@ class TestValidateSearchCategoriesAndSubcategories:
         """Teste que les sous-catégories invalides sont rejetées."""
         baker.make("ServiceSubCategory", value="cat1--sub1", label="Sous-catégorie 1")
 
-        with pytest.raises(serializers.ValidationError) as exc_info:
+        with pytest.raises(ValidationError) as exc_info:
             _validate_search_categories_and_subcategories(
                 categories_list=None, subcategories_list=["invalid--sub"]
             )
@@ -187,7 +187,7 @@ class TestValidateSearchCategoriesAndSubcategories:
             is_obsolete=True,
         )
 
-        with pytest.raises(serializers.ValidationError) as exc_info:
+        with pytest.raises(ValidationError) as exc_info:
             _validate_search_categories_and_subcategories(
                 categories_list=["obsolete_cat"], subcategories_list=None
             )
@@ -203,7 +203,7 @@ class TestValidateSearchCategoriesAndSubcategories:
             is_obsolete=True,
         )
 
-        with pytest.raises(serializers.ValidationError) as exc_info:
+        with pytest.raises(ValidationError) as exc_info:
             _validate_search_categories_and_subcategories(
                 categories_list=None, subcategories_list=["cat1--obsolete_sub"]
             )

--- a/back/dora/services/views.py
+++ b/back/dora/services/views.py
@@ -22,7 +22,7 @@ from rest_framework import (
     viewsets,
 )
 from rest_framework.decorators import action, api_view, permission_classes
-from rest_framework.exceptions import NotFound, PermissionDenied
+from rest_framework.exceptions import NotFound, PermissionDenied, ValidationError
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 
@@ -434,7 +434,7 @@ class BookmarkViewSet(
             di_id=slug if is_di else "",
         )
         if not created:
-            raise serializers.ValidationError("ce bookmark existe déjà")
+            raise ValidationError("ce bookmark existe déjà")
 
         return Response(status=status.HTTP_201_CREATED)
 
@@ -530,9 +530,7 @@ class ModelViewSet(ServiceViewSet):
                 raise PermissionDenied
 
             if service.model:
-                raise serializers.ValidationError(
-                    "Impossible de copier un service synchronisé"
-                )
+                raise ValidationError("Impossible de copier un service synchronisé")
 
         structure_slug = self.request.data.get("structure")
         try:
@@ -841,7 +839,7 @@ def _validate_search_categories_and_subcategories(
     """Valide que les catégories et sous-catégories fournies existent et ne sont pas obsolètes.
 
     Raises:
-        serializers.ValidationError: Si des catégories ou sous-catégories sont invalides
+        ValidationError: Si des catégories ou sous-catégories sont invalides
     """
     invalid_categories = []
     invalid_subcategories = []
@@ -870,7 +868,7 @@ def _validate_search_categories_and_subcategories(
             error_parts.append(
                 f"Sous-catégories invalides : {', '.join(invalid_subcategories)}"
             )
-        raise serializers.ValidationError(
+        raise ValidationError(
             " ; ".join(error_parts),
             code="invalid_categories_or_subcategories",
         )

--- a/back/dora/structures/csv_import.py
+++ b/back/dora/structures/csv_import.py
@@ -6,6 +6,7 @@ from typing import Dict, List, Union
 from django.db import IntegrityError
 from django.utils import timezone
 from rest_framework import serializers
+from rest_framework.exceptions import ValidationError
 
 from dora.core.models import ModerationStatus
 from dora.core.notify import send_moderation_notification
@@ -379,7 +380,7 @@ class ImportSerializer(serializers.Serializer):
             and not Structure.objects.filter(siret=siret).exists()
             and not Establishment.objects.filter(siret=siret).exists()
         ):
-            raise serializers.ValidationError(
+            raise ValidationError(
                 f"Siret inconnu: https://annuaire-entreprises.data.gouv.fr/etablissement/{siret}"
             )
         return siret
@@ -390,12 +391,12 @@ class ImportSerializer(serializers.Serializer):
             and not Structure.objects.filter(siret=parent_siret).exists()
             and not Establishment.objects.filter(siret=parent_siret).exists()
         ):
-            raise serializers.ValidationError(
+            raise ValidationError(
                 f"SIRET parent inconnu: https://annuaire-entreprises.data.gouv.fr/etablissement/{parent_siret}"
             )
 
         if Structure.objects.filter(siret=parent_siret, parent__isnull=False).exists():
-            raise serializers.ValidationError(
+            raise ValidationError(
                 f"Le SIRET {parent_siret} est une antenne, il ne peut pas être utilisé comme parent"
             )
 
@@ -406,7 +407,7 @@ class ImportSerializer(serializers.Serializer):
         parent_siret = data.get("parent_siret")
 
         if not siret and not parent_siret:
-            raise serializers.ValidationError("`siret` ou `parent_siret` sont requis")
+            raise ValidationError("`siret` ou `parent_siret` sont requis")
 
         return super().validate(data)
 
@@ -417,7 +418,7 @@ class ImportSerializer(serializers.Serializer):
                 label_obj = StructureNationalLabel.objects.get(value=label)
                 labels.append(label_obj)
             except StructureNationalLabel.DoesNotExist:
-                raise serializers.ValidationError(f"Label inconnu {label}")
+                raise ValidationError(f"Label inconnu {label}")
         return labels
 
     def validate_models(self, model_slugs: List[str]) -> List[ServiceModel]:
@@ -427,5 +428,5 @@ class ImportSerializer(serializers.Serializer):
                 model = ServiceModel.objects.get(slug=slug)
                 models.append(model)
             except ServiceModel.DoesNotExist:
-                raise serializers.ValidationError(f"Modèle inconnu {slug}")
+                raise ValidationError(f"Modèle inconnu {slug}")
         return models

--- a/back/dora/support/views.py
+++ b/back/dora/support/views.py
@@ -1,5 +1,5 @@
-from rest_framework import mixins, permissions, serializers, viewsets
-from rest_framework.exceptions import PermissionDenied
+from rest_framework import mixins, permissions, viewsets
+from rest_framework.exceptions import PermissionDenied, ValidationError
 
 from dora.core.models import ModerationStatus
 from dora.core.notify import send_moderation_notification
@@ -45,7 +45,7 @@ class ModerationMixin:
         )
 
         if not status_before_update != status_after_update:
-            raise serializers.ValidationError(
+            raise ValidationError(
                 "Mise à jour du statut de modération sans changement de statut"
             )
         msg = "Statut de modération changé par un•e membre de l'équipe"

--- a/back/dora/users/views.py
+++ b/back/dora/users/views.py
@@ -1,5 +1,6 @@
 from rest_framework import permissions, serializers, status
 from rest_framework.decorators import api_view, permission_classes
+from rest_framework.exceptions import ValidationError
 from rest_framework.response import Response
 
 from .models import User
@@ -13,9 +14,7 @@ class UserProfileSerializer(serializers.ModelSerializer):
 
     def validate(self, attrs):
         if "main_activity" not in attrs and not self.instance.main_activity:
-            raise serializers.ValidationError(
-                "Le champ « Activité principale » est requis"
-            )
+            raise ValidationError("Le champ « Activité principale » est requis")
         return attrs
 
 


### PR DESCRIPTION
C’est l’endroit où l’exception est définie.

Les exceptions ont été gardées à l’identique pour ne pas changer le comportement de production, mais je suspecte que plusieurs DjangoValidationError devraient être des ValidationError (DRF).