### PR TITLE
chore: Permettre à NPM de télécharger les dépendances directes depuis une tarball

### DIFF
--- a/front/.npmrc
+++ b/front/.npmrc
@@ -1,1 +1,4 @@
+# SheetJS only distributes xlsx through its CDN.
+# https://docs.sheetjs.com/docs/getting-started/installation/nodejs#legacy-endpoints
+allow-remote=root
 engine-strict=true


### PR DESCRIPTION
NPM 12 change le comportement par défaut qui était de télécharger les tarballs pour toutes les dépendances, suite à de multiples incidents de sécurité.

https://github.blog/changelog/2026-06-09-upcoming-breaking-changes-for-npm-v12/

> --allow-remote defaults to none: npm install will no longer resolve
  dependencies from remote URLs, such as https tarballs (direct or
  transitive), unless explicitly allowed via --allow-remote. This flag
  is available in npm 11.15.0+. The related --allow-file and
  --allow-directory flags are not changing their defaults in v12.