### PR TITLE
chore: Nouvelle adresse API BAN définie comme constante

### DIFF
--- a/front/src/lib/components/inputs/geo/street-search.svelte
+++ b/front/src/lib/components/inputs/geo/street-search.svelte
@@ -5,6 +5,7 @@
 
   import Select from "$lib/components/inputs/select/select.svelte";
 
+  import { BAN_API_SEARCH_URL } from "$lib/consts";
   import { fetchWithRetry } from "$lib/utils/fetch-retry";
 
   import {
@@ -34,7 +35,6 @@
     readonly = false,
   }: Props = $props();
 
-  const banAPIUrl = "https://api-adresse.data.gouv.fr/search/";
   let currentSearchController: AbortController | undefined;
 
   async function searchAddress(query: string) {
@@ -42,7 +42,7 @@
     const controller = new AbortController();
     currentSearchController = controller;
 
-    const url = `${banAPIUrl}?q=${encodeURIComponent(
+    const url = `${BAN_API_SEARCH_URL}?q=${encodeURIComponent(
       query
     )}&limit=10&citycode=${cityCode}`;
 

--- a/front/src/lib/components/specialized/service-search.svelte
+++ b/front/src/lib/components/specialized/service-search.svelte
@@ -11,6 +11,7 @@
   import Button from "$lib/components/display/button.svelte";
   import SelectField from "$lib/components/inputs/obsolete/select-field.svelte";
   import Select from "$lib/components/inputs/select/select.svelte";
+  import { BAN_API_SEARCH_URL } from "$lib/consts";
   import type {
     Choice,
     FeeCondition,
@@ -104,10 +105,8 @@
       : address.properties.label;
   }
 
-  const banAPIUrl = "https://api-adresse.data.gouv.fr/search/";
-
   async function searchAddress(addrQuery) {
-    const url = `${banAPIUrl}?q=${encodeURIComponent(addrQuery)}&limit=10`;
+    const url = `${BAN_API_SEARCH_URL}?q=${encodeURIComponent(addrQuery)}&limit=10`;
     try {
       const response = await fetch(url);
       if (!response.ok) {

--- a/front/src/lib/consts.ts
+++ b/front/src/lib/consts.ts
@@ -17,6 +17,9 @@ export const MON_RECAP_DEPARTMENTS = ["59", "69", "93"];
 
 export const SEARCH_RADIUS_KM = 50;
 
+// Endpoint de recherche de la Base Adresse Nationale (BAN)
+export const BAN_API_SEARCH_URL = "https://data.geopf.fr/geocodage/search/";
+
 export const METABASE_DASHBOARD_URL = (departmentCode: string) =>
   `https://metabase.dora.inclusion.gouv.fr/public/dashboard/cac884d0-fdeb-4d69-b1cc-9ae58a4cd32f?d%25C3%25A9partement_de_la_structure=${departmentCode}`;
 

--- a/front/svelte.config.js
+++ b/front/svelte.config.js
@@ -18,7 +18,7 @@ const config = {
           process.env?.VITE_API_URL,
           process.env?.VITE_ENVIRONMENT === "local" ? "ws:" : null,
           "https://*.sentry.io",
-          "https://api-adresse.data.gouv.fr/",
+          "https://data.geopf.fr/",
           "https://openmaptiles.data.gouv.fr",
           "https://openmaptiles.geo.data.gouv.fr/",
           "https://openmaptiles.github.io/osm-bright-gl-style/",


### PR DESCRIPTION
Nous utilisions l'ancienne (adresse de) l'[API BAN](https://www.data.gouv.fr/dataservices/api-adresse-base-adresse-nationale-ban), à savoir `api-adresse.data.gouv.fr`, alors qu'elle est maintenant `data.geopf.fr/geocodage`.

Passée comme constante ; elle était en dur dans quelques fichiers.