### PR TITLE
feat(services): Ajouter la route de recherche par mot-clé d·i

### DIFF
--- a/back/config/urls.py
+++ b/back/config/urls.py
@@ -65,7 +65,12 @@ private_api_patterns = [
     path("auth/", include("dora.rest_auth.urls")),
     path(
         "search/",
-        dora.services.views.search,
+        dora.services.views.search_services_view,
+    ),
+    path(
+        "search/keyword/",
+        dora.services.views.search_keyword_view,
+        name="search-keyword",
     ),
     path("stats/event/", dora.stats.views.log_event),
     path("services-di/<str:di_id>/", dora.services.views.service_di),

--- a/back/dora/api/exceptions.py
+++ b/back/dora/api/exceptions.py
@@ -1,0 +1,10 @@
+from rest_framework.exceptions import APIException
+from rest_framework.status import HTTP_503_SERVICE_UNAVAILABLE
+
+
+class ServiceUnavailable(APIException):
+    status_code = HTTP_503_SERVICE_UNAVAILABLE
+    default_detail = (
+        "Le serveur n'est pas prêt à traiter la requête, réessayez plus tard."
+    )
+    default_code = "service_unavailable"

--- a/back/dora/data_inclusion/client.py
+++ b/back/dora/data_inclusion/client.py
@@ -5,6 +5,7 @@ from typing import Optional
 
 import furl
 import requests
+from data_inclusion.schema.v1 import Frais, ModeAccueil, Public, Thematique, TypeService
 from django.conf import settings
 
 logger = logging.getLogger(__name__)
@@ -147,3 +148,55 @@ class DataInclusionClient:
         except requests.RequestException as err:
             logger.error(err)
             return None
+
+    @log_conn_error
+    def search(
+        self,
+        q: Optional[str] = None,
+        sources: Optional[list[str]] = None,
+        score_qualite_minimum: Optional[float] = None,
+        code_commune: Optional[str] = None,
+        code_departement: Optional[str] = None,
+        code_region: Optional[str] = None,
+        lat: Optional[float] = None,
+        lon: Optional[float] = None,
+        thematiques: Optional[list[Thematique]] = None,
+        frais: Optional[list[Frais]] = None,
+        modes_accueil: Optional[list[ModeAccueil]] = None,
+        publics: Optional[list[Public]] = None,
+        types: Optional[list[TypeService]] = None,
+        page: int = 1,
+        size: int = 50,
+    ) -> dict:
+        url = self.base_url.copy()
+        url = url / "search"
+        if q is not None:
+            url.args["q"] = q
+        if sources is not None:
+            url.args["sources"] = sources
+        if score_qualite_minimum is not None:
+            url.args["score_qualite_minimum"] = score_qualite_minimum
+        if code_commune is not None:
+            url.args["code_commune"] = code_commune
+        if code_departement is not None:
+            url.args["code_departement"] = code_departement
+        if code_region is not None:
+            url.args["code_region"] = code_region
+        if lat is not None:
+            url.args["lat"] = lat
+        if lon is not None:
+            url.args["lon"] = lon
+        if thematiques is not None:
+            url.args["thematiques"] = thematiques
+        if frais is not None:
+            url.args["frais"] = frais
+        if modes_accueil is not None:
+            url.args["modes_accueil"] = modes_accueil
+        if publics is not None:
+            url.args["publics"] = publics
+        if types is not None:
+            url.args["types"] = types
+        url.args["page"] = page
+        url.args["size"] = size
+        response = self._get(url)
+        return response.json()

--- a/back/dora/data_inclusion/mappings.py
+++ b/back/dora/data_inclusion/mappings.py
@@ -75,6 +75,7 @@ def map_search_result(result: dict) -> dict:
         #
         # SearchResultSerializer
         #
+        "search_score": result.get("score_recherche"),
         "distance": result["distance"]
         if result["distance"] is not None
         else None,  # en km

--- a/back/dora/data_inclusion/test_utils.py
+++ b/back/dora/data_inclusion/test_utils.py
@@ -1,7 +1,8 @@
+import math
 from typing import Optional
 from uuid import uuid4
 
-from data_inclusion.schema.v1 import ModeAccueil
+from data_inclusion.schema.v1 import Frais, ModeAccueil, Public, Thematique, TypeService
 
 
 def make_di_service_data(**kwargs) -> dict:
@@ -138,3 +139,29 @@ class FakeDataInclusionClient:
             ]
         else:
             return [{"distance": 30, "service": s} for s in services]
