### PR TITLE
fix: Ne pas créer d'experiment Matomo lors du SSR

### DIFF
--- a/front/src/lib/utils/matomo.ts
+++ b/front/src/lib/utils/matomo.ts
@@ -34,6 +34,12 @@ type MatomoEvent = {
 };
 
 export function registerMatomoExperiment(experiment: MatomoExperiment) {
+  // Matomo n'est disponible que côté navigateur : on ne fait rien lors du
+  // rendu serveur, sans quoi l'accès à `window` provoque une erreur.
+  if (typeof window === "undefined") {
+    return;
+  }
+
   function createExperiment() {
     const Experiment = Matomo.AbTesting.Experiment;
 


### PR DESCRIPTION
Lors du premier chargement (via SSR) de la page, `registerMatomoExperiment` provoquait une erreur qui donnait systématiquement :
<img width="2560" height="1496" alt="Screenshot 2026-06-16 at 14-31-29 Erreur DORA" src="https://github.com/user-attachments/assets/24c43f1f-1a75-452d-9275-ce2e133e9b92" />
Pour voir s'afficher correctement le contenu de la page, il fallait cliquer sur un lien pour recharger le composant :
<img width="2560" height="1508" alt="image" src="https://github.com/user-attachments/assets/82674b46-f946-4922-8e71-d16e371ef87b" />
La modification proposée corrige ce souci.