### PR TITLE
fix(ui): ne plus remonter à Sentry les fausses erreurs 500 de Safari lors du rechargement après déploiement

### DIFF
--- a/front/src/hooks.client.ts
+++ b/front/src/hooks.client.ts
@@ -4,7 +4,7 @@ import type { HandleClientError } from "@sveltejs/kit";
 
 import { setupFetchInterceptor } from "$lib/utils/fetch-interceptor";
 import {
-  STALE_CHUNK_ERROR_MESSAGE,
+  STALE_CHUNK_ERROR_MESSAGES,
   STALE_CHUNK_RELOAD_MESSAGE,
 } from "$lib/consts";
 
@@ -16,7 +16,7 @@ if (ENVIRONMENT !== "local") {
     environment: ENVIRONMENT,
     tracesSampleRate: 0,
     tracePropagationTargets: [],
-    ignoreErrors: [STALE_CHUNK_ERROR_MESSAGE],
+    ignoreErrors: STALE_CHUNK_ERROR_MESSAGES,
   });
 }
 
@@ -27,7 +27,9 @@ export const handleError: HandleClientError = Sentry.handleErrorWithSentry(
     // pour que le navigateur récupère le nouvel HTML et les nouveaux chunks.
     if (
       error instanceof TypeError &&
-      error.message.includes(STALE_CHUNK_ERROR_MESSAGE)
+      STALE_CHUNK_ERROR_MESSAGES.some((message) =>
+        error.message.includes(message)
+      )
     ) {
       window.location.reload();
       return { message: STALE_CHUNK_RELOAD_MESSAGE };

--- a/front/src/lib/consts.ts
+++ b/front/src/lib/consts.ts
@@ -38,7 +38,12 @@ export const ORIENTATION_JWT_QUERY_PARAM = "op";
 
 export const TOAST_DURATION_MS = 30000;
 
-export const STALE_CHUNK_ERROR_MESSAGE = "dynamically imported module";
+// Messages d'erreur de chargement de chunk obsolète, propres à chaque
+// navigateur : Chrome/Edge et Firefox pour le premier, Safari pour le second
+export const STALE_CHUNK_ERROR_MESSAGES = [
+  "dynamically imported module",
+  "Importing a module script failed",
+];
 
 // Marqueur retourné par le handleError client lors du rechargement automatique
 // après un déploiement, pour que la page d'erreur ne le remonte pas à Sentry


### PR DESCRIPTION
Complète https://github.com/gip-inclusion/dora/pull/1160

Le précédent correctif fonctionne mais le message d'erreur concernant les chunks obsolètes est différent pour Safari.

Ce nouveau correctif gère les erreurs de Safari.

Issue Sentry sur les dernières 24h : https://inclusion.sentry.io/issues/112661553/events/latest/?project=4509599011045456&referrer=latest-event&statsPeriod=24h