### PR TITLE
feat: Ajout d'un endpoint de synchronisation des statuts des orientations Les Emplois

### DIFF
--- a/back/dora/emplois/serializers.py
+++ b/back/dora/emplois/serializers.py
@@ -107,8 +107,8 @@ class EmploisOrientationDataSerializer(serializers.Serializer):
     prescriber_phone = serializers.CharField(max_length=10)
 
 
-class EmploisOrientationSerializer(OrientationSerializer):
-    """API Les Emplois : le service Dora est ciblé via `di_service_id` = `dora--` + UUID du service."""
+class EmploisOrientationCreateSerializer(OrientationSerializer):
+    """Création d'une orientation par Les Emplois : le service Dora est ciblé via `di_service_id` = `dora--` + UUID du service."""
 
     emplois_data = EmploisOrientationDataSerializer(write_only=True)
 

--- a/back/dora/emplois/serializers.py
+++ b/back/dora/emplois/serializers.py
@@ -5,7 +5,7 @@ from rest_framework import serializers
 from rest_framework.exceptions import NotFound, ValidationError
 
 from dora.core.validators import validate_siret
-from dora.orientations.models import EmploisOrientationData
+from dora.orientations.models import EmploisOrientationData, Orientation
 from dora.orientations.serializers import OrientationSerializer
 from dora.services.models import Service
 from dora.stats.models import (
@@ -208,6 +208,19 @@ class EmploisOrientationCreateSerializer(OrientationSerializer):
         if instance.service_id:
             data["di_service_id"] = f"dora--{instance.service_id}"
         return data
+
+
+class EmploisOrientationStatusSerializer(serializers.ModelSerializer):
+    """Statut des orientations émises par Les Emplois."""
+
+    emplois_sync_uid = serializers.UUIDField(
+        source="emplois_orientation_data.emplois_sync_uid", read_only=True
+    )
+    updated_at = serializers.DateTimeField(read_only=True)
+
+    class Meta:
+        model = Orientation
+        fields = ["emplois_sync_uid", "status", "updated_at"]
 
 
 # Valeurs constantes communes à tous les événements de mobilisation enregistrés

--- a/back/dora/emplois/tests/test_emplois_orientations.py
+++ b/back/dora/emplois/tests/test_emplois_orientations.py
@@ -504,7 +504,7 @@ def test_orientation_status_list_returns_only_emplois_orientations(
     results = response.data["results"]
     assert len(results) == 1
 
-    item = results[0]
+    [item] = response.data["results"]
     assert set(item.keys()) == {"emplois_sync_uid", "status", "updated_at"}
     assert item["emplois_sync_uid"] == str(
         emplois_orientation.emplois_orientation_data.emplois_sync_uid
@@ -522,7 +522,8 @@ def test_orientation_status_list_updated_at_falls_back_to_creation_date(
     response = emplois_api_client.get(reverse(ORIENTATION_STATUS_URL))
 
     assert response.status_code == 200
-    item = response.data["results"][0]
+    assert len(response.data["results"]) == 1
+    [item] = response.data["results"]
     assert item["updated_at"] == DateTimeField().to_representation(
         orientation.creation_date
     )

--- a/back/dora/emplois/tests/test_emplois_orientations.py
+++ b/back/dora/emplois/tests/test_emplois_orientations.py
@@ -558,12 +558,18 @@ def test_orientation_status_list_filters_by_updated_after(emplois_api_client):
 
 
 def test_orientation_status_list_rejects_invalid_updated_after(emplois_api_client):
+    invalid_value = "pas-une-date"
+    with pytest.raises(ValidationError) as exc_info:
+        DateTimeField().run_validation(invalid_value)
+    expected = exc_info.value.detail[0]
+
     response = emplois_api_client.get(
-        reverse(ORIENTATION_STATUS_URL), {"updated_after": "pas-une-date"}
+        reverse(ORIENTATION_STATUS_URL), {"updated_after": invalid_value}
     )
 
     assert response.status_code == 400
-    assert "updated_after" in response.data
+    assert response.data["updated_after"][0]["code"] == expected.code
+    assert str(response.data["updated_after"][0]["message"]) == str(expected)
 
 
 def test_orientation_status_list_ignores_empty_updated_after(emplois_api_client):

--- a/back/dora/emplois/tests/test_emplois_orientations.py
+++ b/back/dora/emplois/tests/test_emplois_orientations.py
@@ -1,20 +1,25 @@
 import json
 import uuid
+from datetime import timedelta
 from unittest.mock import patch
 
 import pytest
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.urls import reverse
+from django.utils import timezone
 from model_bakery import baker
 from rest_framework.exceptions import ValidationError
+from rest_framework.fields import DateTimeField
 
-from dora.core.test_utils import make_service
+from dora.core.test_utils import make_orientation, make_service
 from dora.orientations.models import (
+    EmploisOrientationData,
     Orientation,
     OrientationStatus,
 )
 
 ORIENTATION_URL = "emplois:orientation-list"
+ORIENTATION_STATUS_URL = "emplois:orientation-status"
 DEFAULT_DI_SERVICE_ID = "soliguide--svc-1"
 
 EMPLOIS_DATA = {
@@ -451,3 +456,122 @@ def test_orientations_create_rejects_invalid_data_json(emplois_api_client):
 
     assert response.status_code == 400
     assert "data" in response.data
+
+
+def make_emplois_orientation(**kwargs):
+    """Crée une orientation émise par Les Emplois (avec ses `EmploisOrientationData`)."""
+    orientation = baker.make(
+        Orientation,
+        di_service_id=DEFAULT_DI_SERVICE_ID,
+        service=None,
+        **kwargs,
+    )
+    baker.make(EmploisOrientationData, orientation=orientation)
+    return orientation
+
+
+def test_orientation_status_list_requires_authentication(api_client):
+    response = api_client.get(reverse(ORIENTATION_STATUS_URL))
+    assert response.status_code == 401
+
+
+def test_orientation_status_list_requires_emplois_email(api_client):
+    user = baker.make("users.User", is_valid=True, email="other@example.com")
+    api_client.force_authenticate(user=user)
+    response = api_client.get(reverse(ORIENTATION_STATUS_URL))
+    assert response.status_code == 403
+
+
+def test_orientation_status_list_returns_only_emplois_orientations(
+    emplois_api_client,
+):
+    processing_date = timezone.now()
+    emplois_orientation = make_emplois_orientation(
+        status=OrientationStatus.ACCEPTED,
+        processing_date=processing_date,
+    )
+    # orientation Dora classique, sans données Les Emplois : exclue de la liste
+    make_orientation()
+    # orientation avec données Les Emplois mais avec un prescripteur Dora
+    # (créée depuis un JWT Emplois) : exclue de la liste
+    make_emplois_orientation(
+        prescriber=baker.make("users.User", is_valid=True),
+    )
+
+    response = emplois_api_client.get(reverse(ORIENTATION_STATUS_URL))
+
+    assert response.status_code == 200
+    results = response.data["results"]
+    assert len(results) == 1
+
+    item = results[0]
+    assert set(item.keys()) == {"emplois_sync_uid", "status", "updated_at"}
+    assert item["emplois_sync_uid"] == str(
+        emplois_orientation.emplois_orientation_data.emplois_sync_uid
+    )
+    assert item["status"] == OrientationStatus.ACCEPTED
+    assert item["updated_at"] == DateTimeField().to_representation(processing_date)
+
+
+def test_orientation_status_list_updated_at_falls_back_to_creation_date(
+    emplois_api_client,
+):
+    # orientation pas encore traitée : pas de date de traitement
+    orientation = make_emplois_orientation(status=OrientationStatus.PENDING)
+
+    response = emplois_api_client.get(reverse(ORIENTATION_STATUS_URL))
+
+    assert response.status_code == 200
+    item = response.data["results"][0]
+    assert item["updated_at"] == DateTimeField().to_representation(
+        orientation.creation_date
+    )
+
+
+def test_orientation_status_list_filters_by_updated_after(emplois_api_client):
+    cutoff = timezone.now()
+    make_emplois_orientation(
+        status=OrientationStatus.ACCEPTED,
+        processing_date=cutoff - timedelta(days=1),
+    )
+    on_cutoff = make_emplois_orientation(
+        status=OrientationStatus.REJECTED,
+        processing_date=cutoff,
+    )
+    after_cutoff = make_emplois_orientation(
+        status=OrientationStatus.ACCEPTED,
+        processing_date=cutoff + timedelta(days=1),
+    )
+
+    response = emplois_api_client.get(
+        reverse(ORIENTATION_STATUS_URL), {"updated_after": cutoff.isoformat()}
+    )
+
+    assert response.status_code == 200
+    # borne incluse : l'orientation mise à jour exactement à `updated_after`
+    # est retournée
+    assert [item["emplois_sync_uid"] for item in response.data["results"]] == [
+        str(on_cutoff.emplois_orientation_data.emplois_sync_uid),
+        str(after_cutoff.emplois_orientation_data.emplois_sync_uid),
+    ]
+
+
+def test_orientation_status_list_rejects_invalid_updated_after(emplois_api_client):
+    response = emplois_api_client.get(
+        reverse(ORIENTATION_STATUS_URL), {"updated_after": "pas-une-date"}
+    )
+
+    assert response.status_code == 400
+    assert "updated_after" in response.data
+
+
+def test_orientation_status_list_ignores_empty_updated_after(emplois_api_client):
+    make_emplois_orientation(status=OrientationStatus.PENDING)
+
+    response = emplois_api_client.get(
+        reverse(ORIENTATION_STATUS_URL), {"updated_after": ""}
+    )
+
+    # paramètre facultatif : vide, il est ignoré et la liste est complète
+    assert response.status_code == 200
+    assert len(response.data["results"]) == 1

--- a/back/dora/emplois/tests/test_emplois_orientations.py
+++ b/back/dora/emplois/tests/test_emplois_orientations.py
@@ -12,6 +12,7 @@ from rest_framework.exceptions import ValidationError
 from rest_framework.fields import DateTimeField
 
 from dora.core.test_utils import make_orientation, make_service
+from dora.emplois.views import AwareDateTimeField
 from dora.orientations.models import (
     EmploisOrientationData,
     Orientation,
@@ -560,11 +561,26 @@ def test_orientation_status_list_filters_by_updated_after(emplois_api_client):
 def test_orientation_status_list_rejects_invalid_updated_after(emplois_api_client):
     invalid_value = "pas-une-date"
     with pytest.raises(ValidationError) as exc_info:
-        DateTimeField().run_validation(invalid_value)
+        AwareDateTimeField().run_validation(invalid_value)
     expected = exc_info.value.detail[0]
 
     response = emplois_api_client.get(
         reverse(ORIENTATION_STATUS_URL), {"updated_after": invalid_value}
+    )
+
+    assert response.status_code == 400
+    assert response.data["updated_after"][0]["code"] == expected.code
+    assert str(response.data["updated_after"][0]["message"]) == str(expected)
+
+
+def test_orientation_status_list_rejects_naive_updated_after(emplois_api_client):
+    naive_value = "2026-07-13T15:00:00"
+    with pytest.raises(ValidationError) as exc_info:
+        AwareDateTimeField().run_validation(naive_value)
+    expected = exc_info.value.detail[0]
+
+    response = emplois_api_client.get(
+        reverse(ORIENTATION_STATUS_URL), {"updated_after": naive_value}
     )
 
     assert response.status_code == 400

--- a/back/dora/emplois/urls.py
+++ b/back/dora/emplois/urls.py
@@ -16,6 +16,11 @@ router.register(
 router.register(r"orientations", views.OrientationViewSet, basename="orientation")
 
 urlpatterns = [
+    path(
+        "orientations/status/",
+        views.OrientationStatusListView.as_view(),
+        name="orientation-status",
+    ),
     path("", include(router.urls)),
     path(
         "mobilisation-event/",

--- a/back/dora/emplois/views.py
+++ b/back/dora/emplois/views.py
@@ -255,12 +255,8 @@ class OrientationStatusListView(generics.ListAPIView):
         if updated_after:
             try:
                 value = DateTimeField().run_validation(updated_after)
-            except ValidationError:
-                raise ValidationError(
-                    {
-                        "updated_after": "Format de date invalide (datetime ISO 8601 attendu)."
-                    }
-                )
+            except ValidationError as exc:
+                raise ValidationError({"updated_after": exc.detail}) from exc
             queryset = queryset.filter(updated_at__gte=value)
         return queryset
 

--- a/back/dora/emplois/views.py
+++ b/back/dora/emplois/views.py
@@ -6,6 +6,7 @@ from django.core.files.storage import default_storage
 from django.db import transaction
 from django.db.models import CharField, Prefetch, Value
 from django.db.models.functions import Coalesce
+from django.utils import timezone
 from rest_framework import generics, mixins, permissions, status, viewsets
 from rest_framework.decorators import api_view, permission_classes, renderer_classes
 from rest_framework.exceptions import ValidationError
@@ -222,6 +223,18 @@ class OrientationViewSet(
         return orientation
 
 
+class AwareDateTimeField(DateTimeField):
+    default_error_messages = {
+        **DateTimeField.default_error_messages,
+        "naive": "La date et l'heure doivent inclure une indication de fuseau horaire.",
+    }
+
+    def enforce_timezone(self, value):
+        if timezone.is_naive(value):
+            self.fail("naive")
+        return super().enforce_timezone(value)
+
+
 class OrientationStatusListView(generics.ListAPIView):
     """Statuts des orientations émises par Les Emplois, pour leur synchronisation."""
 
@@ -247,14 +260,16 @@ class OrientationStatusListView(generics.ListAPIView):
     def filter_queryset(self, queryset):
         queryset = super().filter_queryset(queryset)
 
-        # `?updated_after=<ISO 8601>` : synchronisation incrémentale des
-        # statuts. Facultatif : absent ou vide, la liste est complète.
+        # `?updated_after=<ISO 8601 avec fuseau horaire>` : synchronisation
+        # incrémentale des statuts. Format attendu :
+        # `YYYY-MM-DDThh:mm[:ss[.uuuuuu]]Z` ou `...+HH:MM` / `...-HH:MM`
+        # (ex. `2026-07-13T13:00:00Z`).
         # Borne incluse pour ne pas rater une mise à jour simultanée ;
         # Les Emplois dédoublonnent via `emplois_sync_uid`.
         updated_after = self.request.query_params.get("updated_after")
         if updated_after:
             try:
-                value = DateTimeField().run_validation(updated_after)
+                value = AwareDateTimeField().run_validation(updated_after)
             except ValidationError as exc:
                 raise ValidationError({"updated_after": exc.detail}) from exc
             queryset = queryset.filter(updated_at__gte=value)

--- a/back/dora/emplois/views.py
+++ b/back/dora/emplois/views.py
@@ -5,9 +5,11 @@ from django.conf import settings
 from django.core.files.storage import default_storage
 from django.db import transaction
 from django.db.models import CharField, Prefetch, Value
-from rest_framework import mixins, permissions, status, viewsets
+from django.db.models.functions import Coalesce
+from rest_framework import generics, mixins, permissions, status, viewsets
 from rest_framework.decorators import api_view, permission_classes, renderer_classes
 from rest_framework.exceptions import ValidationError
+from rest_framework.fields import DateTimeField
 from rest_framework.parsers import FormParser, MultiPartParser
 from rest_framework.renderers import JSONRenderer
 from rest_framework.response import Response
@@ -34,6 +36,7 @@ from .serializers import (
     DoraServiceMobilisationSerializer,
     DoraStructureViewSerializer,
     EmploisOrientationCreateSerializer,
+    EmploisOrientationStatusSerializer,
     ExternalServiceMobilisationSerializer,
     ReferenceDataSerializer,
     ServiceSerializer,
@@ -217,6 +220,49 @@ class OrientationViewSet(
                 )
             )
         return orientation
+
+
+class OrientationStatusListView(generics.ListAPIView):
+    """Statuts des orientations émises par Les Emplois, pour leur synchronisation."""
+
+    permission_classes = (APIPermission,)
+    serializer_class = EmploisOrientationStatusSerializer
+    renderer_classes = (JSONRenderer,)
+    pagination_class = DefaultPageNumberPagination
+
+    def get_queryset(self):
+        return (
+            Orientation.objects.emplois()
+            .annotate(updated_at=Coalesce("processing_date", "creation_date"))
+            .select_related("emplois_orientation_data")
+            .only(
+                "status",
+                "processing_date",
+                "creation_date",
+                "emplois_orientation_data__emplois_sync_uid",
+            )
+            .order_by("pk")
+        )
+
+    def filter_queryset(self, queryset):
+        queryset = super().filter_queryset(queryset)
+
+        # `?updated_after=<ISO 8601>` : synchronisation incrémentale des
+        # statuts. Facultatif : absent ou vide, la liste est complète.
+        # Borne incluse pour ne pas rater une mise à jour simultanée ;
+        # Les Emplois dédoublonnent via `emplois_sync_uid`.
+        updated_after = self.request.query_params.get("updated_after")
+        if updated_after:
+            try:
+                value = DateTimeField().run_validation(updated_after)
+            except ValidationError:
+                raise ValidationError(
+                    {
+                        "updated_after": "Format de date invalide (datetime ISO 8601 attendu)."
+                    }
+                )
+            queryset = queryset.filter(updated_at__gte=value)
+        return queryset
 
 
 @api_view(["POST"])

--- a/back/dora/emplois/views.py
+++ b/back/dora/emplois/views.py
@@ -33,7 +33,7 @@ from .serializers import (
     DisabledDoraFormDIStructureSerializer,
     DoraServiceMobilisationSerializer,
     DoraStructureViewSerializer,
-    EmploisOrientationSerializer,
+    EmploisOrientationCreateSerializer,
     ExternalServiceMobilisationSerializer,
     ReferenceDataSerializer,
     ServiceSerializer,
@@ -149,7 +149,7 @@ class OrientationViewSet(
     viewsets.GenericViewSet,
 ):
     permission_classes = (OrientationAPIPermission,)
-    serializer_class = EmploisOrientationSerializer
+    serializer_class = EmploisOrientationCreateSerializer
     parser_classes = (MultiPartParser, FormParser)
     renderer_classes = (JSONRenderer,)
     throttle_classes = (UploadRateThrottle,)

--- a/back/dora/orientations/management/commands/anonymize_orientations.py
+++ b/back/dora/orientations/management/commands/anonymize_orientations.py
@@ -4,7 +4,7 @@ from django.conf import settings
 from django.utils import timezone
 
 from dora.core.commands import BaseCommand
-from dora.orientations.models import Orientation
+from dora.orientations.models import EmploisOrientationData, Orientation
 
 
 class Command(BaseCommand):
@@ -24,6 +24,15 @@ class Command(BaseCommand):
             is_anonymized=False, creation_date__date__lte=anonymization_date
         )
 
+        emplois_count = EmploisOrientationData.objects.filter(
+            orientation__in=orientations_to_anonymize
+        ).update(
+            prescriber_email="",
+            prescriber_first_name="",
+            prescriber_last_name="",
+            prescriber_phone="",
+        )
+
         count = orientations_to_anonymize.update(
             beneficiary_first_name="",
             beneficiary_last_name="",
@@ -40,6 +49,7 @@ class Command(BaseCommand):
         )
 
         self.logger.info(
-            "%s orientations ont été anonymisées.",
+            "%s orientations ont été anonymisées (dont %s avec des données Les Emplois).",
             count,
+            emplois_count,
         )

--- a/back/dora/orientations/models.py
+++ b/back/dora/orientations/models.py
@@ -55,6 +55,14 @@ class OrientationQuerySet(models.QuerySet):
             processing_date__isnull=False,
         )
 
+    def emplois(self):
+        # Orientations émises par Les Emplois — mêmes conditions
+        # que `Orientation.is_emplois()`.
+        return self.filter(
+            prescriber__isnull=True,
+            emplois_orientation_data__isnull=False,
+        )
+
 
 @dataclass(frozen=True)
 class PrescriberInfo:
@@ -359,6 +367,7 @@ class Orientation(models.Model):
             return ""
 
     def is_emplois(self):
+        # mêmes conditions que `OrientationQuerySet.emplois()`
         return self.prescriber_id is None and hasattr(self, "emplois_orientation_data")
 
     def source(self):

--- a/back/dora/orientations/tests/test_anonymize_orientations.py
+++ b/back/dora/orientations/tests/test_anonymize_orientations.py
@@ -1,12 +1,15 @@
 from datetime import timedelta
 from io import StringIO
 
+from django.conf import settings
 from django.core.management import call_command
 from django.test import TestCase
 from django.utils import timezone
 from freezegun import freeze_time
+from model_bakery import baker
 
 from dora.core.test_utils import make_orientation
+from dora.orientations.models import EmploisOrientationData
 
 
 class AnonymizeOrientationsTestCase(TestCase):
@@ -71,3 +74,51 @@ class AnonymizeOrientationsTestCase(TestCase):
 
         self.assertFalse(self.orientation.is_anonymized)
         self.assertIsNone(self.orientation.processing_date, timezone.now())
+
+
+def make_emplois_orientation_data(creation_date):
+    orientation = make_orientation(creation_date=creation_date)
+    return baker.make(
+        EmploisOrientationData,
+        orientation=orientation,
+        prescriber_email="alice.martin@example.org",
+        prescriber_first_name="Alice",
+        prescriber_last_name="Martin",
+        prescriber_phone="0601020304",
+        structure_name="Mission locale de Paris",
+    )
+
+
+def test_should_anonymize_emplois_orientation_data():
+    old_creation_date = timezone.now() - timedelta(
+        days=settings.ORIENTATION_ANONYMIZATION_PERIOD_DAYS + 1
+    )
+    emplois_data = make_emplois_orientation_data(old_creation_date)
+
+    call_command("anonymize_orientations", stdout=StringIO())
+
+    emplois_data.refresh_from_db()
+    assert emplois_data.prescriber_email == ""
+    assert emplois_data.prescriber_first_name == ""
+    assert emplois_data.prescriber_last_name == ""
+    assert emplois_data.prescriber_phone == ""
+
+    orientation = emplois_data.orientation
+    orientation.refresh_from_db()
+    assert orientation.is_anonymized
+
+
+def test_should_not_anonymize_recent_emplois_orientation_data():
+    emplois_data = make_emplois_orientation_data(timezone.now())
+
+    call_command("anonymize_orientations", stdout=StringIO())
+
+    emplois_data.refresh_from_db()
+    assert emplois_data.prescriber_email == "alice.martin@example.org"
+    assert emplois_data.prescriber_first_name == "Alice"
+    assert emplois_data.prescriber_last_name == "Martin"
+    assert emplois_data.prescriber_phone == "0601020304"
+
+    orientation = emplois_data.orientation
+    orientation.refresh_from_db()
+    assert not orientation.is_anonymized


### PR DESCRIPTION
Ajoute le endpoint GET `/orientations/status/` (compte API Les Emplois) : liste paginée des orientations émises par Les Emplois, avec `emplois_sync_uid`, `status` et `updated_at` (date de traitement, sinon de création). Le paramètre facultatif `?updated_after=<datetime ISO 8601>` (borne incluse) permet une synchro incrémentale.

Autres changements :

- nouveau queryset `Orientation.objects.emplois()`, aligné sur `is_emplois()` ;
- renommage de `EmploisOrientationSerializer` en `EmploisOrientationCreateSerializer` cat il ne sert qu'à créer des orientations ;
- correctif RGPD : `anonymize_orientations` vide désormais aussi les données personnelles du prescripteur dans `EmploisOrientationData`.