### PR TITLE
chore: Version de NPM fixée à 24 LTS

### DIFF
--- a/front/package.json
+++ b/front/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.20",
   "engines": {
     "npm": ">=11.6.2",
-    "node": ">=24.13"
+    "node": "24.x"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Plus conservateur que la précédente config dans `package.json` (qui faisait systématiquement râler Scalingo lors du déploiement).

**AVANT** :
```json
  "engines": {
    "npm": ">=11.6.2",
    "node": ">=24.13"
  },
```

**APRÈS** :
```json
  "engines": {
    "npm": ">=11.6.2",
    "node": "24.x"
  },
```