### PR TITLE
perf: éliminer le n+1 query sur la liste des services

### DIFF
--- a/back/dora/services/tests/test_services.py
+++ b/back/dora/services/tests/test_services.py
@@ -23,7 +23,7 @@ from rest_framework.test import APIRequestFactory, APITestCase
 from dora.core.constants import WGS84
 from dora.core.test_utils import make_model, make_service, make_structure
 from dora.data_inclusion.test_utils import FakeDataInclusionClient, make_di_service_data
-from dora.decoupage_administratif.models import AdminDivisionType, City
+from dora.decoupage_administratif.models import AdminDivisionType, City, EPCI
 from dora.services.enums import ServiceStatus
 from dora.services.migration_utils import (
     add_categories_and_subcategories_if_subcategory,
@@ -198,36 +198,47 @@ class ServiceTestCase(APITestCase):
     def test_cache_diffusion_zones(self):
         # `ServiceViewSet.list` doit pré-charger les `City` en bloc via
         # `warm_cache` pour éviter un N+1 sur la zone de diffusion. On crée
-        # plusieurs services dont la zone est une commune, puis on vérifie
-        # qu'une seule requête sur la table `City` est émise par la vue.
+        # 5 services dont la zone est une commune et 5 dont la zone et une EPCI, puis on vérifie
+        # qu'une seule requête sur la table `City` et une requête sur la table `EPCI`
+        # est émise par la vue.
+
         for _ in range(5):
             city = baker.make("decoupage_administratif.City")
+            epci = baker.make("decoupage_administratif.EPCI")
             make_service(
                 structure=self.my_struct,
                 status=ServiceStatus.PUBLISHED,
                 diffusion_zone_type=AdminDivisionType.CITY,
                 diffusion_zone_details=city.code,
             )
+            make_service(
+                structure=self.my_struct,
+                status=ServiceStatus.PUBLISHED,
+                diffusion_zone_type=AdminDivisionType.EPCI,
+                diffusion_zone_details=epci.code,
+            )
 
         # Cache process-wide : on le vide pour repartir d'un état connu.
         City.objects._cache.clear()
+        EPCI.objects._cache.clear()
 
         with CaptureQueriesContext(connection) as ctx:
             response = self.client.get("/services/")
             self.assertEqual(response.status_code, 200)
 
-        city_queries = [
+        diffusion_zone_queries = [
             q
             for q in ctx.captured_queries
             if '"decoupage_administratif_city"' in q["sql"]
+            or '"decoupage_administratif_epci"' in q["sql"]
         ]
-        # Avec `warm_cache` : 1 SELECT IN. Sans `warm_cache` : 5 SELECT (un
-        # par service). Le seuil à 1 fait échouer le test dès qu'on retire
+        # Avec `warm_cache` : 2 SELECT IN. Sans `warm_cache` : 10 SELECT (un
+        # par service). Le seuil à 2 fait échouer le test dès qu'on retire
         # le pré-chargement.
         self.assertLessEqual(
-            len(city_queries),
-            1,
-            msg=f"N+1 détecté sur `City` : {len(city_queries)} requêtes",
+            len(diffusion_zone_queries),
+            2,
+            msg=f"N+1 détecté sur `City` et `EPCI`: {len(diffusion_zone_queries)} requêtes",
         )
 
     # Modification

--- a/back/dora/services/tests/test_services.py
+++ b/back/dora/services/tests/test_services.py
@@ -12,7 +12,9 @@ from django.conf import settings
 from django.contrib.gis.geos import Point
 from django.core.cache import cache
 from django.core.exceptions import ValidationError
+from django.db import connection
 from django.test import override_settings
+from django.test.utils import CaptureQueriesContext
 from django.utils import timezone
 from freezegun import freeze_time
 from model_bakery import baker
@@ -21,7 +23,7 @@ from rest_framework.test import APIRequestFactory, APITestCase
 from dora.core.constants import WGS84
 from dora.core.test_utils import make_model, make_service, make_structure
 from dora.data_inclusion.test_utils import FakeDataInclusionClient, make_di_service_data
-from dora.decoupage_administratif.models import AdminDivisionType
+from dora.decoupage_administratif.models import AdminDivisionType, City
 from dora.services.enums import ServiceStatus
 from dora.services.migration_utils import (
     add_categories_and_subcategories_if_subcategory,
@@ -192,6 +194,41 @@ class ServiceTestCase(APITestCase):
         )
         response = self.client.get(f"/services/{service.slug}/")
         self.assertEqual(response.status_code, 404)
+
+    def test_cache_diffusion_zones(self):
+        # `ServiceViewSet.list` doit pré-charger les `City` en bloc via
+        # `warm_cache` pour éviter un N+1 sur la zone de diffusion. On crée
+        # plusieurs services dont la zone est une commune, puis on vérifie
+        # qu'une seule requête sur la table `City` est émise par la vue.
+        for _ in range(5):
+            city = baker.make("decoupage_administratif.City")
+            make_service(
+                structure=self.my_struct,
+                status=ServiceStatus.PUBLISHED,
+                diffusion_zone_type=AdminDivisionType.CITY,
+                diffusion_zone_details=city.code,
+            )
+
+        # Cache process-wide : on le vide pour repartir d'un état connu.
+        City.objects._cache.clear()
+
+        with CaptureQueriesContext(connection) as ctx:
+            response = self.client.get("/services/")
+            self.assertEqual(response.status_code, 200)
+
+        city_queries = [
+            q
+            for q in ctx.captured_queries
+            if '"decoupage_administratif_city"' in q["sql"]
+        ]
+        # Avec `warm_cache` : 1 SELECT IN. Sans `warm_cache` : 5 SELECT (un
+        # par service). Le seuil à 1 fait échouer le test dès qu'on retire
+        # le pré-chargement.
+        self.assertLessEqual(
+            len(city_queries),
+            1,
+            msg=f"N+1 détecté sur `City` : {len(city_queries)} requêtes",
+        )
 
     # Modification
 

--- a/back/dora/services/tests/test_services.py
+++ b/back/dora/services/tests/test_services.py
@@ -23,7 +23,7 @@ from rest_framework.test import APIRequestFactory, APITestCase
 from dora.core.constants import WGS84
 from dora.core.test_utils import make_model, make_service, make_structure
 from dora.data_inclusion.test_utils import FakeDataInclusionClient, make_di_service_data
-from dora.decoupage_administratif.models import AdminDivisionType, City, EPCI
+from dora.decoupage_administratif.models import EPCI, AdminDivisionType, City
 from dora.services.enums import ServiceStatus
 from dora.services.migration_utils import (
     add_categories_and_subcategories_if_subcategory,

--- a/back/dora/services/views.py
+++ b/back/dora/services/views.py
@@ -32,7 +32,7 @@ from dora.core.notify import send_moderation_notification
 from dora.core.pagination import OptionalPageNumberPagination
 from dora.core.utils import TRUTHY_VALUES
 from dora.data_inclusion.mappings import map_service
-from dora.decoupage_administratif.models import AdminDivisionType, City
+from dora.decoupage_administratif.models import EPCI, AdminDivisionType, City
 from dora.decoupage_administratif.utils import arrdt_to_main_insee_code
 from dora.services.emails import send_service_feedback_email
 from dora.services.enums import ServiceStatus
@@ -103,12 +103,29 @@ class ServicePermission(permissions.BasePermission):
         return service.can_write(user)
 
 
+def warm_diffusion_zone_caches(services):
+    # Évite le N+1 sur `City`/`EPCI` au rendu de la liste : un SELECT IN par
+    # type au lieu d'une requête par service. `Department`/`Region` utilisent
+    # déjà un cache "tout charger d'un coup" au premier appel.
+    city_codes = set()
+    epci_codes = set()
+    for s in services:
+        if not s.diffusion_zone_details:
+            continue
+        if s.diffusion_zone_type == AdminDivisionType.CITY:
+            city_codes.add(s.diffusion_zone_details)
+        elif s.diffusion_zone_type == AdminDivisionType.EPCI:
+            epci_codes.add(s.diffusion_zone_details)
+    if city_codes:
+        City.objects.warm_cache(city_codes)
+    if epci_codes:
+        EPCI.objects.warm_cache(epci_codes)
+
+
 def get_visible_services(user):
     all_services = (
         Service.objects.all()
-        .select_related(
-            "structure",
-        )
+        .select_related("structure", "model")
         .prefetch_related(
             "kinds",
             "categories",
@@ -172,6 +189,18 @@ class ServiceViewSet(
             qs = qs.filter(status=ServiceStatus.PUBLISHED)
 
         return qs.order_by("-modification_date")
+
+    def list(self, request, *args, **kwargs):
+        queryset = self.filter_queryset(self.get_queryset())
+        page = self.paginate_queryset(queryset)
+        if page is not None:
+            warm_diffusion_zone_caches(page)
+            serializer = self.get_serializer(page, many=True)
+            return self.get_paginated_response(serializer.data)
+        services = list(queryset)
+        warm_diffusion_zone_caches(services)
+        serializer = self.get_serializer(services, many=True)
+        return Response(serializer.data)
 
     def get_serializer_class(self):
         if self.action == "list":


### PR DESCRIPTION
On voit une pique de consommation du CPU de l'api et en même temps, une croissance des instances de ce [n+1 query](https://inclusion.sentry.io/issues/54974668/distributions/url/?environment=production&project=4509599009144912&query=is%3Aunresolved&referrer=issue-stream) sur la liste des services à `/services/`

Les deux soucis avec cette route sont :
1. il n'y a pas un `select_related` du champ `model`
2. chaque service déclenche un nouveau query pour chercher l'object `City` ou `EPCI` lié à la `diffusion_zone_type`

Ce PR:
1. ajoute `model` à `select_related`
2. s'appuie sur la cache des objects géographiques

Avec `page_size = 1000`
Avant :
<img width="184" height="197" alt="Screenshot 2026-06-23 at 15 34 34" src="https://github.com/user-attachments/assets/e715d047-d394-4e10-883a-b9d8b96f90d2" />

Après :
<img width="184" height="197" alt="Screenshot 2026-06-23 at 15 34 39" src="https://github.com/user-attachments/assets/1a710c44-744f-4543-914d-84e9685821f3" />
