### PR TITLE
fix: Correction de l'export des publics vers DI et de leur affichage dans DORA

### DIFF
--- a/back/dora/api/serializers.py
+++ b/back/dora/api/serializers.py
@@ -1,4 +1,5 @@
 # from django.core.files.storage import default_storage
+from data_inclusion.schema.v1.publics import Public as DiPublic
 from rest_framework import serializers
 
 from dora.services.models import (
@@ -304,7 +305,17 @@ class ServiceSerializer(serializers.ModelSerializer):
             for public in obj.publics.all()
             for item in public.corresponding_di_publics
         ]
-        return list(dict.fromkeys(all_items))
+        unique_di_publics = list(dict.fromkeys(all_items))
+        all_publics = {
+            p.value for p in DiPublic if p.value != DiPublic.TOUS_PUBLICS.value
+        }
+        if (
+            not unique_di_publics
+            or DiPublic.TOUS_PUBLICS.value in unique_di_publics
+            or set(unique_di_publics) >= all_publics
+        ):
+            return [DiPublic.TOUS_PUBLICS.value]
+        return unique_di_publics
 
     def get_publics_precisions(self, obj):
         return ", ".join([p.name for p in obj.publics.all()])

--- a/back/dora/api/test_api.py
+++ b/back/dora/api/test_api.py
@@ -415,6 +415,34 @@ def test_service_serialization_exemple(authenticated_user, api_client, settings)
             assert data[key] == expected_val
 
 
+def test_service_publics_export_empty_maps_to_tous_publics(
+    authenticated_user, api_client
+):
+    service = make_service(status=ServiceStatus.PUBLISHED)
+    service.publics.clear()  # no publics
+
+    response = api_client.get(f"/api/v2/services/{service.id}/")
+
+    assert response.status_code == 200
+    assert response.json()["publics"] == ["tous-publics"]
+
+
+def test_service_publics_export_all_maps_to_tous_publics(
+    authenticated_user, api_client
+):
+    all_real_publics = [p.value for p in DiPublic if p.value != "tous-publics"]
+    service = make_service(status=ServiceStatus.PUBLISHED)
+    service.publics.clear()
+    service.publics.add(
+        baker.make(Public, name="tous", corresponding_di_publics=all_real_publics)
+    )  # all publics
+
+    response = api_client.get(f"/api/v2/services/{service.id}/")
+
+    assert response.status_code == 200
+    assert response.json()["publics"] == ["tous-publics"]
+
+
 def test_service_serialization_formulaire_en_ligne(
     authenticated_user, api_client, settings
 ):

--- a/front/src/lib/utils/service-share-mailto.ts
+++ b/front/src/lib/utils/service-share-mailto.ts
@@ -71,7 +71,10 @@ export function buildServiceShareMailto(
   lines.push(
     "",
     "Le public concerné :",
-    formatBulletList(service.publicsDisplay, "Tous publics"),
+    formatBulletList(
+      service.publicsDisplay,
+      service.publicsDisplay === null ? "Non renseigné" : "Tous publics"
+    ),
     "",
     "Comment mobiliser ce service :",
     "",

--- a/front/src/routes/(modeles-services)/components/service-body/service-presentation/service-key-informations/service-key-informations.svelte
+++ b/front/src/routes/(modeles-services)/components/service-body/service-presentation/service-key-informations/service-key-informations.svelte
@@ -66,11 +66,15 @@
         <ul
           class="[&>li+li]:before:mx-s6 [&>li]:inline [&>li+li]:before:inline [&>li+li]:before:content-['·']"
         >
-          {#each service.publicsDisplay || [] as pub}
-            <li>{pub}</li>
+          {#if service.publicsDisplay === null}
+            <li>Non renseigné</li>
           {:else}
-            <li>Tous publics</li>
-          {/each}
+            {#each service.publicsDisplay as pub}
+              <li>{pub}</li>
+            {:else}
+              <li>Tous publics</li>
+            {/each}
+          {/if}
         </ul>
       </ServiceKeyInformationSection>
     </div>


### PR DESCRIPTION
data⋅inclusion has various cases for the publics:
- publics=non empty list : a list of the avilable publics that can be displayed
- publics=NULL : 'we don't know' (non spécifié), bad quality score
- publics=[] : tous publics (
- publics=[all available publics] => 'tous-publics'

DORA did not have this display logic about public=NULL means "Non renseigné" and displayed "Tous publics".

Also, within DORA services, if a service has NULL or empty publics, it *definitely* means it is "tous-publics". So we mirror this when exporting DORA services's publics to data⋅inclusion.