### PR TITLE
feat: Activation du dropdown Nexus pour tous les utilisateurs

### DIFF
--- a/back/dora/nexus/tests/test_views.py
+++ b/back/dora/nexus/tests/test_views.py
@@ -276,19 +276,16 @@ def test_nexus_menu_status_user_not_authenticated(api_client):
 
 
 @pytest.mark.parametrize(
-    "mvp_enabled,proconnect,activated_services",
+    "proconnect,activated_services",
     [
-        (False, True, ["les-emplois"]),
-        (False, False, []),
-        (True, True, ["les-emplois"]),
-        (True, False, []),
+        (True, ["les-emplois"]),
+        (False, []),
     ],
 )
 @override_settings(NEXUS_MENU_ENABLED=True)
 def test_nexus_menu_status_authenticated(
     api_client,
     user,
-    mvp_enabled,
     proconnect,
     activated_services,
 ):
@@ -298,7 +295,6 @@ def test_nexus_menu_status_authenticated(
     mock_data = {
         "proconnect": proconnect,
         "activated_services": activated_services,
-        "mvp_enabled": mvp_enabled,
     }
 
     with patch("dora.nexus.views.NexusAPIClient") as mock_client_class:
@@ -310,5 +306,4 @@ def test_nexus_menu_status_authenticated(
         assert response.status_code == status.HTTP_200_OK
         assert response.data["proconnect"] == proconnect
         assert response.data["activated_services"] == activated_services
-        assert response.data["mvp_enabled"] == mvp_enabled
         mock_client_instance.dropdown_status.assert_called_once_with(user.email)

--- a/front/src/lib/requests/nexus.ts
+++ b/front/src/lib/requests/nexus.ts
@@ -13,7 +13,6 @@ export type NexusServiceID =
 export type NexusMenuStatus = {
   proconnect: boolean;
   activatedServices: NexusServiceID[];
-  mvpEnabled: boolean;
 };
 
 export const getNexusMenuStatus = async () => {

--- a/front/src/routes/_index/menu-nexus/menu-nexus.svelte
+++ b/front/src/routes/_index/menu-nexus/menu-nexus.svelte
@@ -45,7 +45,7 @@
   }
 </script>
 
-{#if nexusMenuStatus && nexusMenuStatus.mvpEnabled}
+{#if nexusMenuStatus}
   <DropdownMenu
     withBorders
     withSeparator={false}


### PR DESCRIPTION

https://app.notion.com/p/gip-inclusion/G-n-raliser-Nexus-l-ensemble-des-d-partements-3815f321b60480eea12be3860590ce94

J'ai un doute sur la récupération du statut : les emplois vont continuer à renvoyer mvp_enabled le temps de la bascle sur dora, est-ce que ça peut casser au moment de `return response.json() as Promise<NexusMenuStatus>;`