### PR TITLE
chore: mettre à jour itoutils

### DIFF
--- a/back/requirements/base.txt
+++ b/back/requirements/base.txt
@@ -572,9 +572,9 @@ idna==3.18 \
     #   email-validator
     #   httpx
     #   requests
-itoutils[django]==26.5.18.0 \
-    --hash=sha256:1727b3347bd02790773d1d35f72951eb8af7c24dd066086bf0bfb743d19f2d43 \
-    --hash=sha256:855ad34c391a6b14091fcf3834c78b6e7ae6593f90d40670edb3227c8ada1bf9
+itoutils[django]==26.7.9.0 \
+    --hash=sha256:3f3bd3b8afd12144a38f6bb4dcab7213c1e0cbc33c6c363a4eb08fa082422e48 \
+    --hash=sha256:52b720eb33baca9256a713e47356e6659ee1c7ba91db56a3662fc7e9eb65f971
     # via -r requirements/base.in
 jmespath==1.1.0 \
     --hash=sha256:472c87d80f36026ae83c6ddd0f1d05d4e510134ed462851fd5f754c8c3cbb88d \

--- a/back/requirements/dev.txt
+++ b/back/requirements/dev.txt
@@ -622,9 +622,9 @@ iniconfig==2.3.0 \
     --hash=sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730 \
     --hash=sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12
     # via pytest
-itoutils[django,django-testing]==26.5.18.0 \
-    --hash=sha256:1727b3347bd02790773d1d35f72951eb8af7c24dd066086bf0bfb743d19f2d43 \
-    --hash=sha256:855ad34c391a6b14091fcf3834c78b6e7ae6593f90d40670edb3227c8ada1bf9
+itoutils[django, django-testing]==26.7.9.0 \
+    --hash=sha256:3f3bd3b8afd12144a38f6bb4dcab7213c1e0cbc33c6c363a4eb08fa082422e48 \
+    --hash=sha256:52b720eb33baca9256a713e47356e6659ee1c7ba91db56a3662fc7e9eb65f971
     # via
     #   -r requirements/base.in
     #   -r requirements/test.in

--- a/back/requirements/prod.txt
+++ b/back/requirements/prod.txt
@@ -568,9 +568,9 @@ idna==3.18 \
     #   email-validator
     #   httpx
     #   requests
-itoutils[django]==26.5.18.0 \
-    --hash=sha256:1727b3347bd02790773d1d35f72951eb8af7c24dd066086bf0bfb743d19f2d43 \
-    --hash=sha256:855ad34c391a6b14091fcf3834c78b6e7ae6593f90d40670edb3227c8ada1bf9
+itoutils[django]==26.7.9.0 \
+    --hash=sha256:3f3bd3b8afd12144a38f6bb4dcab7213c1e0cbc33c6c363a4eb08fa082422e48 \
+    --hash=sha256:52b720eb33baca9256a713e47356e6659ee1c7ba91db56a3662fc7e9eb65f971
     # via -r requirements/base.in
 jmespath==1.1.0 \
     --hash=sha256:472c87d80f36026ae83c6ddd0f1d05d4e510134ed462851fd5f754c8c3cbb88d \

--- a/back/requirements/test.txt
+++ b/back/requirements/test.txt
@@ -586,9 +586,9 @@ iniconfig==2.3.0 \
     --hash=sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730 \
     --hash=sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12
     # via pytest
-itoutils[django,django-testing]==26.5.18.0 \
-    --hash=sha256:1727b3347bd02790773d1d35f72951eb8af7c24dd066086bf0bfb743d19f2d43 \
-    --hash=sha256:855ad34c391a6b14091fcf3834c78b6e7ae6593f90d40670edb3227c8ada1bf9
+itoutils[django, django-testing]==26.7.9.0 \
+    --hash=sha256:3f3bd3b8afd12144a38f6bb4dcab7213c1e0cbc33c6c363a4eb08fa082422e48 \
+    --hash=sha256:52b720eb33baca9256a713e47356e6659ee1c7ba91db56a3662fc7e9eb65f971
     # via
     #   -r requirements/base.in
     #   -r requirements/test.in


### PR DESCRIPTION
J'ai poussé un [fix](https://github.com/gip-inclusion/itoutils/commit/5d5b571a9686fd4371b04b2edbcd597120eeff9f) pour cette [erreur ](https://inclusion.sentry.io/issues/98976866/?environment=production&project=4509599009144912&query=is%3Aunresolved&referrer=issue-stream) dans itoutils. Cette PR met à jour le package à la dernière version qui contient le fix