### PR TITLE
fix(structures): Permettre la réactivation d'une structure obsolète

### DIFF
--- a/back/dora/structures/tests/test_structures.py
+++ b/back/dora/structures/tests/test_structures.py
@@ -73,7 +73,33 @@ class StructureTestCase(APITestCase):
         response = self.client.get(f"/structures/{obsolete_struct.slug}/")
         self.assertEqual(response.status_code, 404)
 
+    def test_obsolete_struct_not_in_listing(self):
+        obsolete_struct = make_structure(is_obsolete=True)
+        make_structure_member(user=self.me, structure=obsolete_struct, is_admin=True)
+        response = self.client.get("/structures/")
+        structures_ids = [s["slug"] for s in response.data]
+        self.assertNotIn(obsolete_struct.slug, structures_ids)
+
     # Modification
+
+    def test_can_reactivate_obsolete_struct(self):
+        obsolete_struct = make_structure(is_obsolete=True)
+        make_structure_member(user=self.me, structure=obsolete_struct, is_admin=True)
+        response = self.client.patch(
+            f"/structures/{obsolete_struct.slug}/", {"is_obsolete": False}
+        )
+        self.assertEqual(response.status_code, 200)
+        obsolete_struct.refresh_from_db()
+        self.assertFalse(obsolete_struct.is_obsolete)
+
+    def test_cant_reactivate_obsolete_struct_without_permission(self):
+        obsolete_struct = make_structure(is_obsolete=True)
+        response = self.client.patch(
+            f"/structures/{obsolete_struct.slug}/", {"is_obsolete": False}
+        )
+        self.assertEqual(response.status_code, 403)
+        obsolete_struct.refresh_from_db()
+        self.assertTrue(obsolete_struct.is_obsolete)
 
     def test_can_edit_my_administered_structures(self):
         response = self.client.patch(

--- a/back/dora/structures/tests/test_structures.py
+++ b/back/dora/structures/tests/test_structures.py
@@ -92,7 +92,7 @@ class StructureTestCase(APITestCase):
         obsolete_struct.refresh_from_db()
         self.assertFalse(obsolete_struct.is_obsolete)
 
-    def test_cant_reactivate_obsolete_struct_without_permission(self):
+    def test_cannot_reactivate_obsolete_struct_without_permission(self):
         obsolete_struct = make_structure(is_obsolete=True)
         response = self.client.patch(
             f"/structures/{obsolete_struct.slug}/", {"is_obsolete": False}

--- a/back/dora/structures/views.py
+++ b/back/dora/structures/views.py
@@ -58,7 +58,7 @@ class StructureViewSet(
         structures = Structure.objects.select_related("source", "parent")
 
         # Masquées en lecture, mais accessibles en écriture pour pouvoir les réactiver.
-        if self.action not in ("update", "partial_update"):
+        if self.request.method in permissions.SAFE_METHODS:
             structures = structures.filter(is_obsolete=False)
 
         if search_string:

--- a/back/dora/structures/views.py
+++ b/back/dora/structures/views.py
@@ -55,9 +55,11 @@ class StructureViewSet(
         only_active = self.request.query_params.get("active")
         search_string = self.request.query_params.get("search", None)
 
-        structures = Structure.objects.select_related("source", "parent").filter(
-            is_obsolete=False
-        )
+        structures = Structure.objects.select_related("source", "parent")
+
+        # Masquées en lecture, mais accessibles en écriture pour pouvoir les réactiver.
+        if self.action not in ("update", "partial_update"):
+            structures = structures.filter(is_obsolete=False)
 
         if search_string:
             structures = structures.filter(name__icontains=search_string)


### PR DESCRIPTION
Filtrage des structures obsolètes dans le _queryset_ en lecture uniquement.