### PR TITLE
fix: Suppression du message de non-cumulabilité des services DI

### DIFF
--- a/back/dora/data_inclusion/mappings.py
+++ b/back/dora/data_inclusion/mappings.py
@@ -317,7 +317,7 @@ def map_service(service_data: dict, is_authenticated: bool) -> dict:
         "has_already_been_unpublished": None,
         "is_available": True,
         "is_contact_info_public": True,
-        "is_cumulative": None,
+        "is_cumulative": True,
         "is_orientable": is_orientable(service_data),
         "is_model": False,
         "kinds": [kind.value] if kind is not None else None,

--- a/front/src/lib/types.ts
+++ b/front/src/lib/types.ts
@@ -500,6 +500,7 @@ export interface ShortService {
   diffusionZoneDetailsDisplay: string;
   diffusionZoneType: AdminDivisionType;
   diffusionZoneTypeDisplay: string;
+  isCumulative: boolean;
   model: string;
   modelChanged: boolean;
   modificationDate: string;

--- a/front/src/lib/types.ts
+++ b/front/src/lib/types.ts
@@ -425,7 +425,7 @@ export interface Service {
   coachOrientationModesExternalFormLinkText: string;
   coachOrientationModesExternalFormLink: string | null;
   coachOrientationModesOther: string | null;
-  publics: CustomizableFK[] | null; // TODO: should be plural
+  publics: CustomizableFK[] | null;
   publicsDisplay: string[] | null;
   contactInfoFilled: boolean;
   contactEmail: string | null;
@@ -577,7 +577,7 @@ export type ServicesOptions = {
   diPublics: { value: string; label: string }[];
   credentials: CustomChoice[];
   deploymentDepartments: string[];
-  diffusionZoneType: { value: AdminDivisionType; label: string }; // TODO: should be plural
+  diffusionZoneType: { value: AdminDivisionType; label: string };
   feeConditions: { value: FeeCondition; label: string }[];
   kinds: { value: ServiceKind; label: string }[];
   locationKinds: { value: LocationKind; label: string }[];


### PR DESCRIPTION
- On assigne `True` qu lieu de `None` lors du mapping des données d'un service DI ;
- J'en profite pour ajouter le champ `isCumulative` qui manquait au type `ShortService` et pour supprimer des `TODO`.