### PR TITLE
refactor: Utiliser l’enum ModeAccueil de d·i

### DIFF
--- a/back/dora/api/serializers.py
+++ b/back/dora/api/serializers.py
@@ -306,12 +306,10 @@ class ServiceSerializer(serializers.ModelSerializer):
             for item in public.corresponding_di_publics
         ]
         unique_di_publics = list(dict.fromkeys(all_items))
-        all_publics = {
-            p.value for p in DiPublic if p.value != DiPublic.TOUS_PUBLICS.value
-        }
+        all_publics = {p.value for p in DiPublic if p != DiPublic.TOUS_PUBLICS}
         if (
             not unique_di_publics
-            or DiPublic.TOUS_PUBLICS.value in unique_di_publics
+            or DiPublic.TOUS_PUBLICS in unique_di_publics
             or set(unique_di_publics) >= all_publics
         ):
             return [DiPublic.TOUS_PUBLICS.value]

--- a/back/dora/api/test_api.py
+++ b/back/dora/api/test_api.py
@@ -333,11 +333,9 @@ def test_service_serialization_exemple(authenticated_user, api_client, settings)
         baker.make(Public, name="femmes", corresponding_di_publics=[DiPublic.FEMMES]),
     )
     service.location_kinds.add(
-        LocationKind.objects.get(value=ModeAccueil.EN_PRESENTIEL.value)
+        LocationKind.objects.get(value=ModeAccueil.EN_PRESENTIEL)
     )
-    service.location_kinds.add(
-        LocationKind.objects.get(value=ModeAccueil.A_DISTANCE.value)
-    )
+    service.location_kinds.add(LocationKind.objects.get(value=ModeAccueil.A_DISTANCE))
     service.requirements.add(
         baker.make(Requirement, name="Bonne connaissance du français oral et écrit"),
     )
@@ -435,7 +433,7 @@ def test_service_publics_export_empty_maps_to_tous_publics(
 def test_service_publics_export_all_maps_to_tous_publics(
     authenticated_user, api_client
 ):
-    all_real_publics = [p.value for p in DiPublic if p.value != "tous-publics"]
+    all_real_publics = [p.value for p in DiPublic if p != DiPublic.TOUS_PUBLICS]
     service = make_service(status=ServiceStatus.PUBLISHED)
     service.publics.clear()
     service.publics.add(
@@ -566,11 +564,9 @@ def test_service_serialization_exemple_need_di_user(api_client):
         baker.make(Public, name="femmes", corresponding_di_publics=[DiPublic.FEMMES]),
     )
     service.location_kinds.add(
-        LocationKind.objects.get(value=ModeAccueil.EN_PRESENTIEL.value)
+        LocationKind.objects.get(value=ModeAccueil.EN_PRESENTIEL)
     )
-    service.location_kinds.add(
-        LocationKind.objects.get(value=ModeAccueil.A_DISTANCE.value)
-    )
+    service.location_kinds.add(LocationKind.objects.get(value=ModeAccueil.A_DISTANCE))
     service.requirements.add(
         baker.make(Requirement, name="Bonne connaissance du français oral et écrit"),
     )

--- a/back/dora/api/test_api.py
+++ b/back/dora/api/test_api.py
@@ -1,4 +1,5 @@
 import pytest
+from data_inclusion.schema.v1 import ModeAccueil
 from data_inclusion.schema.v1.publics import Public as DiPublic
 from django.contrib.gis.geos import Point
 from django.utils import timezone
@@ -331,8 +332,12 @@ def test_service_serialization_exemple(authenticated_user, api_client, settings)
         ),
         baker.make(Public, name="femmes", corresponding_di_publics=[DiPublic.FEMMES]),
     )
-    service.location_kinds.add(LocationKind.objects.get(value="en-presentiel"))
-    service.location_kinds.add(LocationKind.objects.get(value="a-distance"))
+    service.location_kinds.add(
+        LocationKind.objects.get(value=ModeAccueil.EN_PRESENTIEL.value)
+    )
+    service.location_kinds.add(
+        LocationKind.objects.get(value=ModeAccueil.A_DISTANCE.value)
+    )
     service.requirements.add(
         baker.make(Requirement, name="Bonne connaissance du français oral et écrit"),
     )
@@ -560,8 +565,12 @@ def test_service_serialization_exemple_need_di_user(api_client):
         ),
         baker.make(Public, name="femmes", corresponding_di_publics=[DiPublic.FEMMES]),
     )
-    service.location_kinds.add(LocationKind.objects.get(value="en-presentiel"))
-    service.location_kinds.add(LocationKind.objects.get(value="a-distance"))
+    service.location_kinds.add(
+        LocationKind.objects.get(value=ModeAccueil.EN_PRESENTIEL.value)
+    )
+    service.location_kinds.add(
+        LocationKind.objects.get(value=ModeAccueil.A_DISTANCE.value)
+    )
     service.requirements.add(
         baker.make(Requirement, name="Bonne connaissance du français oral et écrit"),
     )

--- a/back/dora/data_inclusion/mappings.py
+++ b/back/dora/data_inclusion/mappings.py
@@ -1,6 +1,11 @@
 import textwrap
 
-from data_inclusion.schema.v1 import ModeMobilisation, PersonneMobilisatrice, Public
+from data_inclusion.schema.v1 import (
+    ModeAccueil,
+    ModeMobilisation,
+    PersonneMobilisatrice,
+    Public,
+)
 from django.conf import settings
 from django.utils import dateparse, timezone
 
@@ -64,7 +69,7 @@ def map_search_result(result: dict, supported_service_kinds: list[str]) -> dict:
     service_data = result["service"]
     location_kinds = service_data["modes_accueil"] or []
     if location_kinds == [] and result["distance"] is not None:
-        location_kinds = ["en-presentiel"]
+        location_kinds = [ModeAccueil.EN_PRESENTIEL.value]
 
     kinds = (
         [service_data["type"]]

--- a/back/dora/data_inclusion/mappings.py
+++ b/back/dora/data_inclusion/mappings.py
@@ -69,7 +69,7 @@ def map_search_result(result: dict, supported_service_kinds: list[str]) -> dict:
     service_data = result["service"]
     location_kinds = service_data["modes_accueil"] or []
     if location_kinds == [] and result["distance"] is not None:
-        location_kinds = [ModeAccueil.EN_PRESENTIEL.value]
+        location_kinds = [ModeAccueil.EN_PRESENTIEL]
 
     kinds = (
         [service_data["type"]]
@@ -104,7 +104,7 @@ def map_search_result(result: dict, supported_service_kinds: list[str]) -> dict:
         "name": service_data["nom"],
         "short_desc": shorten_and_clean_description(service_data["description"]),
         "slug": service_data["id"],
-        "status": ServiceStatus.PUBLISHED.value,
+        "status": ServiceStatus.PUBLISHED,
         "structure": service_data["structure_id"],
         # Champs spécifiques aux résultats d·i
         "type": "di",

--- a/back/dora/data_inclusion/test_utils.py
+++ b/back/dora/data_inclusion/test_utils.py
@@ -1,6 +1,8 @@
 from typing import Optional
 from uuid import uuid4
 
+from data_inclusion.schema.v1 import ModeAccueil
+
 
 def make_di_service_data(**kwargs) -> dict:
     source = kwargs.pop("source", "emplois-de-linclusion")
@@ -32,7 +34,7 @@ def make_di_service_data(**kwargs) -> dict:
             "latitude": 0,
             "telephone": "+33123456789",
             "courriel": "exemple@inclusion.gouv.fr",
-            "modes_accueil": ["a-distance"],
+            "modes_accueil": [ModeAccueil.A_DISTANCE],
             "zone_eligibilite": ["75056"],
             "contact_nom_prenom": "string",
             "lien_mobilisation": "https://www.actionlogement.fr/demande-cfi",

--- a/back/dora/services/management/commands/fix_missing_geom.py
+++ b/back/dora/services/management/commands/fix_missing_geom.py
@@ -8,7 +8,7 @@ from dora.services.models import Service
 class Command(BaseCommand):
     def handle(self, *args, **options):
         services_w_missing_geo = Service.objects.filter(
-            location_kinds__value=ModeAccueil.EN_PRESENTIEL.value, geom=None
+            location_kinds__value=ModeAccueil.EN_PRESENTIEL, geom=None
         ).exclude(city_code="", address1="")
         self.stdout.write(
             self.style.NOTICE(

--- a/back/dora/services/management/commands/fix_missing_geom.py
+++ b/back/dora/services/management/commands/fix_missing_geom.py
@@ -1,3 +1,5 @@
+from data_inclusion.schema.v1 import ModeAccueil
+
 from dora.core.commands import BaseCommand
 from dora.core.utils import get_geo_data
 from dora.services.models import Service
@@ -6,7 +8,7 @@ from dora.services.models import Service
 class Command(BaseCommand):
     def handle(self, *args, **options):
         services_w_missing_geo = Service.objects.filter(
-            location_kinds__value="en-presentiel", geom=None
+            location_kinds__value=ModeAccueil.EN_PRESENTIEL.value, geom=None
         ).exclude(city_code="", address1="")
         self.stdout.write(
             self.style.NOTICE(

--- a/back/dora/services/management/commands/send_saved_searches_notifications.py
+++ b/back/dora/services/management/commands/send_saved_searches_notifications.py
@@ -36,8 +36,8 @@ class Command(BaseCommand):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.on_site = LocationKind.objects.get(value=ModeAccueil.EN_PRESENTIEL.value)
-        self.remote = LocationKind.objects.get(value=ModeAccueil.A_DISTANCE.value)
+        self.on_site = LocationKind.objects.get(value=ModeAccueil.EN_PRESENTIEL)
+        self.remote = LocationKind.objects.get(value=ModeAccueil.A_DISTANCE)
 
     def handle(self, *args, **options):
         self.logger.info("Vérification des notifications de recherches sauvegardées")

--- a/back/dora/services/management/commands/send_saved_searches_notifications.py
+++ b/back/dora/services/management/commands/send_saved_searches_notifications.py
@@ -1,5 +1,6 @@
 from datetime import timedelta
 
+from data_inclusion.schema.v1 import ModeAccueil
 from django.conf import settings
 from django.template.loader import render_to_string
 from django.utils import timezone
@@ -35,8 +36,8 @@ class Command(BaseCommand):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.on_site = LocationKind.objects.get(value="en-presentiel")
-        self.remote = LocationKind.objects.get(value="a-distance")
+        self.on_site = LocationKind.objects.get(value=ModeAccueil.EN_PRESENTIEL.value)
+        self.remote = LocationKind.objects.get(value=ModeAccueil.A_DISTANCE.value)
 
     def handle(self, *args, **options):
         self.logger.info("Vérification des notifications de recherches sauvegardées")

--- a/back/dora/services/models.py
+++ b/back/dora/services/models.py
@@ -725,7 +725,7 @@ class Service(ModerationMixin, models.Model):
         if self.location_kinds.count() == 0:
             missing.append("lieu de déroulement")
 
-        if self.location_kinds.filter(value=ModeAccueil.EN_PRESENTIEL.value).exists():
+        if self.location_kinds.filter(value=ModeAccueil.EN_PRESENTIEL).exists():
             if not self.city:
                 missing.append("ville")
 

--- a/back/dora/services/models.py
+++ b/back/dora/services/models.py
@@ -2,6 +2,7 @@ import logging
 import uuid
 from datetime import datetime, timedelta
 
+from data_inclusion.schema.v1 import ModeAccueil
 from data_inclusion.schema.v1.publics import Public as DiPublic
 from dateutil.relativedelta import relativedelta
 from django.conf import settings
@@ -724,7 +725,7 @@ class Service(ModerationMixin, models.Model):
         if self.location_kinds.count() == 0:
             missing.append("lieu de déroulement")
 
-        if self.location_kinds.filter(value="en-presentiel").exists():
+        if self.location_kinds.filter(value=ModeAccueil.EN_PRESENTIEL.value).exists():
             if not self.city:
                 missing.append("ville")
 

--- a/back/dora/services/search.py
+++ b/back/dora/services/search.py
@@ -40,7 +40,7 @@ def _filter_and_annotate_dora_services(
     no_services = models.Service.objects.none()
     # 1) services ayant un lieu de déroulement, à moins de MAX_DISTANCE km
     services_on_site = (
-        services.filter(location_kinds__value=ModeAccueil.EN_PRESENTIEL.value)
+        services.filter(location_kinds__value=ModeAccueil.EN_PRESENTIEL)
         .annotate(distance=Distance("geom", location))
         .filter(distance__lte=D(km=MAX_DISTANCE))
         if with_onsite
@@ -50,8 +50,8 @@ def _filter_and_annotate_dora_services(
     services_remote = (
         (
             services.filter(
-                Q(location_kinds__value=ModeAccueil.A_DISTANCE.value)
-                | ~Q(location_kinds__value=ModeAccueil.EN_PRESENTIEL.value)
+                Q(location_kinds__value=ModeAccueil.A_DISTANCE)
+                | ~Q(location_kinds__value=ModeAccueil.EN_PRESENTIEL)
             )
             .exclude(id__in=services_on_site)
             .distinct()
@@ -69,15 +69,12 @@ def _sort_services(services):
 
     for s in services:
         if (
-            ModeAccueil.EN_PRESENTIEL.value in s["location_kinds"]
+            ModeAccueil.EN_PRESENTIEL in s["location_kinds"]
             and s["distance"] is not None
             and s["distance"] <= MAX_DISTANCE
         ):
             on_site_services.append(s)
-        elif (
-            ModeAccueil.A_DISTANCE.value in s["location_kinds"]
-            or s["location_kinds"] == []
-        ):
+        elif ModeAccueil.A_DISTANCE in s["location_kinds"] or s["location_kinds"] == []:
             remote_services.append(s)
     random.seed(date.today().isoformat())
     random.shuffle(on_site_services)
@@ -234,7 +231,7 @@ def _map_di_results(
         result
         for result in mapped_di_results
         if (
-            ModeAccueil.A_DISTANCE.value in result["location_kinds"]
+            ModeAccueil.A_DISTANCE in result["location_kinds"]
             or (
                 result.get("distance") is not None
                 and result["distance"] <= MAX_DISTANCE
@@ -245,21 +242,14 @@ def _map_di_results(
     # FIXME: gestion du paramètre `location_kinds`
     # Idéalement, il faudrait le transmettre à l’API d·i, mais tant qu’elle ne le prend pas
     # en charge, on filtre les services à posteriori
-    with_remote = not location_kinds or ModeAccueil.A_DISTANCE.value in location_kinds
-    with_onsite = (
-        not location_kinds or ModeAccueil.EN_PRESENTIEL.value in location_kinds
-    )
+    with_remote = not location_kinds or ModeAccueil.A_DISTANCE in location_kinds
+    with_onsite = not location_kinds or ModeAccueil.EN_PRESENTIEL in location_kinds
     mapped_di_results = [
         result
         for result in mapped_di_results
         if (
-            (
-                with_onsite
-                and ModeAccueil.EN_PRESENTIEL.value in result["location_kinds"]
-            )
-            or (
-                with_remote and ModeAccueil.A_DISTANCE.value in result["location_kinds"]
-            )
+            (with_onsite and ModeAccueil.EN_PRESENTIEL in result["location_kinds"])
+            or (with_remote and ModeAccueil.A_DISTANCE in result["location_kinds"])
         )
     ]
     return mapped_di_results
@@ -308,10 +298,8 @@ def _get_dora_results(
     if funding_labels:
         services = services.filter(funding_labels__value__in=funding_labels)
 
-    with_remote = not location_kinds or ModeAccueil.A_DISTANCE.value in location_kinds
-    with_onsite = (
-        not location_kinds or ModeAccueil.EN_PRESENTIEL.value in location_kinds
-    )
+    with_remote = not location_kinds or ModeAccueil.A_DISTANCE in location_kinds
+    with_onsite = not location_kinds or ModeAccueil.EN_PRESENTIEL in location_kinds
 
     categories_filter = Q()
     if categories:

--- a/back/dora/services/search.py
+++ b/back/dora/services/search.py
@@ -5,6 +5,7 @@ from functools import reduce
 from typing import Optional
 
 import requests
+from data_inclusion.schema.v1 import ModeAccueil
 from django.conf import settings
 from django.contrib.gis.db.models.functions import Distance
 from django.contrib.gis.geos import Point
@@ -39,7 +40,7 @@ def _filter_and_annotate_dora_services(
     no_services = models.Service.objects.none()
     # 1) services ayant un lieu de déroulement, à moins de MAX_DISTANCE km
     services_on_site = (
-        services.filter(location_kinds__value="en-presentiel")
+        services.filter(location_kinds__value=ModeAccueil.EN_PRESENTIEL.value)
         .annotate(distance=Distance("geom", location))
         .filter(distance__lte=D(km=MAX_DISTANCE))
         if with_onsite
@@ -49,8 +50,8 @@ def _filter_and_annotate_dora_services(
     services_remote = (
         (
             services.filter(
-                Q(location_kinds__value="a-distance")
-                | ~Q(location_kinds__value="en-presentiel")
+                Q(location_kinds__value=ModeAccueil.A_DISTANCE.value)
+                | ~Q(location_kinds__value=ModeAccueil.EN_PRESENTIEL.value)
             )
             .exclude(id__in=services_on_site)
             .distinct()
@@ -68,12 +69,15 @@ def _sort_services(services):
 
     for s in services:
         if (
-            "en-presentiel" in s["location_kinds"]
+            ModeAccueil.EN_PRESENTIEL.value in s["location_kinds"]
             and s["distance"] is not None
             and s["distance"] <= MAX_DISTANCE
         ):
             on_site_services.append(s)
-        elif "a-distance" in s["location_kinds"] or s["location_kinds"] == []:
+        elif (
+            ModeAccueil.A_DISTANCE.value in s["location_kinds"]
+            or s["location_kinds"] == []
+        ):
             remote_services.append(s)
     random.seed(date.today().isoformat())
     random.shuffle(on_site_services)
@@ -230,7 +234,7 @@ def _map_di_results(
         result
         for result in mapped_di_results
         if (
-            "a-distance" in result["location_kinds"]
+            ModeAccueil.A_DISTANCE.value in result["location_kinds"]
             or (
                 result.get("distance") is not None
                 and result["distance"] <= MAX_DISTANCE
@@ -241,14 +245,21 @@ def _map_di_results(
     # FIXME: gestion du paramètre `location_kinds`
     # Idéalement, il faudrait le transmettre à l’API d·i, mais tant qu’elle ne le prend pas
     # en charge, on filtre les services à posteriori
-    with_remote = not location_kinds or "a-distance" in location_kinds
-    with_onsite = not location_kinds or "en-presentiel" in location_kinds
+    with_remote = not location_kinds or ModeAccueil.A_DISTANCE.value in location_kinds
+    with_onsite = (
+        not location_kinds or ModeAccueil.EN_PRESENTIEL.value in location_kinds
+    )
     mapped_di_results = [
         result
         for result in mapped_di_results
         if (
-            (with_onsite and "en-presentiel" in result["location_kinds"])
-            or (with_remote and "a-distance" in result["location_kinds"])
+            (
+                with_onsite
+                and ModeAccueil.EN_PRESENTIEL.value in result["location_kinds"]
+            )
+            or (
+                with_remote and ModeAccueil.A_DISTANCE.value in result["location_kinds"]
+            )
         )
     ]
     return mapped_di_results
@@ -297,8 +308,10 @@ def _get_dora_results(
     if funding_labels:
         services = services.filter(funding_labels__value__in=funding_labels)
 
-    with_remote = not location_kinds or "a-distance" in location_kinds
-    with_onsite = not location_kinds or "en-presentiel" in location_kinds
+    with_remote = not location_kinds or ModeAccueil.A_DISTANCE.value in location_kinds
+    with_onsite = (
+        not location_kinds or ModeAccueil.EN_PRESENTIEL.value in location_kinds
+    )
 
     categories_filter = Q()
     if categories:

--- a/back/dora/services/serializers.py
+++ b/back/dora/services/serializers.py
@@ -3,6 +3,7 @@ import textwrap
 from datetime import timedelta
 
 import requests
+from data_inclusion.schema.v1 import ModeAccueil
 from django.conf import settings
 from django.core.exceptions import ValidationError as DjangoValidationError
 from django.core.files.storage import default_storage
@@ -903,11 +904,11 @@ class SearchResultSerializer(ServiceListSerializer):
         location_kind_values = [lk.value for lk in obj.location_kinds.all()]
         if (
             obj.distance is None
-            and "a-distance" in location_kind_values
-            and "en-presentiel" in location_kind_values
+            and ModeAccueil.A_DISTANCE.value in location_kind_values
+            and ModeAccueil.EN_PRESENTIEL.value in location_kind_values
         ):
             location_kind_values = [
-                v for v in location_kind_values if v != "en-presentiel"
+                v for v in location_kind_values if v != ModeAccueil.EN_PRESENTIEL.value
             ]
         return location_kind_values
 

--- a/back/dora/services/serializers.py
+++ b/back/dora/services/serializers.py
@@ -904,11 +904,11 @@ class SearchResultSerializer(ServiceListSerializer):
         location_kind_values = [lk.value for lk in obj.location_kinds.all()]
         if (
             obj.distance is None
-            and ModeAccueil.A_DISTANCE.value in location_kind_values
-            and ModeAccueil.EN_PRESENTIEL.value in location_kind_values
+            and ModeAccueil.A_DISTANCE in location_kind_values
+            and ModeAccueil.EN_PRESENTIEL in location_kind_values
         ):
             location_kind_values = [
-                v for v in location_kind_values if v != ModeAccueil.EN_PRESENTIEL.value
+                v for v in location_kind_values if v != ModeAccueil.EN_PRESENTIEL
             ]
         return location_kind_values
 

--- a/back/dora/services/tests/test_import_services.py
+++ b/back/dora/services/tests/test_import_services.py
@@ -4,6 +4,7 @@ from unittest import TestCase
 from unittest.mock import patch
 
 import pytest
+from data_inclusion.schema.v1 import ModeAccueil
 from django.contrib.gis.geos import Point
 from django.core.management import call_command
 from freezegun import freeze_time
@@ -258,7 +259,7 @@ class ImportServicesTestCase(TestCase):
         csv_content = (
             f"{self.csv_headers}\n"
             f"{self.service_model.slug},{self.structure.siret},referent@email.com,"
-            f"{self.funding_label.value},Test Person,0123456789,a-distance,,,,,,"
+            f"{self.funding_label.value},Test Person,0123456789,{ModeAccueil.A_DISTANCE.value},,,,,,"
         )
 
         reader = csv.reader(io.StringIO(csv_content))
@@ -314,7 +315,7 @@ class ImportServicesTestCase(TestCase):
     def test_location_kinds(self):
         csv_content = (
             f"{self.csv_headers}\n"
-            f'{self.service_model.slug},{self.structure.siret},referent@email.com,{self.funding_label.value},,,"a-distance,en-presentiel",,,,,'
+            f'{self.service_model.slug},{self.structure.siret},referent@email.com,{self.funding_label.value},,,"{ModeAccueil.A_DISTANCE.value},{ModeAccueil.EN_PRESENTIEL.value}",,,,,'
         )
 
         reader = csv.reader(io.StringIO(csv_content))
@@ -618,7 +619,7 @@ class ImportServicesTestCase(TestCase):
         csv_content = (
             f"{self.csv_headers}\n"
             f"{self.service_model.slug},{self.structure.siret},referent@email.com,"
-            f"{self.funding_label.value},Test Person,0123456789,a-distance,,,,,city,"
+            f"{self.funding_label.value},Test Person,0123456789,{ModeAccueil.A_DISTANCE.value},,,,,city,"
         )
 
         reader = csv.reader(io.StringIO(csv_content))
@@ -646,7 +647,7 @@ class ImportServicesTestCase(TestCase):
         csv_content = (
             f"{self.csv_headers}\n"
             f"{self.service_model.slug},{self.structure.siret},referent@email.com,"
-            f"{self.funding_label.value},Test Person,0123456789,en-presentiel,Paris,1 rue de test,,75020,city,"
+            f"{self.funding_label.value},Test Person,0123456789,{ModeAccueil.EN_PRESENTIEL.value},Paris,1 rue de test,,75020,city,"
         )
 
         reader = csv.reader(io.StringIO(csv_content))
@@ -668,7 +669,7 @@ class ImportServicesTestCase(TestCase):
         csv_content = (
             f"{self.csv_headers}\n"
             f"{self.service_model.slug},{self.structure.siret},referent@email.com,"
-            f"{self.funding_label.value},Test Person,0123456789,en-presentiel,Paris,1 rue de test,,,,"
+            f"{self.funding_label.value},Test Person,0123456789,{ModeAccueil.EN_PRESENTIEL.value},Paris,1 rue de test,,,,"
         )
 
         reader = csv.reader(io.StringIO(csv_content))
@@ -688,7 +689,7 @@ class ImportServicesTestCase(TestCase):
         csv_content = (
             f"{self.csv_headers}\n"
             f"{self.service_model.slug},{self.structure.siret},referent@email.com,"
-            f"{self.funding_label.value},Test Person,,a-distance,,,,,,"
+            f"{self.funding_label.value},Test Person,,{ModeAccueil.A_DISTANCE.value},,,,,,"
         )
 
         reader = csv.reader(io.StringIO(csv_content))
@@ -708,7 +709,7 @@ class ImportServicesTestCase(TestCase):
         csv_content = (
             f"{self.csv_headers}\n"
             f"{self.service_model.slug},{self.structure.siret},referent@email.com,"
-            f"{self.funding_label.value},Test Person,,a-distance,,,,,,oui"
+            f"{self.funding_label.value},Test Person,,{ModeAccueil.A_DISTANCE.value},,,,,,oui"
         )
 
         reader = csv.reader(io.StringIO(csv_content))
@@ -735,7 +736,7 @@ class ImportServicesTestCase(TestCase):
         csv_content = (
             f"{self.csv_headers}\n"
             f"{self.service_model.slug},{self.structure.siret},referent@email.com,"
-            f"{self.funding_label.value},Test Person,,a-distance,,,,,,"
+            f"{self.funding_label.value},Test Person,,{ModeAccueil.A_DISTANCE.value},,,,,,"
         )
 
         reader = csv.reader(io.StringIO(csv_content))
@@ -790,7 +791,7 @@ class ImportServicesTestCase(TestCase):
         csv_content = (
             f"{self.csv_headers}\n"
             f"{self.service_model.slug},{self.structure.siret},referent@email.com,"
-            f"{self.funding_label.value},Test Person,,a-distance,,,,,,"
+            f"{self.funding_label.value},Test Person,,{ModeAccueil.A_DISTANCE.value},,,,,,"
         )
 
         reader = csv.reader(io.StringIO(csv_content))
@@ -819,7 +820,7 @@ class ImportServicesTestCase(TestCase):
         csv_content = (
             f"{self.csv_headers}\n"
             f"{self.service_model.slug},{self.structure.siret},referent@email.com,"
-            f"{self.funding_label.value},Test Person,,a-distance,,,,,,"
+            f"{self.funding_label.value},Test Person,,{ModeAccueil.A_DISTANCE.value},,,,,,"
         )
 
         reader = csv.reader(io.StringIO(csv_content))
@@ -842,7 +843,7 @@ class ImportServicesTestCase(TestCase):
         csv_content = (
             f"{missing_headers}\n"
             f"{self.service_model.slug},{self.structure.siret},referent@email.com,"
-            f"{self.funding_label.value},Test Person,,a-distance,,,,,,"
+            f"{self.funding_label.value},Test Person,,{ModeAccueil.A_DISTANCE.value},,,,,,"
         )
 
         reader = csv.reader(io.StringIO(csv_content))

--- a/back/dora/services/tests/test_import_services.py
+++ b/back/dora/services/tests/test_import_services.py
@@ -259,7 +259,7 @@ class ImportServicesTestCase(TestCase):
         csv_content = (
             f"{self.csv_headers}\n"
             f"{self.service_model.slug},{self.structure.siret},referent@email.com,"
-            f"{self.funding_label.value},Test Person,0123456789,{ModeAccueil.A_DISTANCE.value},,,,,,"
+            f"{self.funding_label.value},Test Person,0123456789,{ModeAccueil.A_DISTANCE},,,,,,"
         )
 
         reader = csv.reader(io.StringIO(csv_content))
@@ -315,7 +315,7 @@ class ImportServicesTestCase(TestCase):
     def test_location_kinds(self):
         csv_content = (
             f"{self.csv_headers}\n"
-            f'{self.service_model.slug},{self.structure.siret},referent@email.com,{self.funding_label.value},,,"{ModeAccueil.A_DISTANCE.value},{ModeAccueil.EN_PRESENTIEL.value}",,,,,'
+            f'{self.service_model.slug},{self.structure.siret},referent@email.com,{self.funding_label.value},,,"{ModeAccueil.A_DISTANCE},{ModeAccueil.EN_PRESENTIEL}",,,,,'
         )
 
         reader = csv.reader(io.StringIO(csv_content))
@@ -619,7 +619,7 @@ class ImportServicesTestCase(TestCase):
         csv_content = (
             f"{self.csv_headers}\n"
             f"{self.service_model.slug},{self.structure.siret},referent@email.com,"
-            f"{self.funding_label.value},Test Person,0123456789,{ModeAccueil.A_DISTANCE.value},,,,,city,"
+            f"{self.funding_label.value},Test Person,0123456789,{ModeAccueil.A_DISTANCE},,,,,city,"
         )
 
         reader = csv.reader(io.StringIO(csv_content))
@@ -647,7 +647,7 @@ class ImportServicesTestCase(TestCase):
         csv_content = (
             f"{self.csv_headers}\n"
             f"{self.service_model.slug},{self.structure.siret},referent@email.com,"
-            f"{self.funding_label.value},Test Person,0123456789,{ModeAccueil.EN_PRESENTIEL.value},Paris,1 rue de test,,75020,city,"
+            f"{self.funding_label.value},Test Person,0123456789,{ModeAccueil.EN_PRESENTIEL},Paris,1 rue de test,,75020,city,"
         )
 
         reader = csv.reader(io.StringIO(csv_content))
@@ -669,7 +669,7 @@ class ImportServicesTestCase(TestCase):
         csv_content = (
             f"{self.csv_headers}\n"
             f"{self.service_model.slug},{self.structure.siret},referent@email.com,"
-            f"{self.funding_label.value},Test Person,0123456789,{ModeAccueil.EN_PRESENTIEL.value},Paris,1 rue de test,,,,"
+            f"{self.funding_label.value},Test Person,0123456789,{ModeAccueil.EN_PRESENTIEL},Paris,1 rue de test,,,,"
         )
 
         reader = csv.reader(io.StringIO(csv_content))
@@ -689,7 +689,7 @@ class ImportServicesTestCase(TestCase):
         csv_content = (
             f"{self.csv_headers}\n"
             f"{self.service_model.slug},{self.structure.siret},referent@email.com,"
-            f"{self.funding_label.value},Test Person,,{ModeAccueil.A_DISTANCE.value},,,,,,"
+            f"{self.funding_label.value},Test Person,,{ModeAccueil.A_DISTANCE},,,,,,"
         )
 
         reader = csv.reader(io.StringIO(csv_content))
@@ -709,7 +709,7 @@ class ImportServicesTestCase(TestCase):
         csv_content = (
             f"{self.csv_headers}\n"
             f"{self.service_model.slug},{self.structure.siret},referent@email.com,"
-            f"{self.funding_label.value},Test Person,,{ModeAccueil.A_DISTANCE.value},,,,,,oui"
+            f"{self.funding_label.value},Test Person,,{ModeAccueil.A_DISTANCE},,,,,,oui"
         )
 
         reader = csv.reader(io.StringIO(csv_content))
@@ -736,7 +736,7 @@ class ImportServicesTestCase(TestCase):
         csv_content = (
             f"{self.csv_headers}\n"
             f"{self.service_model.slug},{self.structure.siret},referent@email.com,"
-            f"{self.funding_label.value},Test Person,,{ModeAccueil.A_DISTANCE.value},,,,,,"
+            f"{self.funding_label.value},Test Person,,{ModeAccueil.A_DISTANCE},,,,,,"
         )
 
         reader = csv.reader(io.StringIO(csv_content))
@@ -791,7 +791,7 @@ class ImportServicesTestCase(TestCase):
         csv_content = (
             f"{self.csv_headers}\n"
             f"{self.service_model.slug},{self.structure.siret},referent@email.com,"
-            f"{self.funding_label.value},Test Person,,{ModeAccueil.A_DISTANCE.value},,,,,,"
+            f"{self.funding_label.value},Test Person,,{ModeAccueil.A_DISTANCE},,,,,,"
         )
 
         reader = csv.reader(io.StringIO(csv_content))
@@ -820,7 +820,7 @@ class ImportServicesTestCase(TestCase):
         csv_content = (
             f"{self.csv_headers}\n"
             f"{self.service_model.slug},{self.structure.siret},referent@email.com,"
-            f"{self.funding_label.value},Test Person,,{ModeAccueil.A_DISTANCE.value},,,,,,"
+            f"{self.funding_label.value},Test Person,,{ModeAccueil.A_DISTANCE},,,,,,"
         )
 
         reader = csv.reader(io.StringIO(csv_content))
@@ -843,7 +843,7 @@ class ImportServicesTestCase(TestCase):
         csv_content = (
             f"{missing_headers}\n"
             f"{self.service_model.slug},{self.structure.siret},referent@email.com,"
-            f"{self.funding_label.value},Test Person,,{ModeAccueil.A_DISTANCE.value},,,,,,"
+            f"{self.funding_label.value},Test Person,,{ModeAccueil.A_DISTANCE},,,,,,"
         )
 
         reader = csv.reader(io.StringIO(csv_content))

--- a/back/dora/services/tests/test_services.py
+++ b/back/dora/services/tests/test_services.py
@@ -1568,7 +1568,7 @@ class DataInclusionSearchTestCase(APITestCase):
             (None, None, None),
             ([], [], []),
             (["valeur-inconnue"], [], []),
-            ([Public.JEUNES.value], [Public.JEUNES.value], [Public.JEUNES.label]),
+            ([Public.JEUNES], [Public.JEUNES], [Public.JEUNES.label]),
         ]
         for publics_input, publics, publics_display in cases:
             with self.subTest(publics=publics_input):
@@ -1708,8 +1708,8 @@ class DataInclusionSearchTestCase(APITestCase):
             (None, None, None),
             ([], [], []),
             (
-                [ModeAccueil.EN_PRESENTIEL.value],
-                [ModeAccueil.EN_PRESENTIEL.value],
+                [ModeAccueil.EN_PRESENTIEL],
+                [ModeAccueil.EN_PRESENTIEL],
                 [ModeAccueil.EN_PRESENTIEL.label],
             ),
         ]
@@ -1745,8 +1745,8 @@ class DataInclusionSearchTestCase(APITestCase):
             (None, None, None),
             ("", None, None),
             (
-                TypeService.ACCOMPAGNEMENT.value,
-                [TypeService.ACCOMPAGNEMENT.value],
+                TypeService.ACCOMPAGNEMENT,
+                [TypeService.ACCOMPAGNEMENT],
                 [TypeService.ACCOMPAGNEMENT.label],
             ),
         ]
@@ -2570,7 +2570,7 @@ class ServiceSearchOrderingTestCase(APITestCase):
             geom=self.point_in_toulouse,
         )
         service1.location_kinds.set(
-            [LocationKind.objects.get(value=ModeAccueil.EN_PRESENTIEL.value)]
+            [LocationKind.objects.get(value=ModeAccueil.EN_PRESENTIEL)]
         )
         service2 = make_service(
             slug="s2",
@@ -2580,7 +2580,7 @@ class ServiceSearchOrderingTestCase(APITestCase):
             geom=self.point_in_toulouse,
         )
         service2.location_kinds.set(
-            [LocationKind.objects.get(value=ModeAccueil.A_DISTANCE.value)]
+            [LocationKind.objects.get(value=ModeAccueil.A_DISTANCE)]
         )
 
         service3 = make_service(
@@ -2591,7 +2591,7 @@ class ServiceSearchOrderingTestCase(APITestCase):
             geom=self.point_in_toulouse,
         )
         service3.location_kinds.set(
-            [LocationKind.objects.get(value=ModeAccueil.EN_PRESENTIEL.value)]
+            [LocationKind.objects.get(value=ModeAccueil.EN_PRESENTIEL)]
         )
 
         response = self.client.get("/search/?city=31555")
@@ -2609,7 +2609,7 @@ class ServiceSearchOrderingTestCase(APITestCase):
             geom=self.point_in_toulouse,
         )
         service1.location_kinds.set(
-            [LocationKind.objects.get(value=ModeAccueil.EN_PRESENTIEL.value)]
+            [LocationKind.objects.get(value=ModeAccueil.EN_PRESENTIEL)]
         )
 
         service2 = make_service(
@@ -2620,7 +2620,7 @@ class ServiceSearchOrderingTestCase(APITestCase):
             geom=self.blagnac_center,
         )
         service2.location_kinds.set(
-            [LocationKind.objects.get(value=ModeAccueil.EN_PRESENTIEL.value)]
+            [LocationKind.objects.get(value=ModeAccueil.EN_PRESENTIEL)]
         )
 
         service3 = make_service(
@@ -2631,7 +2631,7 @@ class ServiceSearchOrderingTestCase(APITestCase):
             geom=self.toulouse_center,
         )
         service3.location_kinds.set(
-            [LocationKind.objects.get(value=ModeAccueil.EN_PRESENTIEL.value)]
+            [LocationKind.objects.get(value=ModeAccueil.EN_PRESENTIEL)]
         )
 
         response = self.client.get("/search/?city=31555")
@@ -2649,7 +2649,7 @@ class ServiceSearchOrderingTestCase(APITestCase):
             geom=self.point_in_toulouse,
         )
         service1.location_kinds.set(
-            [LocationKind.objects.get(value=ModeAccueil.EN_PRESENTIEL.value)]
+            [LocationKind.objects.get(value=ModeAccueil.EN_PRESENTIEL)]
         )
 
         service2 = make_service(
@@ -2659,7 +2659,7 @@ class ServiceSearchOrderingTestCase(APITestCase):
             geom=self.montauban_center,
         )
         service2.location_kinds.set(
-            [LocationKind.objects.get(value=ModeAccueil.EN_PRESENTIEL.value)]
+            [LocationKind.objects.get(value=ModeAccueil.EN_PRESENTIEL)]
         )
 
         response = self.client.get("/search/?city=31555")
@@ -2674,7 +2674,7 @@ class ServiceSearchOrderingTestCase(APITestCase):
             geom=self.point_in_toulouse,
         )
         service1.location_kinds.set(
-            [LocationKind.objects.get(value=ModeAccueil.EN_PRESENTIEL.value)]
+            [LocationKind.objects.get(value=ModeAccueil.EN_PRESENTIEL)]
         )
 
         service2 = make_service(
@@ -2684,7 +2684,7 @@ class ServiceSearchOrderingTestCase(APITestCase):
             geom=self.rocamadour_center,
         )
         service2.location_kinds.set(
-            [LocationKind.objects.get(value=ModeAccueil.EN_PRESENTIEL.value)]
+            [LocationKind.objects.get(value=ModeAccueil.EN_PRESENTIEL)]
         )
 
         response = self.client.get("/search/?city=31555")
@@ -2701,8 +2701,8 @@ class ServiceSearchOrderingTestCase(APITestCase):
         )
         service.location_kinds.set(
             [
-                LocationKind.objects.get(value=ModeAccueil.EN_PRESENTIEL.value),
-                LocationKind.objects.get(value=ModeAccueil.A_DISTANCE.value),
+                LocationKind.objects.get(value=ModeAccueil.EN_PRESENTIEL),
+                LocationKind.objects.get(value=ModeAccueil.A_DISTANCE),
             ]
         )
 
@@ -2720,8 +2720,8 @@ class ServiceSearchOrderingTestCase(APITestCase):
         )
         service.location_kinds.set(
             [
-                LocationKind.objects.get(value=ModeAccueil.EN_PRESENTIEL.value),
-                LocationKind.objects.get(value=ModeAccueil.A_DISTANCE.value),
+                LocationKind.objects.get(value=ModeAccueil.EN_PRESENTIEL),
+                LocationKind.objects.get(value=ModeAccueil.A_DISTANCE),
             ]
         )
 
@@ -2741,37 +2741,37 @@ class ServiceSearchOrderingTestCase(APITestCase):
             slug="s1", **template, modification_date=timezone.now() - timedelta(days=1)
         )
         service1.location_kinds.set(
-            [LocationKind.objects.get(value=ModeAccueil.EN_PRESENTIEL.value)]
+            [LocationKind.objects.get(value=ModeAccueil.EN_PRESENTIEL)]
         )
         service2 = make_service(
             slug="s2", **template, modification_date=timezone.now() - timedelta(days=2)
         )
         service2.location_kinds.set(
-            [LocationKind.objects.get(value=ModeAccueil.EN_PRESENTIEL.value)]
+            [LocationKind.objects.get(value=ModeAccueil.EN_PRESENTIEL)]
         )
         service3 = make_service(
             slug="s3", **template, modification_date=timezone.now() - timedelta(days=3)
         )
         service3.location_kinds.set(
-            [LocationKind.objects.get(value=ModeAccueil.EN_PRESENTIEL.value)]
+            [LocationKind.objects.get(value=ModeAccueil.EN_PRESENTIEL)]
         )
         service4 = make_service(
             slug="s4", **template, modification_date=timezone.now() - timedelta(days=4)
         )
         service4.location_kinds.set(
-            [LocationKind.objects.get(value=ModeAccueil.EN_PRESENTIEL.value)]
+            [LocationKind.objects.get(value=ModeAccueil.EN_PRESENTIEL)]
         )
         service5 = make_service(
             slug="s5", **template, modification_date=timezone.now() - timedelta(days=5)
         )
         service5.location_kinds.set(
-            [LocationKind.objects.get(value=ModeAccueil.A_DISTANCE.value)]
+            [LocationKind.objects.get(value=ModeAccueil.A_DISTANCE)]
         )
         service6 = make_service(
             slug="s6", **template, modification_date=timezone.now() - timedelta(days=6)
         )
         service6.location_kinds.set(
-            [LocationKind.objects.get(value=ModeAccueil.A_DISTANCE.value)]
+            [LocationKind.objects.get(value=ModeAccueil.A_DISTANCE)]
         )
 
         response = self.client.get("/search/?city=31555")

--- a/back/dora/services/tests/test_services.py
+++ b/back/dora/services/tests/test_services.py
@@ -3,6 +3,7 @@ from unittest import mock
 
 import requests
 from data_inclusion.schema.v1 import (
+    ModeAccueil,
     ModeMobilisation,
     PersonneMobilisatrice,
     Public,
@@ -1706,7 +1707,11 @@ class DataInclusionSearchTestCase(APITestCase):
         cases = [
             (None, None, None),
             ([], [], []),
-            (["en-presentiel"], ["en-presentiel"], ["En présentiel"]),
+            (
+                [ModeAccueil.EN_PRESENTIEL.value],
+                [ModeAccueil.EN_PRESENTIEL.value],
+                [ModeAccueil.EN_PRESENTIEL.label],
+            ),
         ]
         for modes_accueil, location_kinds, location_kinds_display in cases:
             with self.subTest(modes_accueil=modes_accueil):
@@ -2564,7 +2569,9 @@ class ServiceSearchOrderingTestCase(APITestCase):
             diffusion_zone_details="31555",
             geom=self.point_in_toulouse,
         )
-        service1.location_kinds.set([LocationKind.objects.get(value="en-presentiel")])
+        service1.location_kinds.set(
+            [LocationKind.objects.get(value=ModeAccueil.EN_PRESENTIEL.value)]
+        )
         service2 = make_service(
             slug="s2",
             status=ServiceStatus.PUBLISHED,
@@ -2572,7 +2579,9 @@ class ServiceSearchOrderingTestCase(APITestCase):
             diffusion_zone_details="31555",
             geom=self.point_in_toulouse,
         )
-        service2.location_kinds.set([LocationKind.objects.get(value="a-distance")])
+        service2.location_kinds.set(
+            [LocationKind.objects.get(value=ModeAccueil.A_DISTANCE.value)]
+        )
 
         service3 = make_service(
             slug="s3",
@@ -2581,7 +2590,9 @@ class ServiceSearchOrderingTestCase(APITestCase):
             diffusion_zone_details="31555",
             geom=self.point_in_toulouse,
         )
-        service3.location_kinds.set([LocationKind.objects.get(value="en-presentiel")])
+        service3.location_kinds.set(
+            [LocationKind.objects.get(value=ModeAccueil.EN_PRESENTIEL.value)]
+        )
 
         response = self.client.get("/search/?city=31555")
         assert response.data["services"][0]["slug"] in [service1.slug, service3.slug]
@@ -2597,7 +2608,9 @@ class ServiceSearchOrderingTestCase(APITestCase):
             diffusion_zone_details="31",
             geom=self.point_in_toulouse,
         )
-        service1.location_kinds.set([LocationKind.objects.get(value="en-presentiel")])
+        service1.location_kinds.set(
+            [LocationKind.objects.get(value=ModeAccueil.EN_PRESENTIEL.value)]
+        )
 
         service2 = make_service(
             slug="s2",
@@ -2606,7 +2619,9 @@ class ServiceSearchOrderingTestCase(APITestCase):
             diffusion_zone_details="31",
             geom=self.blagnac_center,
         )
-        service2.location_kinds.set([LocationKind.objects.get(value="en-presentiel")])
+        service2.location_kinds.set(
+            [LocationKind.objects.get(value=ModeAccueil.EN_PRESENTIEL.value)]
+        )
 
         service3 = make_service(
             slug="s3",
@@ -2615,7 +2630,9 @@ class ServiceSearchOrderingTestCase(APITestCase):
             diffusion_zone_details="31",
             geom=self.toulouse_center,
         )
-        service3.location_kinds.set([LocationKind.objects.get(value="en-presentiel")])
+        service3.location_kinds.set(
+            [LocationKind.objects.get(value=ModeAccueil.EN_PRESENTIEL.value)]
+        )
 
         response = self.client.get("/search/?city=31555")
 
@@ -2631,7 +2648,9 @@ class ServiceSearchOrderingTestCase(APITestCase):
             diffusion_zone_type=AdminDivisionType.COUNTRY,
             geom=self.point_in_toulouse,
         )
-        service1.location_kinds.set([LocationKind.objects.get(value="en-presentiel")])
+        service1.location_kinds.set(
+            [LocationKind.objects.get(value=ModeAccueil.EN_PRESENTIEL.value)]
+        )
 
         service2 = make_service(
             slug="s2",
@@ -2639,7 +2658,9 @@ class ServiceSearchOrderingTestCase(APITestCase):
             diffusion_zone_type=AdminDivisionType.COUNTRY,
             geom=self.montauban_center,
         )
-        service2.location_kinds.set([LocationKind.objects.get(value="en-presentiel")])
+        service2.location_kinds.set(
+            [LocationKind.objects.get(value=ModeAccueil.EN_PRESENTIEL.value)]
+        )
 
         response = self.client.get("/search/?city=31555")
         self.assertTrue(40 < response.data["services"][1]["distance"] < 50)
@@ -2652,7 +2673,9 @@ class ServiceSearchOrderingTestCase(APITestCase):
             diffusion_zone_type=AdminDivisionType.COUNTRY,
             geom=self.point_in_toulouse,
         )
-        service1.location_kinds.set([LocationKind.objects.get(value="en-presentiel")])
+        service1.location_kinds.set(
+            [LocationKind.objects.get(value=ModeAccueil.EN_PRESENTIEL.value)]
+        )
 
         service2 = make_service(
             slug="s2",
@@ -2660,7 +2683,9 @@ class ServiceSearchOrderingTestCase(APITestCase):
             diffusion_zone_type=AdminDivisionType.COUNTRY,
             geom=self.rocamadour_center,
         )
-        service2.location_kinds.set([LocationKind.objects.get(value="en-presentiel")])
+        service2.location_kinds.set(
+            [LocationKind.objects.get(value=ModeAccueil.EN_PRESENTIEL.value)]
+        )
 
         response = self.client.get("/search/?city=31555")
         assert len(response.data) == 4
@@ -2676,8 +2701,8 @@ class ServiceSearchOrderingTestCase(APITestCase):
         )
         service.location_kinds.set(
             [
-                LocationKind.objects.get(value="en-presentiel"),
-                LocationKind.objects.get(value="a-distance"),
+                LocationKind.objects.get(value=ModeAccueil.EN_PRESENTIEL.value),
+                LocationKind.objects.get(value=ModeAccueil.A_DISTANCE.value),
             ]
         )
 
@@ -2695,8 +2720,8 @@ class ServiceSearchOrderingTestCase(APITestCase):
         )
         service.location_kinds.set(
             [
-                LocationKind.objects.get(value="en-presentiel"),
-                LocationKind.objects.get(value="a-distance"),
+                LocationKind.objects.get(value=ModeAccueil.EN_PRESENTIEL.value),
+                LocationKind.objects.get(value=ModeAccueil.A_DISTANCE.value),
             ]
         )
 
@@ -2715,27 +2740,39 @@ class ServiceSearchOrderingTestCase(APITestCase):
         service1 = make_service(
             slug="s1", **template, modification_date=timezone.now() - timedelta(days=1)
         )
-        service1.location_kinds.set([LocationKind.objects.get(value="en-presentiel")])
+        service1.location_kinds.set(
+            [LocationKind.objects.get(value=ModeAccueil.EN_PRESENTIEL.value)]
+        )
         service2 = make_service(
             slug="s2", **template, modification_date=timezone.now() - timedelta(days=2)
         )
-        service2.location_kinds.set([LocationKind.objects.get(value="en-presentiel")])
+        service2.location_kinds.set(
+            [LocationKind.objects.get(value=ModeAccueil.EN_PRESENTIEL.value)]
+        )
         service3 = make_service(
             slug="s3", **template, modification_date=timezone.now() - timedelta(days=3)
         )
-        service3.location_kinds.set([LocationKind.objects.get(value="en-presentiel")])
+        service3.location_kinds.set(
+            [LocationKind.objects.get(value=ModeAccueil.EN_PRESENTIEL.value)]
+        )
         service4 = make_service(
             slug="s4", **template, modification_date=timezone.now() - timedelta(days=4)
         )
-        service4.location_kinds.set([LocationKind.objects.get(value="en-presentiel")])
+        service4.location_kinds.set(
+            [LocationKind.objects.get(value=ModeAccueil.EN_PRESENTIEL.value)]
+        )
         service5 = make_service(
             slug="s5", **template, modification_date=timezone.now() - timedelta(days=5)
         )
-        service5.location_kinds.set([LocationKind.objects.get(value="a-distance")])
+        service5.location_kinds.set(
+            [LocationKind.objects.get(value=ModeAccueil.A_DISTANCE.value)]
+        )
         service6 = make_service(
             slug="s6", **template, modification_date=timezone.now() - timedelta(days=6)
         )
-        service6.location_kinds.set([LocationKind.objects.get(value="a-distance")])
+        service6.location_kinds.set(
+            [LocationKind.objects.get(value=ModeAccueil.A_DISTANCE.value)]
+        )
 
         response = self.client.get("/search/?city=31555")
         # on s'attend à ce que les services soient classés par date de modification décroissante

--- a/back/dora/services/views.py
+++ b/back/dora/services/views.py
@@ -764,7 +764,7 @@ def options(request):
         "di_publics": [
             {"value": p.value, "label": p.label}
             for p in DiPublic
-            if p.value != DiPublic.TOUS_PUBLICS.value
+            if p.value != DiPublic.TOUS_PUBLICS
         ],
         "requirements": RequirementSerializer(
             filter_custom_choices(


### PR DESCRIPTION
Ne pas écrire les valeurs en dur (avec le risque de typo), énumérer les choix possibles et sera bientôt utilisé pour valider les paramètres de la recherche par mots-clés.