+
+    def search(
+        self,
+        q: Optional[str] = None,
+        sources: Optional[list[str]] = None,
+        score_qualite_minimum: Optional[float] = None,
+        code_commune: Optional[str] = None,
+        code_departement: Optional[str] = None,
+        code_region: Optional[str] = None,
+        lat: Optional[float] = None,
+        lon: Optional[float] = None,
+        thematiques: Optional[list[Thematique]] = None,
+        frais: Optional[list[Frais]] = None,
+        modes_accueil: Optional[list[ModeAccueil]] = None,
+        publics: Optional[list[Public]] = None,
+        types: Optional[list[TypeService]] = None,
+        page: int = 1,
+        size: int = 50,
+    ):
+        return {
+            "items": self.services,
+            "total": len(self.services),
+            "page": page,
+            "size": size,
+            "pages": math.ceil(len(self.services) / size),
+        }

--- a/back/dora/services/search.py
+++ b/back/dora/services/search.py
@@ -1,3 +1,4 @@
+import logging
 import random
 from _operator import itemgetter
 from datetime import date
@@ -15,6 +16,7 @@ from django.utils import timezone
 
 import dora.services.models as models
 from dora import data_inclusion
+from dora.api.exceptions import ServiceUnavailable
 from dora.core.constants import WGS84
 from dora.data_inclusion.mappings import map_search_result
 from dora.decoupage_administratif.models import City
@@ -29,6 +31,8 @@ DEPARTMENT_CODE_SOMME = "80"
 DEPARTMENT_CODE_VOSGES = "88"
 MEDIATION_NUMERIQUE_SOURCE = "mediation-numerique"
 FRANCE_SERVICES_STRUCTURE_ID_PREFIX = "mediation-numerique--France-Services"
