### PR TITLE
chore: Configuration des chemins de GDAL et GEOS via settings

### DIFF
--- a/back/config/settings/dev.py
+++ b/back/config/settings/dev.py
@@ -85,3 +85,8 @@ EMAIL_PORT = 1025
 EMAIL_HOST_USER = ""
 EMAIL_HOST_PASSWORD = ""
 EMAIL_USE_TLS = False
+
+# Custom paths for GDAL and GEOS libraries.
+# ------------------------------------------------------------------------------
+GDAL_LIBRARY_PATH = os.getenv("GDAL_LIBRARY_PATH")
+GEOS_LIBRARY_PATH = os.getenv("GEOS_LIBRARY_PATH")


### PR DESCRIPTION
Permet de définir, via deux variables d'environnement, des chemins personnalisé pour les librairies GDAL et GEOS.

Plus pratique pour les utilisateurs de macOS qui ont installé les librairies avec brew, par exemple.

cf. cette même PR sur les Emplois : https://github.com/gip-inclusion/les-emplois/pull/7845/changes

**EDIT** : On l'avait déjà, au temps pour moi (🙈) : https://github.com/gip-inclusion/dora/blob/891a9cc959987afe28c169aa326f74199bd83d91/back/config/settings/base.py#L479-L482