### PR TITLE
chore(deps): Remplacement de la bibliothèque de génération de fichier Excel

### DIFF
--- a/front/.npmrc
+++ b/front/.npmrc
@@ -1,4 +1,1 @@
-# SheetJS only distributes xlsx through its CDN.
-# https://docs.sheetjs.com/docs/getting-started/installation/nodejs#legacy-endpoints
-allow-remote=root
 engine-strict=true

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -61,7 +61,7 @@
         "vite": "^8.1.4",
         "vitest": "^4.1.10",
         "wicg-inert": "^3.1.3",
-        "xlsx": "https://cdn.sheetjs.com/xlsx-0.20.3/xlsx-0.20.3.tgz"
+        "write-excel-file": "^4.1.1"
       },
       "engines": {
         "node": "24.x",
@@ -4767,6 +4767,13 @@
         }
       }
     },
+    "node_modules/fflate": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.3.tgz",
+      "integrity": "sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/file-entry-cache": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
@@ -7852,17 +7859,17 @@
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
-    "node_modules/xlsx": {
-      "version": "0.20.3",
-      "resolved": "https://cdn.sheetjs.com/xlsx-0.20.3/xlsx-0.20.3.tgz",
-      "integrity": "sha512-oLDq3jw7AcLqKWH2AhCpVTZl8mf6X2YReP+Neh0SJUzV/BdZYjth94tG5toiMB1PPrYtxOCfaoUCkvtuH+3AJA==",
+    "node_modules/write-excel-file": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/write-excel-file/-/write-excel-file-4.1.1.tgz",
+      "integrity": "sha512-MUnCnNtQrcZek832ZcU24uU0rSphFmKPD1DvIjXOlygVb93CV7Tme6H3jUTkxsMmjB2W7HIzERzjqTi5kui71A==",
       "dev": true,
-      "license": "Apache-2.0",
-      "bin": {
-        "xlsx": "bin/xlsx.njs"
+      "license": "MIT",
+      "dependencies": {
+        "fflate": "^0.8.2"
       },
       "engines": {
-        "node": ">=0.8"
+        "node": ">=18"
       }
     },
     "node_modules/yallist": {

--- a/front/package.json
+++ b/front/package.json
@@ -77,7 +77,7 @@
     "vite": "^8.1.4",
     "vitest": "^4.1.10",
     "wicg-inert": "^3.1.3",
-    "xlsx": "https://cdn.sheetjs.com/xlsx-0.20.3/xlsx-0.20.3.tgz"
+    "write-excel-file": "^4.1.1"
   },
   "overrides": {
     "cookie": "0.7.2"

--- a/front/src/lib/utils/spreadsheet.ts
+++ b/front/src/lib/utils/spreadsheet.ts
@@ -1,19 +1,19 @@
-import * as XLSX from "xlsx";
 import dayjs from "dayjs";
 
-export function generateSpreadsheet<DATA extends Array<Record<string, any>>>({
-  sheetData,
-  sheetName,
-}: {
-  sheetData: DATA;
-  sheetName: string;
-}) {
-  const numColumns = Object.keys(sheetData[0]).length;
+export async function generateSpreadsheet<
+  DATA extends Array<Record<string, any>>,
+>({ sheetData, sheetName }: { sheetData: DATA; sheetName: string }) {
+  // Import dynamique pour charger la lib uniquement côté navigateur et au moment de l'export
+  const { default: writeExcelFile } = await import("write-excel-file/browser");
 
-  const worksheet = XLSX.utils.json_to_sheet(sheetData);
-  worksheet["!cols"] = Array(numColumns).fill({ wch: 20 });
-  const workbook = XLSX.utils.book_new();
-  XLSX.utils.book_append_sheet(workbook, worksheet);
+  const columns = Object.keys(sheetData[0]).map((header) => ({
+    header,
+    width: 20,
+    cell: (row: DATA[number]) => ({ value: row[header] }),
+  }));
+
   const date = dayjs().format("YYYY-MM-DD");
-  XLSX.writeFile(workbook, `${sheetName}-${date}.xlsx`, { compression: true });
+  await writeExcelFile(sheetData, { columns }).toFile(
+    `${sheetName}-${date}.xlsx`
+  );
 }


### PR DESCRIPTION
## Contexte

Comme SheetJS ne publie plus `xlsx` sur le registre npm, on l'installait via une URL de tarball. Depuis sa version 12, npm refuse de télécharger une dépendance qui vient d'une URL et ça casse le déploiement du front-end sur Scalingo.

```
 !     Error: Unable to install dependencies using npm.
 !     
 !     npm refused to fetch a dependency that points to a remote URL (e.g. an
 !     https tarball), because remote dependencies are disabled by default in
 !     npm 12+. Check the log output above for the offending package.
 !     
 !     Either replace it with a published registry version, or set "allow-remote"
 !     in your .npmrc to permit it.
 !     
 !     Docs: https://docs.npmjs.com/cli/v11/using-npm/config#allow-remote
```

Notre usage se limite à un export Excel en écriture seule, isolé dans une seule fonction.

## Solution

Remplacement de `xlsx` par `write-excel-file`.

Avantages de `write-excel-file` :

- Publiée sur le registre npm (plus besoin de traiter différemment cette dépendance) ;
- Bundle plus léger ;
- Fichiers générés plus petits.