+
+logger = logging.getLogger(__name__)
 
 
 def _filter_and_annotate_dora_services(
@@ -342,6 +346,29 @@ def _get_dora_results(
     }
 
 
+def _dora_services_by_id(service_ids):
+    return {
+        str(service.id): service
+        for service in models.Service.objects.filter_for_DI()
+        .select_related(
+            "structure",
+        )
+        .prefetch_related(
+            "kinds",
+            "fee_condition",
+            "location_kinds",
+            "publics",
+            "categories",
+            "subcategories",
+            "funding_labels",
+            "coach_orientation_modes",
+            "beneficiaries_access_modes",
+        )
+        .filter(id__in=service_ids)
+        .distinct()
+    }
+
+
 def _get_results(
     request,
     di_client: data_inclusion.DataInclusionClient,
@@ -380,26 +407,7 @@ def _get_results(
     }
     dora_ids = list(dora_distances.keys())
 
-    dora_services_by_id = {
-        str(service.id): service
-        for service in models.Service.objects.filter_for_DI()
-        .select_related(
-            "structure",
-        )
-        .prefetch_related(
-            "kinds",
-            "fee_condition",
-            "location_kinds",
-            "publics",
-            "categories",
-            "subcategories",
-            "funding_labels",
-            "coach_orientation_modes",
-            "beneficiaries_access_modes",
-        )
-        .filter(id__in=dora_ids)
-        .distinct()
-    }
+    dora_services_by_id = _dora_services_by_id(dora_ids)
 
     # Annotation des services avec la distance calculée par DI,
     # en conservant l'ordre des résultats DI.
@@ -495,3 +503,51 @@ def search_services(
             lon=lon,
         )
     return _sort_services(results), metadata
+
+
+def _get_keyword_search_results(request, raw_di_results):
+    def dora_id(service):
+        return service["id"].removeprefix("dora--")
+
+    dora_ids = {
+        dora_id(result["service"])
+        for result in raw_di_results
+        if result["service"]["source"] == "dora"
+    }
+    dora_services_by_id = _dora_services_by_id(dora_ids)
+    results = []
+    for raw_di_result in raw_di_results:
+        if raw_di_result["service"]["source"] == "dora":
+            service = dora_services_by_id.get(dora_id(raw_di_result["service"]))
+            if service:
+                service.distance = raw_di_result["distance"]
+                service.search_score = raw_di_result["score_recherche"]
+                data = SearchResultSerializer(
+                    service, context={"request": request}
+                ).data
+                results.append(data)
+            else:
+                logger.warning(
+                    "d·i a retourné un service inconnu, id: %s",
+                    dora_id(raw_di_result["service"]),
+                )
+        else:
+            results.append(map_search_result(raw_di_result))
+    return results
+
+
+def search_keyword(request, api_params):
+    di_client = data_inclusion.di_client_factory()
+    try:
+        raw_di_results = di_client.search(**api_params, size=50)
+    except requests.RequestException:
+        raise ServiceUnavailable(
+            "L’API data.inclusion.gouv.fr nécessaire pour la recherche "
+            "n’est pas disponible. Merci de réessayer ultérieurement."
+        )
+    results = _get_keyword_search_results(request, raw_di_results["items"])
+    metadata = {
+        "services_pages": raw_di_results["pages"],
+        "services_total": raw_di_results["total"],
+    }
+    return results, metadata

--- a/back/dora/services/serializers.py
+++ b/back/dora/services/serializers.py
@@ -3,7 +3,14 @@ import textwrap
 from datetime import timedelta
 
 import requests
-from data_inclusion.schema.v1 import ModeAccueil
+from data_inclusion.schema.v1 import (
+    Categorie,
+    Frais,
+    ModeAccueil,
+    Thematique,
+    TypeService,
+)
+from data_inclusion.schema.v1 import Public as DIPublic
 from django.conf import settings
 from django.core.exceptions import ValidationError as DjangoValidationError
 from django.core.files.storage import default_storage
@@ -847,11 +854,51 @@ class BookmarkSerializer(BookmarkListSerializer):
             }
 
 
+class SearchKeywordQuerySerializer(serializers.Serializer):
+    q = serializers.CharField(required=False)
+    code_commune = serializers.CharField(required=False)
+    code_departement = serializers.CharField(required=False)
+    code_region = serializers.CharField(required=False)
+    lon = serializers.FloatField(required=False)
+    lat = serializers.FloatField(required=False)
+    modes_accueil = serializers.MultipleChoiceField(choices=ModeAccueil, required=False)
+    publics = serializers.MultipleChoiceField(choices=DIPublic, required=False)
+    cats = serializers.MultipleChoiceField(choices=Categorie, required=False)
+    subs = serializers.MultipleChoiceField(choices=Thematique, required=False)
+    types = serializers.MultipleChoiceField(choices=TypeService, required=False)
+    frais = serializers.MultipleChoiceField(choices=Frais, required=False)
+    page = serializers.IntegerField(min_value=1, required=False, default=1)
+
+    def validate(self, attrs):
+        fields_required = {
+            "q",
+            "code_commune",
+            "code_departement",
+            "code_region",
+            "lon",
+            "lat",
+        }
+        if not set(attrs) & fields_required:
+            fields_ordered = [f for f in self.fields if f in fields_required]
+            raise ValidationError(
+                f"Au moins un champ doit être fourni, parmi {', '.join(fields_ordered)}."
+            )
+        lat = attrs.get("lat")
+        lon = attrs.get("lon")
+        if (lat is None) != (lon is None):
+            missing, passed = ("lon", "lat") if lon is None else ("lat", "lon")
+            raise ValidationError(
+                f"Le champ {missing} est requis lorsque {passed} est fourni."
+            )
+        return attrs
+
+
 class SearchResultSerializer(ServiceListSerializer):
     distance = serializers.SerializerMethodField()
     coordinates = serializers.SerializerMethodField()
     di_publics = serializers.SerializerMethodField()
     location_kinds = serializers.SerializerMethodField()
+    search_score = serializers.FloatField(required=False)
 
     class Meta:
         model = Service
@@ -873,6 +920,7 @@ class SearchResultSerializer(ServiceListSerializer):
             "name",
             "postal_code",
             "publication_date",
+            "search_score",
             "short_desc",
             "slug",
             "status",

--- a/back/dora/services/tests/test_search.py
+++ b/back/dora/services/tests/test_search.py
@@ -1,9 +1,15 @@
+import logging
+import random
 from unittest import mock
 
 import pytest
+import requests
+from django.contrib.gis.geos import Point
+from django.urls import reverse
 from model_bakery import baker
 from rest_framework.exceptions import ValidationError
 
+from dora.core.constants import WGS84
 from dora.core.test_utils import (
     make_published_service,
     make_service,
@@ -11,8 +17,10 @@ from dora.core.test_utils import (
     make_user,
 )
 from dora.data_inclusion.test_utils import FakeDataInclusionClient, make_di_service_data
-from dora.decoupage_administratif.models import AdminDivisionType
+from dora.decoupage_administratif.models import AdminDivisionType, City
 from dora.services.enums import ServiceStatus
+from dora.services.models import ServiceSubCategory
+from dora.services.search import MAX_DISTANCE
 from dora.services.views import _validate_search_categories_and_subcategories
 
 
@@ -245,3 +253,421 @@ def test_search_endpoint_rejects_invalid_subcategories(api_client, city):
     assert len(response.data) > 0
     assert "message" in response.data[0]
     assert "Sous-catégories invalides" in str(response.data[0]["message"])
+
+
+class TestSearchKeyword:
+    @property
+    def api_result(self):
+        return {
+            "service": make_di_service_data(),
+            "distance": 0,
+            "score_recherche": 0,
+        }
+
+    @pytest.mark.parametrize(
+        "params,expected",
+        [
+            pytest.param(
+                {},
+                {
+                    "nonFieldErrors": [
+                        {
+                            "message": "Au moins un champ doit être fourni, parmi q, code_commune, code_departement, code_region, lon, lat.",
+                            "code": "invalid",
+                        }
+                    ]
+                },
+                id="noquery",
+            ),
+            pytest.param(
+                {"cats": "foo"},
+                {
+                    "cats": [
+                        {
+                            "message": "«\xa0foo\xa0» n'est pas un choix valide.",
+                            "code": "invalid_choice",
+                        }
+                    ]
+                },
+                id="invalid_category",
+            ),
+            pytest.param(
+                {"lat": "12.1234"},
+                {
+                    "nonFieldErrors": [
+                        {
+                            "message": "Le champ lon est requis lorsque lat est fourni.",
+                            "code": "invalid",
+                        }
+                    ]
+                },
+                id="lat",
+            ),
+            pytest.param(
+                {"lon": "12.1234"},
+                {
+                    "nonFieldErrors": [
+                        {
+                            "message": "Le champ lat est requis lorsque lon est fourni.",
+                            "code": "invalid",
+                        }
+                    ]
+                },
+                id="lon",
+            ),
+            pytest.param(
+                {"lat": "12.1234", "q": "foo"},
+                {
+                    "nonFieldErrors": [
+                        {
+                            "message": "Le champ lon est requis lorsque lat est fourni.",
+                            "code": "invalid",
+                        }
+                    ]
+                },
+                id="lat_with_q",
+            ),
+        ],
+    )
+    def test_invalid_payload(self, api_client, params, expected):
+        response = api_client.get(reverse("search-keyword"), params)
+        assert response.status_code == 400
+        assert response.json() == expected
+
+    @pytest.mark.parametrize(
+        "services_kwargs,expected_coords",
+        [
+            pytest.param(
+                [{"geom": Point(-0.123, 0.123, srid=WGS84)}],
+                [-0.123, 0.123],
+                id="single",
+            ),
+            pytest.param(
+                [
+                    {"geom": Point(-1, 1, srid=WGS84)},
+                    {"geom": Point(-2, 2, srid=WGS84)},
+                ],
+                [-1.5, 1.5],
+                id="search_center_average",
+            ),
+        ],
+    )
+    def test_search_api(self, api_client, expected_coords, services_kwargs):
+        results = []
+        expected_slugs = []
+        for i, service_kwargs in enumerate(services_kwargs):
+            service = make_published_service(
+                diffusion_zone_type=AdminDivisionType.COUNTRY,
+                **service_kwargs,
+            )
+            result = self.api_result
+            result["service"]["id"] = f"dora--{service.pk}"
+            result["service"]["source"] = "dora"
+            # La distance est ignorée dans le tri.
+            result["distance"] = random.uniform(0, 10)
+            result["score_recherche"] = 0.1 * i
+            results.append(result)
+            expected_slugs.append(service.slug)
+        with mock.patch(
+            "dora.data_inclusion.di_client_factory",
+            return_value=FakeDataInclusionClient(services=results),
+        ):
+            response = api_client.get(reverse("search-keyword"), {"q": "foo"})
+
+        assert response.status_code == 200
+        response_json = response.json()
+        assert [s["slug"] for s in response_json["services"]] == expected_slugs
+        assert response_json["searchCenter"] == expected_coords
+
+    def test_search_city(self, api_client):
+        paris = City.objects.create(
+            code="75056",
+            name="Paris",
+            department="75",
+            epci="200054781",
+            region="11",
+            postal_codes=["75001", "75002"],
+            population=2161000,
+            normalized_name="PARIS 75",
+            center=Point(2.3522, 48.8566, srid=WGS84),
+        )
+        service = make_published_service(diffusion_zone_type=AdminDivisionType.COUNTRY)
+        result = self.api_result
+        result["service"]["id"] = f"dora--{service.pk}"
+        result["service"]["source"] = "dora"
+        result["service"]["code_postal"] = paris.postal_codes[0]
+        result["service"]["code_insee"] = paris.code
+        with mock.patch(
+            "dora.data_inclusion.di_client_factory",
+            return_value=FakeDataInclusionClient(services=[result]),
+        ):
+            response = api_client.get(
+                reverse("search-keyword"), {"code_commune": paris.code}
+            )
+
+        assert response.status_code == 200
+        response_json = response.json()
+        assert [s["slug"] for s in response_json["services"]] == [service.slug]
+        assert response_json["searchCenter"] == [paris.center.x, paris.center.y]
+
+    def test_search_lat_lon_0(self, api_client):
+        service = make_published_service(diffusion_zone_type=AdminDivisionType.COUNTRY)
+        result = self.api_result
+        result["service"]["id"] = f"dora--{service.pk}"
+        result["service"]["source"] = "dora"
+        result["service"]["latitude"] = 0
+        result["service"]["longitude"] = 0
+        with mock.patch(
+            "dora.data_inclusion.di_client_factory",
+            return_value=FakeDataInclusionClient(services=[result]),
+        ):
+            response = api_client.get(reverse("search-keyword"), {"lat": 0, "lon": 0})
+
+        assert response.status_code == 200
+        response_json = response.json()
+        assert [s["slug"] for s in response_json["services"]] == [service.slug]
+        assert response_json["searchCenter"] == [0, 0]
+
+    def test_di_unavailable(self, api_client):
+        def requests_error(*args, **kwargs):
+            raise requests.HTTPError()
+
+        fake_client = FakeDataInclusionClient()
+        fake_client.search = requests_error
+        with mock.patch(
+            "dora.data_inclusion.di_client_factory",
+            return_value=fake_client,
+        ):
+            response = api_client.get(reverse("search-keyword"), {"q": "foo"})
+
+        assert response.status_code == 503
+        assert response.json() == {
+            "detail": {
+                "message": (
+                    "L’API data.inclusion.gouv.fr nécessaire pour la recherche "
+                    "n’est pas disponible. Merci de réessayer ultérieurement."
+                ),
+                "code": "service_unavailable",
+            }
+        }
+
+    def test_search_api_ignores_distance(self, api_client):
+        result = self.api_result
+        result["distance"] = MAX_DISTANCE + 1
+        result["service"]["longitude"] = -42
+        result["service"]["latitude"] = 42
+        with mock.patch(
+            "dora.data_inclusion.di_client_factory",
+            return_value=FakeDataInclusionClient(services=[result]),
+        ):
+            response = api_client.get(reverse("search-keyword"), {"q": "oiseau"})
+
+        assert response.status_code == 200
+        response_json = response.json()
+        assert [s["slug"] for s in response_json["services"]] == [
+            result["service"]["id"]
+        ]
+        assert response_json["searchCenter"] == [-42, 42]
+
+    def test_search_ignores_score_qualite_minimum(self, api_client, settings):
+        settings.DATA_INCLUSION_SCORE_QUALITE_MINIMUM = 0.8
+        result = self.api_result
+        result["service"]["score_qualite"] = 0.7
+        with mock.patch(
+            "dora.data_inclusion.di_client_factory",
+            return_value=FakeDataInclusionClient(services=[result]),
+        ):
+            response = api_client.get(reverse("search-keyword"), {"q": "oiseau"})
+
+        assert response.status_code == 200
+        response_json = response.json()
+        assert [s["slug"] for s in response_json["services"]] == [
+            result["service"]["id"]
+        ]
+        assert response_json["searchCenter"] is None
+
+    def test_category(self, api_client):
+        category_value = "choisir-un-metier"
+        subcategories = ServiceSubCategory.objects.filter(
+            value__startswith=category_value
+        )
+        client = FakeDataInclusionClient()
+        spy = mock.MagicMock(wraps=client, spec_set=client)
+        with mock.patch("dora.data_inclusion.di_client_factory", return_value=spy):
+            response = api_client.get(
+                reverse("search-keyword"),
+                {
+                    "q": "foo",  # Pass validation.
+                    "cats": [category_value],
+                },
+            )
+
+        assert response.status_code == 200
+        assert spy.mock_calls == [
+            mock.call.search(
+                q="foo",
+                modes_accueil=[],
+                publics=[],
+                types=[],
+                frais=[],
+                page=1,
+                # Does not include all subcategories for category.
+                thematiques=[s.value for s in subcategories],
+                size=50,
+            )
+        ]
+
+    def test_subcategory_has_precedence_over_category(self, api_client):
+        category_value = "choisir-un-metier"
+        subcategories = ServiceSubCategory.objects.filter(
+            value__startswith=category_value
+        )
+        assert len(subcategories) > 1
+        selected_subcategory_value = subcategories[0].value
+        client = FakeDataInclusionClient()
+        spy = mock.MagicMock(wraps=client, spec_set=client)
+        with mock.patch("dora.data_inclusion.di_client_factory", return_value=spy):
+            response = api_client.get(
+                reverse("search-keyword"),
+                {
+                    "q": "foo",  # Pass validation.
+                    "cats": [category_value],
+                    "subs": [selected_subcategory_value],
+                },
+            )
+
+        assert response.status_code == 200
+        assert spy.mock_calls == [
+            mock.call.search(
+                q="foo",
+                modes_accueil=[],
+                publics=[],
+                types=[],
+                frais=[],
+                page=1,
+                # Does not include all subcategories for category.
+                thematiques=[selected_subcategory_value],
+                size=50,
+            )
+        ]
+
+    def test_logs_nonexistent_dora_service(self, api_client, caplog):
+        caplog.set_level(logging.WARNING)
+        service = make_di_service_data(source="dora")
+        result = {
+            "service": service,
+            "distance": 0,
+            "score_recherche": 0,
+        }
+        service_id = service["id"].removeprefix("dora--")
+        with mock.patch(
+            "dora.data_inclusion.di_client_factory",
+            return_value=FakeDataInclusionClient(services=[result]),
+        ):
+            response = api_client.get(reverse("search-keyword"), {"q": "oiseau"})
+
+        assert response.status_code == 200
+        # Le service non existant est exclu.
+        assert [s["slug"] for s in response.json()["services"]] == []
+        assert caplog.record_tuples == [
+            (
+                "dora.services.search",
+                logging.WARNING,
+                f"d·i a retourné un service inconnu, id: {service_id}",
+            )
+        ]
+
+    def test_preserves_di_ordering(self, api_client):
+        results = []
+        id_to_slug = {}
+        for _ in range(2):
+            service = make_published_service(
+                diffusion_zone_type=AdminDivisionType.COUNTRY,
+            )
+            result = self.api_result
+            id_ = f"dora--{service.pk}"
+            result["service"]["id"] = id_
+            result["service"]["source"] = "dora"
+            id_to_slug[id_] = service.slug
+            results.append(result)
+        results.append(self.api_result)  # service d·i.
+
+        for result in results:
+            result["distance"] = random.uniform(0, 10)
+            result["score_recherche"] = random.random()
+        random.shuffle(results)
+
+        with mock.patch(
+            "dora.data_inclusion.di_client_factory",
+            return_value=FakeDataInclusionClient(services=results),
+        ):
+            response = api_client.get(reverse("search-keyword"), {"q": "foo"})
+
+        assert response.status_code == 200
+        expected_slugs = []
+        for r in results:
+            slug = r["service"]["id"]
+            expected_slugs.append(id_to_slug.get(slug, slug))
+        assert [s["slug"] for s in response.json()["services"]] == expected_slugs
+
+    def test_city_code_is_replaced_with_lon_lat(self, api_client):
+        paris = City.objects.create(
+            code="75056",
+            name="Paris",
+            department="75",
+            epci="200054781",
+            region="11",
+            postal_codes=["75001", "75002"],
+            population=2161000,
+            normalized_name="PARIS 75",
+            center=Point(2.3522, 48.8566, srid=WGS84),
+        )
+        client = FakeDataInclusionClient()
+        spy = mock.MagicMock(wraps=client, spec_set=client)
+        with mock.patch("dora.data_inclusion.di_client_factory", return_value=spy):
+            response = api_client.get(
+                reverse("search-keyword"),
+                {
+                    "code_commune": paris.code,
+                },
+            )
+
+        assert response.status_code == 200
+        assert spy.mock_calls == [
+            mock.call.search(
+                modes_accueil=[],
+                publics=[],
+                types=[],
+                frais=[],
+                page=1,
+                thematiques=[],
+                lon=paris.center.x,
+                lat=paris.center.y,
+                size=50,
+            )
+        ]
+
+    def test_city_code_invalid(self, api_client):
+        client = FakeDataInclusionClient()
+        spy = mock.MagicMock(wraps=client, spec_set=client)
+        with mock.patch("dora.data_inclusion.di_client_factory", return_value=spy):
+            response = api_client.get(
+                reverse("search-keyword"),
+                {
+                    "code_commune": "98765",
+                },
+            )
+
+        assert response.status_code == 200
+        assert spy.mock_calls == [
+            mock.call.search(
+                modes_accueil=[],
+                publics=[],
+                types=[],
+                frais=[],
+                page=1,
+                thematiques=[],
+                code_commune="98765",
+                size=50,
+            )
+        ]

--- a/back/dora/services/tests/test_services.py
+++ b/back/dora/services/tests/test_services.py
@@ -61,7 +61,7 @@ from ..models import (
     ServiceSubCategory,
 )
 from ..utils import SYNC_CUSTOM_M2M_FIELDS, SYNC_FIELDS, SYNC_M2M_FIELDS
-from ..views import search, service_di
+from ..views import search_services_view, service_di
 
 DUMMY_SERVICE = {"name": "Mon service"}
 
@@ -1219,7 +1219,7 @@ class DataInclusionSearchTestCase(APITestCase):
             "dora.data_inclusion.di_client_factory"
         ) as mock_di_client_factory:
             mock_di_client_factory.return_value = di_client or self.di_client
-            return search(request)
+            return search_services_view(request)
 
     def service_di(self, request, di_id):
         with mock.patch(

--- a/back/dora/services/views.py
+++ b/back/dora/services/views.py
@@ -56,7 +56,11 @@ from dora.services.models import (
     ServiceSubCategory,
     UpdateFrequency,
 )
-from dora.services.search import MAX_DISTANCE, search_services
+from dora.services.search import (
+    MAX_DISTANCE,
+    search_keyword,
+    search_services,
+)
 from dora.services.utils import synchronize_service_from_model
 from dora.stats.models import DeploymentLevel, DeploymentState
 from dora.structures.models import Structure, StructureMember
@@ -66,6 +70,7 @@ from .serializers import (
     BookmarkSerializer,
     FeedbackSerializer,
     SavedSearchSerializer,
+    SearchKeywordQuerySerializer,
     ServiceListSerializer,
     ServiceModelSerializer,
     ServiceSerializer,
@@ -906,7 +911,7 @@ def _validate_search_categories_and_subcategories(
 
 @api_view()
 @permission_classes([permissions.AllowAny])
-def search(request):
+def search_services_view(request):
     city_code = request.GET.get("city")
     categories = request.GET.get("cats")
     subcategories = request.GET.get("subs")
@@ -962,5 +967,71 @@ def search(request):
             "search_radius_km": MAX_DISTANCE,
             "funding_labels": metadata["funding_labels"],
             "services": sorted_services,
+        }
+    )
+
+
+@api_view()
+@permission_classes([permissions.AllowAny])
+def search_keyword_view(request):
+    serializer = SearchKeywordQuerySerializer(data=request.GET)
+    serializer.is_valid(raise_exception=True)
+
+    # Les params GET ne correspondant à aucun champ du serializer sont ignorés.
+    query = serializer.data
+    categories = query.pop("cats")
+    subcategories = query.pop("subs")
+    categories = [
+        # Use more specific subcategories.
+        cat
+        for cat in categories
+        if not any(sub.startswith(cat) for sub in subcategories)
+    ]
+    if categories:
+        subcategories.extend(
+            ServiceSubCategory.objects.filter(
+                Q.create(
+                    [Q(value__startswith=cat) for cat in categories],
+                    connector=Q.OR,
+                )
+            ).values_list("value", flat=True)
+        )
+    query["thematiques"] = subcategories
+
+    city = None
+    # La recherche par mots-clés d·i (/search) ne cherche pas aux alentours de
+    # la commune (contrairement à /search/services).
+    if city_code := query.pop("code_commune", None):
+        city_code = arrdt_to_main_insee_code(city_code)
+        try:
+            city = City.objects.get(pk=city_code)
+        except City.DoesNotExist:
+            query["code_commune"] = city_code
+        else:
+            query["lon"] = city.center.x
+            query["lat"] = city.center.y
+    sorted_services, metadata = search_keyword(request, query)
+
+    search_center = None
+    lon = query.get("lon")
+    if lon is not None:
+        search_center = [lon, query["lat"]]
+    if search_center is None:
+        sum_x, sum_y, total = 0, 0, 0
+        for service in sorted_services:
+            if coords := service["coordinates"]:
+                [x, y] = coords
+                sum_x += x
+                sum_y += y
+                total += 1
+        if total:
+            search_center = [sum_x / total, sum_y / total]
+
+    return Response(
+        {
+            "search_center": search_center,
+            "services": sorted_services,
+            "services_pages": metadata["services_pages"],
+            "services_total": metadata["services_total"],
         }
     )


### PR DESCRIPTION
[[Carte Notion](https://app.notion.com/p/gip-inclusion/Page-r-sultats-de-recherche-header-filtres-carte-service-bloc-explicatif-3745f321b6048075ae9ef422f8638eff)]

Les résultats sont paginés, car la recherche de mots courants (famille, aide, a, ...) peut trouver beaucoup de resultats (jusqu’à 150K).

Le filtre sur `location_kinds` est effectué par d·i.

Comme la recherche fonctionne par mots-clés, on s’attend à ce que les utilisateurs aient en tête un résultat précis. Les résultats de faible qualité (score_qualite) ne sont pas exclus, car l’absence de résultat pour une recherche par nom de service / structure est très surprenante.

La vue `services.views.search` a été renommée en `search_services_view` pour distinguer :
- la fonction `search_service`,
- la nouvelle route API de recherche par mots-clés (`/search`)