### PR TITLE
fix(ui): ne plus remonter à Sentry les fausses erreurs 500 lors du rechargement après déploiement

### DIFF
--- a/front/src/hooks.client.ts
+++ b/front/src/hooks.client.ts
@@ -3,7 +3,10 @@ import { ENVIRONMENT, SENTRY_DSN } from "$lib/env";
 import type { HandleClientError } from "@sveltejs/kit";
 
 import { setupFetchInterceptor } from "$lib/utils/fetch-interceptor";
-import { STALE_CHUNK_ERROR_MESSAGE } from "$lib/consts";
+import {
+  STALE_CHUNK_ERROR_MESSAGE,
+  STALE_CHUNK_RELOAD_MESSAGE,
+} from "$lib/consts";
 
 setupFetchInterceptor();
 
@@ -27,7 +30,7 @@ export const handleError: HandleClientError = Sentry.handleErrorWithSentry(
       error.message.includes(STALE_CHUNK_ERROR_MESSAGE)
     ) {
       window.location.reload();
-      return {};
+      return { message: STALE_CHUNK_RELOAD_MESSAGE };
     }
 
     const message =

--- a/front/src/lib/consts.ts
+++ b/front/src/lib/consts.ts
@@ -39,3 +39,7 @@ export const ORIENTATION_JWT_QUERY_PARAM = "op";
 export const TOAST_DURATION_MS = 30000;
 
 export const STALE_CHUNK_ERROR_MESSAGE = "dynamically imported module";
+
+// Marqueur retourné par le handleError client lors du rechargement automatique
+// après un déploiement, pour que la page d'erreur ne le remonte pas à Sentry
+export const STALE_CHUNK_RELOAD_MESSAGE = "stale-chunk-reload";

--- a/front/src/routes/+error.svelte
+++ b/front/src/routes/+error.svelte
@@ -1,16 +1,19 @@
 <script lang="ts">
   import { page } from "$app/stores";
   import CenteredGrid from "$lib/components/display/centered-grid.svelte";
-  import { RATE_LIMIT_MESSAGE } from "$lib/consts";
+  import { RATE_LIMIT_MESSAGE, STALE_CHUNK_RELOAD_MESSAGE } from "$lib/consts";
   import { logException } from "$lib/utils/logger";
   import { onMount } from "svelte";
 
   const notFound = $page.status === 404;
   const forbidden = $page.status === 403;
   const rateLimit = $page.status === 429;
+  // La page va être rechargée automatiquement (voir hooks.client.ts),
+  // inutile de remonter l'erreur à Sentry
+  const staleChunkReload = $page.error?.message === STALE_CHUNK_RELOAD_MESSAGE;
 
   onMount(() => {
-    if (!notFound) {
+    if (!notFound && !staleChunkReload) {
       logException(new Error($page.error?.message ?? String($page.status)));
     }
   });


### PR DESCRIPTION
Depuis #953, le `handleError` client retourne un objet erreur vide quand un chunk est obsolète, et `+error.svelte` loguait une erreur 500 avant le rechargement automatique. Un marqueur explicite permet désormais à la page d'erreur d'ignorer ce cas.