### PR TITLE
feat: publier l'information de contact de services à data⋅inclusion

### DIFF
--- a/back/dora/api/serializers.py
+++ b/back/dora/api/serializers.py
@@ -381,19 +381,13 @@ class ServiceSerializer(serializers.ModelSerializer):
         return obj.get_frontend_url()
 
     def get_telephone(self, obj):
-        if obj.is_contact_info_public:
-            return obj.contact_phone
-        return None
+        return obj.contact_phone
 
     def get_courriel(self, obj):
-        if obj.is_contact_info_public:
-            return obj.contact_email
-        return None
+        return obj.contact_email
 
     def get_contact_nom_prenom(self, obj):
-        if obj.is_contact_info_public:
-            return obj.contact_name
-        return None
+        return obj.contact_name
 
     def get_contact_public(self, obj):
         return obj.is_contact_info_public

--- a/back/dora/api/test_api.py
+++ b/back/dora/api/test_api.py
@@ -622,7 +622,7 @@ def test_service_without_suspension_date_is_included(authenticated_user, api_cli
     assert 200 == response.status_code
 
 
-def test_service_does_not_include_contact_info_when_contact_info_is_not_public(
+def test_service_includes_contact_info_even_when_not_public(
     authenticated_user, api_client
 ):
     service = make_service(
@@ -636,6 +636,7 @@ def test_service_does_not_include_contact_info_when_contact_info_is_not_public(
 
     assert response.status_code == 200
 
-    assert response.data["courriel"] is None
-    assert response.data["telephone"] is None
-    assert response.data["contact_nom_prenom"] is None
+    assert response.data["courriel"] == "private@email.com"
+    assert response.data["telephone"] == "0123456789"
+    assert response.data["contact_nom_prenom"] == "Test Person"
+    assert response.data["contact_public"] is False


### PR DESCRIPTION
https://app.notion.com/p/gip-inclusion/Exposer-d-i-les-infos-de-contact-d-un-service-37a5f321b60480818fc0dd0048e7a011?v=28e5f321b604809f9e2e000cb57fc84b&source=copy_link