### PR TITLE
refactor: Retirer la recherche DORA de la recherche de services

### DIFF
--- a/back/dora/data_inclusion/test_utils.py
+++ b/back/dora/data_inclusion/test_utils.py
@@ -132,13 +132,15 @@ class FakeDataInclusionClient:
             return [
                 # overly simple distance for tests.
                 {
-                    "distance": 0 if code_commune in s["zone_eligibilite"] else 30,
+                    "distance": s.get("distance", 0)
+                    if code_commune in s["zone_eligibilite"]
+                    else 30,
                     "service": s,
                 }
                 for s in services
             ]
         else:
-            return [{"distance": 30, "service": s} for s in services]
+            return [{"distance": s.get("distance", 30), "service": s} for s in services]
 
     def search(
         self,

--- a/back/dora/services/management/commands/send_saved_searches_notifications.py
+++ b/back/dora/services/management/commands/send_saved_searches_notifications.py
@@ -6,6 +6,7 @@ from django.template.loader import render_to_string
 from django.utils import timezone
 from mjml import mjml2html
 
+from dora.api.exceptions import ServiceUnavailable
 from dora.core.commands import BaseCommand
 from dora.core.emails import send_mail
 from dora.services.models import LocationKind
@@ -48,9 +49,17 @@ class Command(BaseCommand):
         num_emails_sent = 0
         for saved_search in saved_searches:
             # On garde les contenus qui ont été publiés depuis la dernière notification
-            new_services = saved_search.get_recent_services(
-                saved_search.last_notification_date
-            )
+            try:
+                new_services = saved_search.get_recent_services(
+                    saved_search.last_notification_date
+                )
+            except ServiceUnavailable:
+                self.logger.warning(
+                    "data·inclusion indisponible, envoi des notifications de "
+                    "recherches sauvegardées interrompu ; %s courriels envoyés",
+                    num_emails_sent,
+                )
+                return
 
             if new_services:
                 # Envoi de l'email

--- a/back/dora/services/models.py
+++ b/back/dora/services/models.py
@@ -11,7 +11,6 @@ from django.contrib.postgres.fields import ArrayField
 from django.core.cache import cache
 from django.core.exceptions import ValidationError
 from django.db.models import CharField, Q, URLField
-from django.shortcuts import get_object_or_404
 from django.utils import timezone
 from django.utils.crypto import get_random_string
 from django.utils.text import slugify
@@ -28,7 +27,6 @@ from dora.decoupage_administratif.models import (
     Region,
 )
 from dora.decoupage_administratif.utils import (
-    arrdt_to_main_insee_code,
     get_clean_city_name,
 )
 from dora.structures.models import Structure
@@ -909,27 +907,18 @@ class SavedSearch(models.Model):
         if self.location_kinds.exists():
             location_kinds = self.location_kinds.values_list("value", flat=True)
 
-        funding_labels = None
-        if self.funding_labels.exists():
-            funding_labels = self.funding_labels.values_list("value", flat=True)
-
         # Récupération des résultats de la recherche
         from .search import search_services
-
-        city_code = arrdt_to_main_insee_code(self.city_code)
-        city = get_object_or_404(City, pk=city_code)
 
         results, metadata = search_services(
             None,
             di_client,
             self.city_code,
-            city,
             [category.value] if category and not subcategories else None,
             subcategories,
             kinds,
             fees,
             location_kinds,
-            funding_labels,
         )
 
         # On garde les contenus qui ont été publiés depuis la dernière notification

--- a/back/dora/services/search.py
+++ b/back/dora/services/search.py
@@ -114,10 +114,6 @@ DI_SERVICE_KINDS = {
 }
 
 
-def _map_kinds_dora_to_di(kinds: list[str]) -> list[str]:
-    return [kind for kind in kinds if kind in DI_SERVICE_KINDS]
-
-
 def _filter_di_results(raw_di_results: list, city_code: str) -> list:
     city = City.objects.filter(code=city_code).first()
 
@@ -193,13 +189,11 @@ def _get_raw_di_results(
     if not thematiques and subcategories:
         return []
 
-    types = _map_kinds_dora_to_di(kinds) if kinds else None
-
     try:
         raw_di_results = di_client.search_services(
             code_commune=city_code,
             thematiques=thematiques if len(thematiques) > 0 else None,
-            types=types,
+            types=kinds,
             frais=fees,
             lat=lat,
             lon=lon,

--- a/back/dora/services/search.py
+++ b/back/dora/services/search.py
@@ -8,23 +8,17 @@ from typing import Optional
 import requests
 from data_inclusion.schema.v1 import ModeAccueil
 from django.conf import settings
-from django.contrib.gis.db.models.functions import Distance
-from django.contrib.gis.geos import Point
-from django.contrib.gis.measure import D
-from django.db.models import IntegerField, Q, QuerySet, Value
-from django.utils import timezone
+from django.db.models import Q
 
 import dora.services.models as models
 from dora import data_inclusion
 from dora.api.exceptions import ServiceUnavailable
-from dora.core.constants import WGS84
 from dora.data_inclusion.mappings import map_search_result
 from dora.decoupage_administratif.models import City
 from dora.services.models import ServiceSubCategory
 
 from .models import FundingLabel
 from .serializers import FundingLabelSerializer, SearchResultSerializer
-from .utils import filter_services_by_city_code
 
 MAX_DISTANCE = 50
 DEPARTMENT_CODE_SOMME = "80"
@@ -33,38 +27,6 @@ MEDIATION_NUMERIQUE_SOURCE = "mediation-numerique"
 FRANCE_SERVICES_STRUCTURE_ID_PREFIX = "mediation-numerique--France-Services"
 
 logger = logging.getLogger(__name__)
-
-
-def _filter_and_annotate_dora_services(
-    services: QuerySet[models.Service],
-    location: Point,
-    with_remote: bool,
-    with_onsite: bool,
-) -> QuerySet[models.Service]:
-    no_services = models.Service.objects.none()
-    # 1) services ayant un lieu de déroulement, à moins de MAX_DISTANCE km
-    services_on_site = (
-        services.filter(location_kinds__value=ModeAccueil.EN_PRESENTIEL)
-        .annotate(distance=Distance("geom", location))
-        .filter(distance__lte=D(km=MAX_DISTANCE))
-        if with_onsite
-        else no_services
-    )
-    # 2) services sans lieu de déroulement
-    services_remote = (
-        (
-            services.filter(
-                Q(location_kinds__value=ModeAccueil.A_DISTANCE)
-                | ~Q(location_kinds__value=ModeAccueil.EN_PRESENTIEL)
-            )
-            .exclude(id__in=services_on_site)
-            .distinct()
-            .annotate(distance=Value(None, output_field=IntegerField()))
-        )
-        if with_remote
-        else no_services
-    )
-    return services_on_site | services_remote
 
 
 def _sort_services(services):
@@ -189,7 +151,10 @@ def _get_raw_di_results(
             lon=lon,
         )
     except requests.ConnectionError:
-        return []
+        raise ServiceUnavailable(
+            "L’API data.inclusion.gouv.fr nécessaire pour la recherche "
+            "n’est pas disponible. Merci de réessayer ultérieurement."
+        )
 
     if raw_di_results is None:
         return []
@@ -237,97 +202,6 @@ def _map_di_results(
         )
     ]
     return mapped_di_results
-
-
-def _get_dora_results(
-    request,
-    city_code: str,
-    city: City,
-    categories: Optional[list[str]] = None,
-    subcategories: Optional[list[str]] = None,
-    kinds: Optional[list[str]] = None,
-    fees: Optional[list[str]] = None,
-    location_kinds: Optional[list[str]] = None,
-    funding_labels: Optional[list[str]] = None,
-    lat: Optional[float] = None,
-    lon: Optional[float] = None,
-):
-    services = (
-        models.Service.objects.filter_for_DI()
-        .select_related(
-            "structure",
-        )
-        .prefetch_related(
-            "kinds",
-            "fee_condition",
-            "location_kinds",
-            "publics",
-            "categories",
-            "subcategories",
-            "funding_labels",
-            "coach_orientation_modes",
-            "beneficiaries_access_modes",
-        )
-    )
-
-    if kinds:
-        services = services.filter(kinds__value__in=kinds)
-
-    if fees:
-        services = services.filter(fee_condition__value__in=fees)
-
-    if location_kinds:
-        services = services.filter(location_kinds__value__in=location_kinds)
-
-    if funding_labels:
-        services = services.filter(funding_labels__value__in=funding_labels)
-
-    with_remote = not location_kinds or ModeAccueil.A_DISTANCE in location_kinds
-    with_onsite = not location_kinds or ModeAccueil.EN_PRESENTIEL in location_kinds
-
-    categories_filter = Q()
-    if categories:
-        categories_filter = Q(categories__value__in=categories)
-
-    subcategories_filter = Q()
-    if subcategories:
-        for subcategory in subcategories:
-            cat, subcat = subcategory.split("--")
-            if subcat == "autre":
-                # Quand on cherche une sous-catégorie de type 'Autre', on veut
-                # aussi remonter les services sans sous-catégorie
-                all_sister_subcats = models.ServiceSubCategory.objects.filter(
-                    value__startswith=f"{cat}--"
-                )
-                subcategories_filter |= Q(subcategories__value=subcategory) | (
-                    Q(categories__value=cat) & ~Q(subcategories__in=all_sister_subcats)
-                )
-            else:
-                subcategories_filter |= Q(subcategories__value=subcategory)
-
-    services = services.filter(categories_filter | subcategories_filter).distinct()
-
-    geofiltered_services = filter_services_by_city_code(services, city_code)
-
-    # Exclude suspended services
-    services_to_display = geofiltered_services.filter(
-        Q(suspension_date=None) | Q(suspension_date__gte=timezone.now())
-    ).distinct()
-
-    results = _filter_and_annotate_dora_services(
-        services_to_display,
-        city.center if not lat or not lon else Point(lon, lat, srid=WGS84),
-        with_remote,
-        with_onsite,
-    )
-
-    funding_labels_found = FundingLabel.objects.filter(service__in=results).distinct()
-
-    return SearchResultSerializer(
-        results, many=True, context={"request": request}
-    ).data, {
-        "funding_labels": FundingLabelSerializer(funding_labels_found, many=True).data
-    }
 
 
 def _dora_services_by_id(service_ids):
@@ -434,13 +308,11 @@ def search_services(
     request,
     di_client: data_inclusion.DataInclusionClient,
     city_code: str,
-    city: City,
     categories: Optional[list[str]] = None,
     subcategories: Optional[list[str]] = None,
     kinds: Optional[list[str]] = None,
     fees: Optional[list[str]] = None,
     location_kinds: Optional[list[str]] = None,
-    funding_labels: Optional[list[str]] = None,
     lat: Optional[float] = None,
     lon: Optional[float] = None,
 ) -> (list[dict], dict):
@@ -470,22 +342,6 @@ def search_services(
         lat=lat,
         lon=lon,
     )
-    if len(results) == 0:
-        # Pas de résultat peut signifier que DI n'est pas accessible.
-        # On relance la recherche sur les services DORA locaux.
-        results, metadata = _get_dora_results(
-            request=request,
-            categories=categories,
-            subcategories=subcategories,
-            city_code=city_code,
-            city=city,
-            kinds=kinds,
-            fees=fees,
-            location_kinds=location_kinds,
-            funding_labels=funding_labels,
-            lat=lat,
-            lon=lon,
-        )
     return _sort_services(results), metadata
 
 

--- a/back/dora/services/search.py
+++ b/back/dora/services/search.py
@@ -104,16 +104,6 @@ def _sort_services(services):
     return results
 
 
-DI_SERVICE_KINDS = {
-    "accompagnement",
-    "aide-financiere",
-    "aide-materielle",
-    "atelier",
-    "formation",
-    "information",
-}
-
-
 def _filter_di_results(raw_di_results: list, city_code: str) -> list:
     city = City.objects.filter(code=city_code).first()
 

--- a/back/dora/services/tests/test_search.py
+++ b/back/dora/services/tests/test_search.py
@@ -58,8 +58,13 @@ def test_search_services_with_obsolete_structure(api_client, city):
 
     # Service publié avec structure non obsolète
     service = make_published_service(diffusion_zone_type=AdminDivisionType.COUNTRY)
+    di_service_data = make_di_service_data(
+        source="dora",
+        id=f"dora--{service.pk}",
+        zone_eligibilite=[city.code],
+    )
 
-    fake_di_client = FakeDataInclusionClient()
+    fake_di_client = FakeDataInclusionClient(services=[di_service_data])
 
     with mock.patch(
         "dora.data_inclusion.di_client_factory", return_value=fake_di_client
@@ -96,7 +101,12 @@ def test_search_services_with_orphan_structure(
     # les services rattachés à une structure orpheline
     # doivent être filtrés lors de la recherche
 
-    fake_di_client = FakeDataInclusionClient()
+    di_service_data = make_di_service_data(
+        source="dora",
+        id=f"dora--{orphan_service.pk}",
+        zone_eligibilite=[city.code],
+    )
+    fake_di_client = FakeDataInclusionClient(services=[di_service_data])
 
     with mock.patch(
         "dora.data_inclusion.di_client_factory", return_value=fake_di_client

--- a/back/dora/services/tests/test_services.py
+++ b/back/dora/services/tests/test_services.py
@@ -1,3 +1,5 @@
+import json
+import random
 from datetime import timedelta
 from unittest import mock
 
@@ -50,8 +52,6 @@ from ..models import (
     AccessCondition,
     BeneficiaryAccessMode,
     CoachOrientationMode,
-    FundingLabel,
-    LocationKind,
     Service,
     ServiceCategory,
     ServiceFee,
@@ -1372,12 +1372,6 @@ class DataInclusionSearchTestCase(APITestCase):
         ]
 
     def test_data_inclusion_connection_error(self):
-        service_dora = make_service(
-            status=ServiceStatus.PUBLISHED,
-            diffusion_zone_type=AdminDivisionType.CITY,
-            diffusion_zone_details=self.city1.code,
-        )
-
         class FaultyDataInclusionClient:
             def search_services(self, **kwargs):
                 raise requests.ConnectionError()
@@ -1385,17 +1379,18 @@ class DataInclusionSearchTestCase(APITestCase):
         di_client = FaultyDataInclusionClient()
         request = self.factory.get("/search/", {"city": self.city1.code})
         response = self.search(request, di_client)
-        assert response.status_code == 200
-        # ajout des "city bounds" pour la carte
-        assert len(response.data) == 4
-        assert [
-            "funding_labels",
-            "search_center",
-            "search_radius_km",
-            "services",
-        ] == sorted(list(response.data.keys()))
-        service, *_ = response.data["services"]
-        assert service["slug"] == service_dora.slug
+        response.render()
+        assert response.status_code == 503
+        assert json.loads(response.content) == {
+            "detail": {
+                "message": (
+                    "L’API data.inclusion.gouv.fr nécessaire "
+                    "pour la recherche n’est pas disponible. "
+                    "Merci de réessayer ultérieurement."
+                ),
+                "code": "service_unavailable",
+            }
+        }
 
     def test_service_di_contains_service_fields(self):
         service_data = self.make_di_service()
@@ -1878,668 +1873,9 @@ class DataInclusionSearchTestCase(APITestCase):
             )
 
 
-class ServiceSearchTestCase(APITestCase):
-    def setUp(self):
-        self.region = baker.make("decoupage_administratif.Region", code="099")
-        self.dept = baker.make(
-            "decoupage_administratif.Department", region=self.region.code, code="77"
-        )
-        self.epci11 = baker.make("decoupage_administratif.EPCI", code="200011111")
-        self.epci12 = baker.make("decoupage_administratif.EPCI", code="200022222")
-        self.city1 = baker.make(
-            "decoupage_administratif.City",
-            code="12345",
-            epci=self.epci11.code,
-            department=self.dept.code,
-            region=self.region.code,
-        )
-        self.city2 = baker.make("decoupage_administratif.City")
-
-        self.di_client = FakeDataInclusionClient()
-        self.patcher = mock.patch("dora.data_inclusion.di_client_factory")
-        self.mock_di_client_factory = self.patcher.start()
-        self.mock_di_client_factory.return_value = self.di_client
-
-        baker.make("ServiceCategory", value="cat1", label="cat1")
-        baker.make("ServiceSubCategory", value="cat1--sub1", label="cat1--sub1")
-        baker.make("ServiceSubCategory", value="cat1--sub2", label="cat1--sub2")
-        baker.make("ServiceSubCategory", value="cat1--sub3", label="cat1--sub3")
-        baker.make("ServiceSubCategory", value="cat1--autre", label="cat1--autre")
-        baker.make("ServiceCategory", value="cat2", label="cat2")
-        baker.make("ServiceSubCategory", value="cat2--sub1", label="cat2--sub1")
-        baker.make("ServiceSubCategory", value="cat2--sub2", label="cat2--sub2")
-        baker.make("ServiceSubCategory", value="cat2--autre", label="cat2--autre")
-        baker.make("ServiceCategory", value="cat3", label="cat3")
-
-    def tearDown(self):
-        self.patcher.stop()
-
-    def test_needs_city_code(self):
-        make_service(
-            status=ServiceStatus.PUBLISHED,
-            diffusion_zone_type=AdminDivisionType.COUNTRY,
-        )
-        response = self.client.get("/search/")
-        self.assertEqual(response.status_code, 404)
-
-    def test_can_see_published_services(self):
-        service = make_service(
-            status=ServiceStatus.PUBLISHED,
-            diffusion_zone_type=AdminDivisionType.COUNTRY,
-        )
-        response = self.client.get(f"/search/?city={self.city1.code}")
-        assert response.status_code == 200
-        assert len(response.data) == 4
-        assert len(response.data["services"]) == 1
-        assert response.data["services"][0]["slug"] == service.slug
-
-    def test_cant_see_draft_services(self):
-        make_service(
-            status=ServiceStatus.DRAFT, diffusion_zone_type=AdminDivisionType.COUNTRY
-        )
-        response = self.client.get(f"/search/?city={self.city1.code}")
-        assert response.status_code == 200
-        assert len(response.data) == 4
-        assert len(response.data["services"]) == 0
-
-    def test_cant_see_suggested_services(self):
-        make_service(
-            status=ServiceStatus.SUGGESTION,
-            diffusion_zone_type=AdminDivisionType.COUNTRY,
-        )
-        response = self.client.get(f"/search/?city={self.city1.code}")
-        assert response.status_code == 200
-        assert len(response.data) == 4
-        assert len(response.data["services"]) == 0
-
-    def test_can_see_service_with_future_suspension_date(self):
-        service = make_service(
-            status=ServiceStatus.PUBLISHED,
-            diffusion_zone_type=AdminDivisionType.COUNTRY,
-            suspension_date=timezone.now() + timedelta(days=1),
-        )
-        response = self.client.get(f"/search/?city={self.city1.code}")
-        assert response.status_code == 200
-        assert len(response.data) == 4
-        assert len(response.data["services"]) == 1
-        assert response.data["services"][0]["slug"] == service.slug
-
-    def test_cannot_see_service_with_past_suspension_date(self):
-        make_service(
-            status=ServiceStatus.PUBLISHED,
-            diffusion_zone_type=AdminDivisionType.COUNTRY,
-            suspension_date=timezone.now() - timedelta(days=1),
-        )
-        response = self.client.get(f"/search/?city={self.city1.code}")
-        assert response.status_code == 200
-        assert len(response.data) == 4
-        assert len(response.data["services"]) == 0
-
-    def test_find_services_in_city(self):
-        service = make_service(
-            status=ServiceStatus.PUBLISHED,
-            diffusion_zone_type=AdminDivisionType.CITY,
-            diffusion_zone_details=self.city1.code,
-        )
-        response = self.client.get(f"/search/?city={self.city1.code}")
-        assert response.status_code == 200
-        assert len(response.data) == 4
-        assert len(response.data["services"]) == 1
-        assert response.data["services"][0]["slug"] == service.slug
-
-    def test_find_services_in_epci(self):
-        service = make_service(
-            status=ServiceStatus.PUBLISHED,
-            diffusion_zone_type=AdminDivisionType.EPCI,
-            diffusion_zone_details=self.epci11.code,
-        )
-        response = self.client.get(f"/search/?city={self.city1.code}")
-        assert response.status_code == 200
-        assert len(response.data) == 4
-        assert len(response.data["services"]) == 1
-        assert response.data["services"][0]["slug"] == service.slug
-
-    def test_find_services_in_dept(self):
-        service = make_service(
-            status=ServiceStatus.PUBLISHED,
-            diffusion_zone_type=AdminDivisionType.DEPARTMENT,
-            diffusion_zone_details=self.dept.code,
-        )
-        response = self.client.get(f"/search/?city={self.city1.code}")
-        assert response.status_code == 200
-        assert len(response.data) == 4
-        assert len(response.data["services"]) == 1
-        assert response.data["services"][0]["slug"] == service.slug
-
-    def test_find_services_in_region(self):
-        service = make_service(
-            status=ServiceStatus.PUBLISHED,
-            diffusion_zone_type=AdminDivisionType.REGION,
-            diffusion_zone_details=self.region.code,
-        )
-        response = self.client.get(f"/search/?city={self.city1.code}")
-        assert response.status_code == 200
-        assert len(response.data) == 4
-        assert len(response.data["services"]) == 1
-        assert response.data["services"][0]["slug"] == service.slug
-
-    def test_dont_find_services_in_other_city(self):
-        make_service(
-            status=ServiceStatus.PUBLISHED,
-            diffusion_zone_type=AdminDivisionType.CITY,
-            diffusion_zone_details=self.city1.code,
-        )
-        response = self.client.get(f"/search/?city={self.city2.code}")
-        assert response.status_code == 200
-        assert len(response.data) == 4
-        assert len(response.data["services"]) == 0
-
-    def test_dont_find_services_in_other_epci(self):
-        make_service(
-            status=ServiceStatus.PUBLISHED,
-            diffusion_zone_type=AdminDivisionType.EPCI,
-            diffusion_zone_details=self.epci11.code,
-        )
-        response = self.client.get(f"/search/?city={self.city2.code}")
-        assert response.status_code == 200
-        assert len(response.data) == 4
-        assert len(response.data["services"]) == 0
-
-    def test_dont_find_services_in_other_department(self):
-        make_service(
-            status=ServiceStatus.PUBLISHED,
-            diffusion_zone_type=AdminDivisionType.DEPARTMENT,
-            diffusion_zone_details=self.dept.code,
-        )
-        response = self.client.get(f"/search/?city={self.city2.code}")
-        assert response.status_code == 200
-        assert len(response.data) == 4
-        assert len(response.data["services"]) == 0
-
-    def test_dont_find_services_in_other_region(self):
-        make_service(
-            status=ServiceStatus.PUBLISHED,
-            diffusion_zone_type=AdminDivisionType.REGION,
-            diffusion_zone_details=self.region.code,
-        )
-        response = self.client.get(f"/search/?city={self.city2.code}")
-        assert response.status_code == 200
-        assert len(response.data) == 4
-        assert len(response.data["services"]) == 0
-
-    def test_filter_by_fee_free(self):
-        service1 = make_service(
-            status=ServiceStatus.PUBLISHED,
-            diffusion_zone_type=AdminDivisionType.COUNTRY,
-            fee_condition=ServiceFee.objects.filter(value="gratuit").first(),
-        )
-        make_service(
-            status=ServiceStatus.PUBLISHED,
-            diffusion_zone_type=AdminDivisionType.COUNTRY,
-            fee_condition=ServiceFee.objects.filter(value="payant").first(),
-        )
-        make_service(
-            status=ServiceStatus.PUBLISHED,
-            diffusion_zone_type=AdminDivisionType.COUNTRY,
-            fee_condition=ServiceFee.objects.filter(value="payant").first(),
-        )
-        response = self.client.get(f"/search/?city={self.city1.code}&fees=gratuit")
-        assert response.status_code == 200
-        assert len(response.data) == 4
-        assert len(response.data["services"]) == 1
-        assert response.data["services"][0]["slug"] == service1.slug
-
-    def test_filter_by_fee_payant(self):
-        make_service(
-            status=ServiceStatus.PUBLISHED,
-            diffusion_zone_type=AdminDivisionType.COUNTRY,
-            fee_condition=ServiceFee.objects.filter(value="gratuit").first(),
-        )
-        service2 = make_service(
-            status=ServiceStatus.PUBLISHED,
-            diffusion_zone_type=AdminDivisionType.COUNTRY,
-            fee_condition=ServiceFee.objects.filter(value="payant").first(),
-        )
-        make_service(
-            status=ServiceStatus.PUBLISHED,
-            diffusion_zone_type=AdminDivisionType.COUNTRY,
-            fee_condition=ServiceFee.objects.filter(value="gratuit").first(),
-        )
-        response = self.client.get(f"/search/?city={self.city1.code}&fees=payant")
-        assert response.status_code == 200
-        assert len(response.data) == 4
-        assert len(response.data["services"]) == 1
-        assert response.data["services"][0]["slug"] == service2.slug
-
-    def test_filter_without_fee(self):
-        make_service(
-            status=ServiceStatus.PUBLISHED,
-            diffusion_zone_type=AdminDivisionType.COUNTRY,
-            fee_condition=ServiceFee.objects.filter(value="gratuit").first(),
-        )
-        make_service(
-            status=ServiceStatus.PUBLISHED,
-            diffusion_zone_type=AdminDivisionType.COUNTRY,
-            fee_condition=ServiceFee.objects.filter(value="payant").first(),
-        )
-        make_service(
-            status=ServiceStatus.PUBLISHED,
-            diffusion_zone_type=AdminDivisionType.COUNTRY,
-            fee_condition=ServiceFee.objects.filter(value="gratuit").first(),
-        )
-        response = self.client.get(f"/search/?city={self.city1.code}")
-        assert response.status_code == 200
-        assert len(response.data) == 4
-        assert len(response.data["services"]) == 3
-
-    def test_filter_kinds_one(self):
-        allowed_kinds = ServiceKind.objects.all()
-        service1 = make_service(
-            status=ServiceStatus.PUBLISHED,
-            diffusion_zone_type=AdminDivisionType.COUNTRY,
-            kinds=[allowed_kinds[0], allowed_kinds[1]],
-        )
-        make_service(
-            status=ServiceStatus.PUBLISHED,
-            diffusion_zone_type=AdminDivisionType.COUNTRY,
-            kinds=[allowed_kinds[2]],
-        )
-        response = self.client.get(
-            f"/search/?city={self.city1.code}&kinds={allowed_kinds[0].value}"
-        )
-        assert response.status_code == 200
-        assert len(response.data) == 4
-        assert len(response.data["services"]) == 1
-        assert response.data["services"][0]["slug"] == service1.slug
-
-    def test_filter_kinds_several(self):
-        allowed_kinds = ServiceKind.objects.all()
-        service1 = make_service(
-            status=ServiceStatus.PUBLISHED,
-            diffusion_zone_type=AdminDivisionType.COUNTRY,
-            kinds=[allowed_kinds[0], allowed_kinds[1]],
-        )
-        service2 = make_service(
-            status=ServiceStatus.PUBLISHED,
-            diffusion_zone_type=AdminDivisionType.COUNTRY,
-            kinds=[allowed_kinds[1], allowed_kinds[2]],
-        )
-        make_service(
-            status=ServiceStatus.PUBLISHED,
-            diffusion_zone_type=AdminDivisionType.COUNTRY,
-            kinds=[allowed_kinds[3]],
-        )
-        response = self.client.get(
-            f"/search/?city={self.city1.code}&kinds={allowed_kinds[1].value},{allowed_kinds[2].value}"
-        )
-        assert response.status_code == 200
-        assert len(response.data) == 4
-        assert len(response.data["services"]) == 2
-
-        response_slugs = [r["slug"] for r in response.data["services"]]
-        assert service1.slug in response_slugs
-        assert service2.slug in response_slugs
-
-    def test_filter_kinds_nomatch(self):
-        allowed_kinds = ServiceKind.objects.all()
-        make_service(
-            status=ServiceStatus.PUBLISHED,
-            diffusion_zone_type=AdminDivisionType.COUNTRY,
-            kinds=[allowed_kinds[0], allowed_kinds[1]],
-        )
-        make_service(
-            status=ServiceStatus.PUBLISHED,
-            diffusion_zone_type=AdminDivisionType.COUNTRY,
-            kinds=[allowed_kinds[1], allowed_kinds[2]],
-        )
-        response = self.client.get(
-            f"/search/?city={self.city1.code}&kinds={allowed_kinds[3].value}"
-        )
-        assert response.status_code == 200
-        assert len(response.data) == 4
-        assert len(response.data["services"]) == 0
-
-    def test_filter_without_funding(self):
-        allowed_funding_labels = FundingLabel.objects.all()
-        make_service(
-            status=ServiceStatus.PUBLISHED,
-            diffusion_zone_type=AdminDivisionType.COUNTRY,
-        )
-        make_service(
-            status=ServiceStatus.PUBLISHED,
-            diffusion_zone_type=AdminDivisionType.COUNTRY,
-            funding_labels=[allowed_funding_labels[0]],
-        )
-        make_service(
-            status=ServiceStatus.PUBLISHED,
-            diffusion_zone_type=AdminDivisionType.COUNTRY,
-            funding_labels=[allowed_funding_labels[1], allowed_funding_labels[2]],
-        )
-        response = self.client.get(f"/search/?city={self.city1.code}")
-        assert response.status_code == 200
-        assert len(response.data) == 4
-        assert len(response.data["services"]) == 3
-
-    def test_funding_one(self):
-        allowed_funding_labels = FundingLabel.objects.all()
-        service1 = make_service(
-            status=ServiceStatus.PUBLISHED,
-            diffusion_zone_type=AdminDivisionType.COUNTRY,
-            funding_labels=[allowed_funding_labels[0], allowed_funding_labels[1]],
-        )
-        make_service(
-            status=ServiceStatus.PUBLISHED,
-            diffusion_zone_type=AdminDivisionType.COUNTRY,
-            funding_labels=[allowed_funding_labels[2]],
-        )
-        response = self.client.get(
-            f"/search/?city={self.city1.code}&funding={allowed_funding_labels[0].value}"
-        )
-        assert response.status_code == 200
-        assert len(response.data) == 4
-        assert len(response.data["services"]) == 1
-        assert response.data["services"][0]["slug"] == service1.slug
-
-    def test_funding_several(self):
-        allowed_funding_labels = FundingLabel.objects.all()
-        service1 = make_service(
-            status=ServiceStatus.PUBLISHED,
-            diffusion_zone_type=AdminDivisionType.COUNTRY,
-            funding_labels=[allowed_funding_labels[0], allowed_funding_labels[1]],
-        )
-        service2 = make_service(
-            status=ServiceStatus.PUBLISHED,
-            diffusion_zone_type=AdminDivisionType.COUNTRY,
-            funding_labels=[allowed_funding_labels[1], allowed_funding_labels[2]],
-        )
-        make_service(
-            status=ServiceStatus.PUBLISHED,
-            diffusion_zone_type=AdminDivisionType.COUNTRY,
-            funding_labels=[allowed_funding_labels[3]],
-        )
-        response = self.client.get(
-            f"/search/?city={self.city1.code}&funding={allowed_funding_labels[1].value},{allowed_funding_labels[2].value}"
-        )
-        assert response.status_code == 200
-        assert len(response.data) == 4
-        assert len(response.data["services"]) == 2
-
-        response_slugs = [r["slug"] for r in response.data["services"]]
-        assert service1.slug in response_slugs
-        assert service2.slug in response_slugs
-
-    def test_funding_nomatch(self):
-        allowed_funding_labels = FundingLabel.objects.all()
-        make_service(
-            status=ServiceStatus.PUBLISHED,
-            diffusion_zone_type=AdminDivisionType.COUNTRY,
-            funding_labels=[allowed_funding_labels[0], allowed_funding_labels[1]],
-        )
-        make_service(
-            status=ServiceStatus.PUBLISHED,
-            diffusion_zone_type=AdminDivisionType.COUNTRY,
-            funding_labels=[allowed_funding_labels[1], allowed_funding_labels[2]],
-        )
-        response = self.client.get(
-            f"/search/?city={self.city1.code}&funding={allowed_funding_labels[3].value}"
-        )
-        assert response.status_code == 200
-        assert len(response.data) == 4
-        assert len(response.data["services"]) == 0
-
-    def test_find_service_with_requested_cat(self):
-        service = make_service(
-            status=ServiceStatus.PUBLISHED,
-            diffusion_zone_type=AdminDivisionType.COUNTRY,
-            categories="cat1",
-        )
-        response = self.client.get(f"/search/?city={self.city1.code}&cats=cat1")
-        assert response.status_code == 200
-        assert len(response.data) == 4
-        assert len(response.data["services"]) == 1
-        assert response.data["services"][0]["slug"] == service.slug
-
-    def test_find_service_with_requested_cats(self):
-        service_1 = make_service(
-            status=ServiceStatus.PUBLISHED,
-            diffusion_zone_type=AdminDivisionType.COUNTRY,
-            categories="cat1",
-        )
-        service_2 = make_service(
-            status=ServiceStatus.PUBLISHED,
-            diffusion_zone_type=AdminDivisionType.COUNTRY,
-            categories="cat2",
-        )
-        response = self.client.get(f"/search/?city={self.city1.code}&cats=cat1,cat2")
-        assert response.status_code == 200
-        assert len(response.data) == 4
-        assert len(response.data["services"]) == 2
-
-        response_slugs = sorted([s["slug"] for s in response.data["services"]])
-        assert response_slugs == sorted([service_1.slug, service_2.slug])
-
-    def test_find_service_with_requested_cats_exclude_one(self):
-        service_1 = make_service(
-            status=ServiceStatus.PUBLISHED,
-            diffusion_zone_type=AdminDivisionType.COUNTRY,
-            categories="cat1",
-        )
-        service_2 = make_service(
-            status=ServiceStatus.PUBLISHED,
-            diffusion_zone_type=AdminDivisionType.COUNTRY,
-            categories="cat2",
-        )
-        make_service(
-            status=ServiceStatus.PUBLISHED,
-            diffusion_zone_type=AdminDivisionType.COUNTRY,
-            categories="cat3",
-        )
-        response = self.client.get(f"/search/?city={self.city1.code}&cats=cat1,cat2")
-        assert response.status_code == 200
-        assert len(response.data) == 4
-        assert len(response.data["services"]) == 2
-
-        response_slugs = sorted([s["slug"] for s in response.data["services"]])
-        assert response_slugs == sorted([service_1.slug, service_2.slug])
-
-    def test_dont_find_service_without_requested_cat(self):
-        make_service(
-            status=ServiceStatus.PUBLISHED,
-            diffusion_zone_type=AdminDivisionType.COUNTRY,
-            categories="cat1",
-        )
-
-        response = self.client.get(f"/search/?city={self.city1.code}&cats=cat2")
-        assert response.status_code == 200
-        assert len(response.data) == 4
-        assert len(response.data["services"]) == 0
-
-    def test_find_service_with_requested_subcat(self):
-        service = make_service(
-            status=ServiceStatus.PUBLISHED,
-            diffusion_zone_type=AdminDivisionType.COUNTRY,
-            subcategories="cat1--sub1",
-        )
-        response = self.client.get(f"/search/?city={self.city1.code}&subs=cat1--sub1")
-        assert response.status_code == 200
-        assert len(response.data) == 4
-        assert len(response.data["services"]) == 1
-        assert response.data["services"][0]["slug"] == service.slug
-
-    def test_find_service_with_requested_subcats(self):
-        service_1 = make_service(
-            status=ServiceStatus.PUBLISHED,
-            diffusion_zone_type=AdminDivisionType.COUNTRY,
-            subcategories="cat1--sub1",
-        )
-        service_2 = make_service(
-            status=ServiceStatus.PUBLISHED,
-            diffusion_zone_type=AdminDivisionType.COUNTRY,
-            subcategories="cat1--sub2",
-        )
-        response = self.client.get(
-            f"/search/?city={self.city1.code}&subs=cat1--sub1,cat1--sub2"
-        )
-        assert response.status_code == 200
-        assert len(response.data) == 4
-        assert len(response.data["services"]) == 2
-
-        response_slugs = sorted([s["slug"] for s in response.data["services"]])
-        assert response_slugs == sorted([service_1.slug, service_2.slug])
-
-    def test_find_service_with_requested_subcats_different_cats(self):
-        service_1 = make_service(
-            status=ServiceStatus.PUBLISHED,
-            diffusion_zone_type=AdminDivisionType.COUNTRY,
-            subcategories="cat1--sub1",
-        )
-        service_2 = make_service(
-            status=ServiceStatus.PUBLISHED,
-            diffusion_zone_type=AdminDivisionType.COUNTRY,
-            subcategories="cat1--sub2",
-        )
-        service_3 = make_service(
-            status=ServiceStatus.PUBLISHED,
-            diffusion_zone_type=AdminDivisionType.COUNTRY,
-            subcategories="cat2--sub1",
-        )
-        make_service(
-            status=ServiceStatus.PUBLISHED,
-            diffusion_zone_type=AdminDivisionType.COUNTRY,
-            subcategories="cat2--sub2",
-        )
-        response = self.client.get(
-            f"/search/?city={self.city1.code}&subs=cat1--sub1,cat1--sub2,cat2--sub1"
-        )
-
-        assert response.status_code == 200
-        assert len(response.data) == 4
-        assert len(response.data["services"]) == 3
-
-        response_slugs = sorted([s["slug"] for s in response.data["services"]])
-        assert response_slugs == sorted(
-            [service_1.slug, service_2.slug, service_3.slug]
-        )
-
-    def test_find_service_with_requested_subcats_exclude_one(self):
-        service_1 = make_service(
-            status=ServiceStatus.PUBLISHED,
-            diffusion_zone_type=AdminDivisionType.COUNTRY,
-            subcategories="cat1--sub1",
-        )
-        service_2 = make_service(
-            status=ServiceStatus.PUBLISHED,
-            diffusion_zone_type=AdminDivisionType.COUNTRY,
-            subcategories="cat1--sub2",
-        )
-        make_service(
-            status=ServiceStatus.PUBLISHED,
-            diffusion_zone_type=AdminDivisionType.COUNTRY,
-            subcategories="cat1--sub3",
-        )
-        response = self.client.get(
-            f"/search/?city={self.city1.code}&subs=cat1--sub1,cat1--sub2"
-        )
-        assert response.status_code == 200
-        assert len(response.data) == 4
-        assert len(response.data["services"]) == 2
-
-        response_slugs = sorted([s["slug"] for s in response.data["services"]])
-        assert response_slugs == sorted([service_1.slug, service_2.slug])
-
-    def test_dont_find_service_without_requested_subcat(self):
-        make_service(
-            status=ServiceStatus.PUBLISHED,
-            diffusion_zone_type=AdminDivisionType.COUNTRY,
-            subcategories="cat1--sub1",
-        )
-
-        response = self.client.get(f"/search/?city={self.city1.code}&subs=cat1--sub2")
-        assert response.status_code == 200
-        assert len(response.data) == 4
-        assert len(response.data["services"]) == 0
-
-    def test_find_service_with_no_subcat_when_looking_for_the__other__subcat(self):
-        # On veut remonter les services sans sous-catégorie quand on interroge la
-        # sous-catégorie 'autres'
-        service = make_service(
-            status=ServiceStatus.PUBLISHED,
-            diffusion_zone_type=AdminDivisionType.COUNTRY,
-            categories="cat1",
-        )
-        response = self.client.get(f"/search/?city={self.city1.code}&subs=cat1--autre")
-        assert response.status_code == 200
-        assert len(response.data) == 4
-        assert len(response.data["services"]) == 1
-        assert response.data["services"][0]["slug"] == service.slug
-
-    def test_find_service_with_no_subcat_when_looking_for_the__other__subcat_2(
-        self,
-    ):
-        # On veut remonter les services sans sous-catégorie **de la même catégorie**
-        # quand on interroge la sous-catégorie 'autres'
-        service = make_service(
-            status=ServiceStatus.PUBLISHED,
-            diffusion_zone_type=AdminDivisionType.COUNTRY,
-            categories="cat1,cat2",
-            subcategories="cat2--sub1",
-        )
-        response = self.client.get(f"/search/?city={self.city1.code}&subs=cat1--autre")
-        assert response.status_code == 200
-        assert len(response.data) == 4
-        assert len(response.data["services"]) == 1
-        assert response.data["services"][0]["slug"] == service.slug
-
-    def test_dont_find_service_with_no_subcat_when_looking_for_any_subcat(self):
-        make_service(
-            status=ServiceStatus.PUBLISHED,
-            diffusion_zone_type=AdminDivisionType.COUNTRY,
-            categories="cat1",
-        )
-        response = self.client.get(f"/search/?city={self.city1.code}&subs=cat1--sub1")
-        assert response.status_code == 200
-        assert len(response.data) == 4
-        assert len(response.data["services"]) == 0
-
-    def test_find_cats_and_subcats_are_independant(self):
-        make_service(
-            status=ServiceStatus.PUBLISHED,
-            diffusion_zone_type=AdminDivisionType.COUNTRY,
-            categories="cat1",
-            subcategories="cat1--sub1",
-        )
-        make_service(
-            status=ServiceStatus.PUBLISHED,
-            diffusion_zone_type=AdminDivisionType.COUNTRY,
-            categories="cat2",
-            subcategories="cat2--sub1",
-        )
-        response = self.client.get(
-            f"/search/?city={self.city1.code}&cats=cat1&subs=cat2--sub1"
-        )
-        assert response.status_code == 200
-        assert len(response.data) == 4
-        assert len(response.data["services"]) == 2
-
-
 class ServiceSearchOrderingTestCase(APITestCase):
     def setUp(self):
         self.toulouse_center = Point(1.4436700, 43.6042600, srid=WGS84)
-        # Points à moins de 100km de Toulouse
-        self.point_in_toulouse = Point(
-            1.4187594455116272, 43.601528176416416, srid=WGS84
-        )
-        self.blagnac_center = Point(1.3939900, 43.6327600, srid=WGS84)
-        self.montauban_center = Point(
-            1.3573408017582829, 44.022187843162136, srid=WGS84
-        )
-
-        # Points à plus de 100km de Toulouse
-        self.rocamadour_center = Point(
-            1.6197328621667728, 44.79914551756315, srid=WGS84
-        )
-        self.paris_center = Point(2.349014, 48.864716, srid=WGS84)
-
         region = baker.make("decoupage_administratif.Region", code="076")
         dept = baker.make(
             "decoupage_administratif.Department", region=region.code, code="31"
@@ -2551,7 +1887,6 @@ class ServiceSearchOrderingTestCase(APITestCase):
             region=region.code,
             center=self.toulouse_center,
         )
-
         self.di_client = FakeDataInclusionClient()
         self.patcher = mock.patch("dora.data_inclusion.di_client_factory")
         self.mock_di_client_factory = self.patcher.start()
@@ -2561,248 +1896,106 @@ class ServiceSearchOrderingTestCase(APITestCase):
         self.patcher.stop()
 
     def test_on_site_first(self):
-        self.assertEqual(Service.objects.all().count(), 0)
-        service1 = make_service(
-            slug="s1",
-            status=ServiceStatus.PUBLISHED,
-            diffusion_zone_type=AdminDivisionType.CITY,
-            diffusion_zone_details="31555",
-            geom=self.point_in_toulouse,
+        service1 = make_di_service_data(
+            modes_accueil=[ModeAccueil.EN_PRESENTIEL],
+            zone_eligibilite="31555",
         )
-        service1.location_kinds.set(
-            [LocationKind.objects.get(value=ModeAccueil.EN_PRESENTIEL)]
+        service2 = make_di_service_data(
+            modes_accueil=[ModeAccueil.A_DISTANCE],
+            zone_eligibilite="31555",
         )
-        service2 = make_service(
-            slug="s2",
-            status=ServiceStatus.PUBLISHED,
-            diffusion_zone_type=AdminDivisionType.CITY,
-            diffusion_zone_details="31555",
-            geom=self.point_in_toulouse,
+        service3 = make_di_service_data(
+            modes_accueil=[ModeAccueil.EN_PRESENTIEL],
+            zone_eligibilite="31555",
         )
-        service2.location_kinds.set(
-            [LocationKind.objects.get(value=ModeAccueil.A_DISTANCE)]
-        )
-
-        service3 = make_service(
-            slug="s3",
-            status=ServiceStatus.PUBLISHED,
-            diffusion_zone_type=AdminDivisionType.CITY,
-            diffusion_zone_details="31555",
-            geom=self.point_in_toulouse,
-        )
-        service3.location_kinds.set(
-            [LocationKind.objects.get(value=ModeAccueil.EN_PRESENTIEL)]
-        )
+        self.di_client.services = [service1, service2, service3]
 
         response = self.client.get("/search/?city=31555")
-        assert response.data["services"][0]["slug"] in [service1.slug, service3.slug]
-        assert response.data["services"][1]["slug"] in [service1.slug, service3.slug]
-        assert response.data["services"][2]["slug"] == service2.slug
+
+        assert response.data["services"][0]["slug"] in [service1["id"], service3["id"]]
+        assert response.data["services"][1]["slug"] in [service1["id"], service3["id"]]
+        assert response.data["services"][2]["slug"] == service2["id"]
 
     def test_on_site_nearest_first(self):
-        self.assertEqual(Service.objects.all().count(), 0)
-        service1 = make_service(
-            slug="s1",
-            status=ServiceStatus.PUBLISHED,
-            diffusion_zone_type=AdminDivisionType.DEPARTMENT,
-            diffusion_zone_details="31",
-            geom=self.point_in_toulouse,
+        service1 = make_di_service_data(
+            modes_accueil=[ModeAccueil.EN_PRESENTIEL],
+            zone_eligibilite="31555",
+            distance=1,
         )
-        service1.location_kinds.set(
-            [LocationKind.objects.get(value=ModeAccueil.EN_PRESENTIEL)]
+        service2 = make_di_service_data(
+            modes_accueil=[ModeAccueil.EN_PRESENTIEL],
+            zone_eligibilite="31555",
+            distance=2,
         )
-
-        service2 = make_service(
-            slug="s2",
-            status=ServiceStatus.PUBLISHED,
-            diffusion_zone_type=AdminDivisionType.DEPARTMENT,
-            diffusion_zone_details="31",
-            geom=self.blagnac_center,
+        service3 = make_di_service_data(
+            modes_accueil=[ModeAccueil.EN_PRESENTIEL],
+            zone_eligibilite="31555",
+            distance=1,
         )
-        service2.location_kinds.set(
-            [LocationKind.objects.get(value=ModeAccueil.EN_PRESENTIEL)]
-        )
-
-        service3 = make_service(
-            slug="s3",
-            status=ServiceStatus.PUBLISHED,
-            diffusion_zone_type=AdminDivisionType.DEPARTMENT,
-            diffusion_zone_details="31",
-            geom=self.toulouse_center,
-        )
-        service3.location_kinds.set(
-            [LocationKind.objects.get(value=ModeAccueil.EN_PRESENTIEL)]
-        )
+        self.di_client.services = [service1, service2, service3]
 
         response = self.client.get("/search/?city=31555")
 
-        assert response.data["services"][0]["slug"] in [service1.slug, service3.slug]
-        assert response.data["services"][1]["slug"] in [service1.slug, service3.slug]
-        assert response.data["services"][2]["slug"] == service2.slug
-
-    def test_distance_is_correct(self):
-        self.assertEqual(Service.objects.all().count(), 0)
-        service1 = make_service(
-            slug="s1",
-            status=ServiceStatus.PUBLISHED,
-            diffusion_zone_type=AdminDivisionType.COUNTRY,
-            geom=self.point_in_toulouse,
-        )
-        service1.location_kinds.set(
-            [LocationKind.objects.get(value=ModeAccueil.EN_PRESENTIEL)]
-        )
-
-        service2 = make_service(
-            slug="s2",
-            status=ServiceStatus.PUBLISHED,
-            diffusion_zone_type=AdminDivisionType.COUNTRY,
-            geom=self.montauban_center,
-        )
-        service2.location_kinds.set(
-            [LocationKind.objects.get(value=ModeAccueil.EN_PRESENTIEL)]
-        )
-
-        response = self.client.get("/search/?city=31555")
-        self.assertTrue(40 < response.data["services"][1]["distance"] < 50)
-
-    def test_distance_no_more_than_100km(self):
-        self.assertEqual(Service.objects.all().count(), 0)
-        service1 = make_service(
-            slug="s1",
-            status=ServiceStatus.PUBLISHED,
-            diffusion_zone_type=AdminDivisionType.COUNTRY,
-            geom=self.point_in_toulouse,
-        )
-        service1.location_kinds.set(
-            [LocationKind.objects.get(value=ModeAccueil.EN_PRESENTIEL)]
-        )
-
-        service2 = make_service(
-            slug="s2",
-            status=ServiceStatus.PUBLISHED,
-            diffusion_zone_type=AdminDivisionType.COUNTRY,
-            geom=self.rocamadour_center,
-        )
-        service2.location_kinds.set(
-            [LocationKind.objects.get(value=ModeAccueil.EN_PRESENTIEL)]
-        )
-
-        response = self.client.get("/search/?city=31555")
-        assert len(response.data) == 4
-        assert len(response.data["services"]) == 1
+        assert response.data["services"][0]["slug"] in [service1["id"], service3["id"]]
+        assert response.data["services"][1]["slug"] in [service1["id"], service3["id"]]
+        assert response.data["services"][2]["slug"] == service2["id"]
 
     def test_displayed_if_remote_and_onsite_more_than_100km(self):
-        self.assertEqual(Service.objects.all().count(), 0)
-        service = make_service(
-            slug="s1",
-            status=ServiceStatus.PUBLISHED,
-            diffusion_zone_type=AdminDivisionType.COUNTRY,
-            geom=self.rocamadour_center,
+        service = make_di_service_data(
+            modes_accueil=[ModeAccueil.EN_PRESENTIEL, ModeAccueil.A_DISTANCE],
+            zone_eligibilite="31555",
+            distance=150,
         )
-        service.location_kinds.set(
-            [
-                LocationKind.objects.get(value=ModeAccueil.EN_PRESENTIEL),
-                LocationKind.objects.get(value=ModeAccueil.A_DISTANCE),
-            ]
-        )
+        self.di_client.services = [service]
 
         response = self.client.get("/search/?city=31555")
         assert len(response.data) == 4
         assert len(response.data["services"]) == 1
 
     def test_displayed_only_once_if_remote_and_onsite_less_than_100km(self):
-        self.assertEqual(Service.objects.all().count(), 0)
-        service = make_service(
-            slug="s1",
-            status=ServiceStatus.PUBLISHED,
-            diffusion_zone_type=AdminDivisionType.COUNTRY,
-            geom=self.point_in_toulouse,
+        service = make_di_service_data(
+            modes_accueil=[ModeAccueil.EN_PRESENTIEL, ModeAccueil.A_DISTANCE],
+            zone_eligibilite="31555",
+            distance=0,
         )
-        service.location_kinds.set(
-            [
-                LocationKind.objects.get(value=ModeAccueil.EN_PRESENTIEL),
-                LocationKind.objects.get(value=ModeAccueil.A_DISTANCE),
-            ]
-        )
+        self.di_client.services = [service]
 
         response = self.client.get("/search/?city=31555")
         assert len(response.data) == 4
         assert len(response.data["services"]) == 1
 
     def test_intercalate_remote(self):
-        self.assertEqual(Service.objects.all().count(), 0)
-        template = {
-            "status": ServiceStatus.PUBLISHED,
-            "diffusion_zone_type": AdminDivisionType.DEPARTMENT,
-            "diffusion_zone_details": "31",
-            "geom": self.toulouse_center,
-        }
-        service1 = make_service(
-            slug="s1", **template, modification_date=timezone.now() - timedelta(days=1)
-        )
-        service1.location_kinds.set(
-            [LocationKind.objects.get(value=ModeAccueil.EN_PRESENTIEL)]
-        )
-        service2 = make_service(
-            slug="s2", **template, modification_date=timezone.now() - timedelta(days=2)
-        )
-        service2.location_kinds.set(
-            [LocationKind.objects.get(value=ModeAccueil.EN_PRESENTIEL)]
-        )
-        service3 = make_service(
-            slug="s3", **template, modification_date=timezone.now() - timedelta(days=3)
-        )
-        service3.location_kinds.set(
-            [LocationKind.objects.get(value=ModeAccueil.EN_PRESENTIEL)]
-        )
-        service4 = make_service(
-            slug="s4", **template, modification_date=timezone.now() - timedelta(days=4)
-        )
-        service4.location_kinds.set(
-            [LocationKind.objects.get(value=ModeAccueil.EN_PRESENTIEL)]
-        )
-        service5 = make_service(
-            slug="s5", **template, modification_date=timezone.now() - timedelta(days=5)
-        )
-        service5.location_kinds.set(
-            [LocationKind.objects.get(value=ModeAccueil.A_DISTANCE)]
-        )
-        service6 = make_service(
-            slug="s6", **template, modification_date=timezone.now() - timedelta(days=6)
-        )
-        service6.location_kinds.set(
-            [LocationKind.objects.get(value=ModeAccueil.A_DISTANCE)]
-        )
+        today = timezone.localdate()
+        on_site_services = [
+            make_di_service_data(
+                date_maj=today - timedelta(days=i),
+                modes_accueil=[ModeAccueil.EN_PRESENTIEL],
+                zone_eligibilite="31555",
+            )
+            for i in range(1, 5)
+        ]
+        remote_services = [
+            make_di_service_data(
+                date_maj=today - timedelta(days=i),
+                modes_accueil=[ModeAccueil.A_DISTANCE],
+                zone_eligibilite="31555",
+            )
+            for i in range(1, 3)
+        ]
+        all_services = on_site_services + remote_services
+        random.shuffle(all_services)
+        self.di_client.services = all_services
 
         response = self.client.get("/search/?city=31555")
-        # on s'attend à ce que les services soient classés par date de modification décroissante
-        # avec un service à distance sur 3 intercalé
-        assert response.data["services"][0]["slug"] in [
-            service1.slug,
-            service2.slug,
-            service3.slug,
-            service4.slug,
-        ]
-        assert response.data["services"][1]["slug"] in [
-            service1.slug,
-            service2.slug,
-            service3.slug,
-            service4.slug,
-        ]
-        assert response.data["services"][2]["slug"] in [service5.slug, service6.slug]
-        assert response.data["services"][3]["slug"] in [
-            service1.slug,
-            service2.slug,
-            service3.slug,
-            service4.slug,
-        ]
-        assert response.data["services"][4]["slug"] in [
-            service1.slug,
-            service2.slug,
-            service3.slug,
-            service4.slug,
-        ]
-        assert response.data["services"][5]["slug"] in [service5.slug, service6.slug]
+
+        on_site_slugs = [s["id"] for s in on_site_services]
+        remote_slugs = [s["id"] for s in remote_services]
+        assert response.data["services"][0]["slug"] in on_site_slugs
+        assert response.data["services"][1]["slug"] in on_site_slugs
+        assert response.data["services"][2]["slug"] in remote_slugs
+        assert response.data["services"][3]["slug"] in on_site_slugs
+        assert response.data["services"][4]["slug"] in on_site_slugs
+        assert response.data["services"][5]["slug"] in remote_slugs
 
 
 class ServiceSyncTestCase(APITestCase):

--- a/back/dora/services/tests/test_services_saved_searchs.py
+++ b/back/dora/services/tests/test_services_saved_searchs.py
@@ -3,6 +3,7 @@ from datetime import timedelta
 from io import StringIO
 from unittest import mock
 
+import requests
 from django.contrib.gis.geos import Point
 from django.core import mail
 from django.core.management import call_command
@@ -374,6 +375,40 @@ class ServiceSavedSearchNotificationTestCase(APITestCase):
             "[LOCAL] Il y a de nouveaux services correspondant à votre alerte",
         )
         self.assertIn(f"<strong>{self.service_name}</strong>", mail.outbox[0].body)
+
+    def test_di_unavailable_does_not_crash_nor_update_dates(self):
+        # ÉTANT DONNÉ un utilisateur avec une notification mensuelle envoyée à J-40
+        user = baker.make("users.User", is_valid=True)
+        last_notification_date = timezone.now() - timedelta(days=40)
+        saved_search = baker.make(
+            "SavedSearch",
+            user=user,
+            frequency=SavedSearchFrequency.MONTHLY,
+            city_label=SAVE_SEARCH_ARGS.get("city_label"),
+            city_code=SAVE_SEARCH_ARGS.get("city_code"),
+            last_notification_date=last_notification_date,
+        )
+
+        # ET data·inclusion indisponible
+        class FaultyDataInclusionClient:
+            def search_services(self, **kwargs):
+                raise requests.ConnectionError()
+
+        self.mock_di_client_factory.return_value = FaultyDataInclusionClient()
+
+        # QUAND j'envoie les notifications
+        # ALORS la commande n'échoue pas
+        self.call_command()
+
+        # ET aucun e-mail n'est envoyé
+        self.assertEqual(len(mail.outbox), 0)
+
+        # ET la date de dernière notification n'est pas mise à jour, afin de
+        # réessayer au prochain passage
+        saved_search.refresh_from_db()
+        self.assertEqual(
+            saved_search.last_notification_date, last_notification_date.date()
+        )
 
     def test_get_no_notification_location(self):
         # ÉTANT DONNÉ un utilisateur avec une notification mensuelle envoyée à J-40

--- a/back/dora/services/tests/test_services_saved_searchs.py
+++ b/back/dora/services/tests/test_services_saved_searchs.py
@@ -1,3 +1,4 @@
+import random
 from datetime import timedelta
 from io import StringIO
 from unittest import mock
@@ -11,7 +12,7 @@ from rest_framework.test import APITestCase
 
 from dora.core.constants import WGS84
 from dora.core.test_utils import make_service
-from dora.data_inclusion.test_utils import FakeDataInclusionClient
+from dora.data_inclusion.test_utils import FakeDataInclusionClient, make_di_service_data
 from dora.decoupage_administratif.models import (
     AdminDivisionType,
     City,
@@ -23,7 +24,7 @@ from dora.services.management.commands.send_saved_searches_notifications import 
     get_saved_search_notifications_to_send,
 )
 
-from ..models import SavedSearch, SavedSearchFrequency
+from ..models import SavedSearch, SavedSearchFrequency, ServiceSubCategory
 
 SAVE_SEARCH_ARGS = {
     "category": "choisir-un-metier",
@@ -202,6 +203,33 @@ class ServiceSavedSearchNotificationTestCase(APITestCase):
     def call_command(self):
         call_command("send_saved_searches_notifications", stdout=StringIO())
 
+    def setup_dora_service_in_di(self, **kwargs):
+        service = make_service(**kwargs)
+        di_kwargs = {}
+        subs = kwargs.get("subcategories", "").split(",")
+        cats = kwargs.get("categories", "").split(",")
+        thematiques = []
+        thematiques.extend(subs)
+        for cat in cats:
+            if not any(sub.startswith(cat) for sub in subs):
+                thematiques.extend(
+                    ServiceSubCategory.objects.filter(
+                        value__startswith=f"{cat}--"
+                    ).values_list("value", flat=True)
+                )
+        di_kwargs["thematiques"] = thematiques
+        if kinds := kwargs.get("kinds"):
+            di_kwargs["type"] = random.choice(kinds).value
+        if fee := kwargs.get("fee_condition"):
+            di_kwargs["frais"] = fee.value
+        di_service = make_di_service_data(
+            source="dora",
+            id=f"dora--{service.pk}",
+            zone_eligibilite=kwargs.get("diffusion_zone_details"),
+            **di_kwargs,
+        )
+        self.di_client.services.append(di_service)
+
     def test_get_monthly_saved_searches(self):
         # ÉTANT DONNÉ un utilisateur avec deux notifications mensuelles
         # envoyée à J-15 puis J-40
@@ -328,7 +356,7 @@ class ServiceSavedSearchNotificationTestCase(APITestCase):
         )
 
         # ET un service mis à jour à J-20
-        make_service(
+        self.setup_dora_service_in_di(
             name=self.service_name,
             status=ServiceStatus.PUBLISHED,
             diffusion_zone_type=AdminDivisionType.CITY,
@@ -360,7 +388,7 @@ class ServiceSavedSearchNotificationTestCase(APITestCase):
         )
 
         # ET un service mis à jour à J-60
-        make_service(
+        self.setup_dora_service_in_di(
             name=self.service_name,
             status=ServiceStatus.PUBLISHED,
             diffusion_zone_type=AdminDivisionType.CITY,
@@ -390,7 +418,7 @@ class ServiceSavedSearchNotificationTestCase(APITestCase):
         )
 
         # ET un service mis à jour à J-20 lié à la même catégorie
-        make_service(
+        self.setup_dora_service_in_di(
             name=self.service_name,
             status=ServiceStatus.PUBLISHED,
             categories="cat1",
@@ -434,7 +462,7 @@ class ServiceSavedSearchNotificationTestCase(APITestCase):
         savedSearch.subcategories.set([sub_category, sub_category_2])
 
         # ET un service mis à jour à J-20 lié à la même catégorie et sous-catégories
-        make_service(
+        self.setup_dora_service_in_di(
             name=self.service_name,
             status=ServiceStatus.PUBLISHED,
             categories="cat1",
@@ -486,7 +514,7 @@ class ServiceSavedSearchNotificationTestCase(APITestCase):
         savedSearch.kinds.set([kind, kind_2])
 
         # ET un service mis à jour à J-20 lié à la même catégorie, sous-catégories et types de service
-        make_service(
+        self.setup_dora_service_in_di(
             name=self.service_name,
             status=ServiceStatus.PUBLISHED,
             categories="cat1",
@@ -546,7 +574,7 @@ class ServiceSavedSearchNotificationTestCase(APITestCase):
         savedSearch.fees.set([fee])
 
         # ET un service mis à jour à J-20 lié à la même catégorie, sous-catégories, types de service et frais à charge
-        make_service(
+        self.setup_dora_service_in_di(
             name=self.service_name,
             status=ServiceStatus.PUBLISHED,
             categories="cat1",
@@ -594,7 +622,7 @@ class ServiceSavedSearchNotificationTestCase(APITestCase):
         )
 
         # ET deux services mis à jour à J-20 liés à la même catégorie mais avec un seul service modifié récemment
-        make_service(
+        self.setup_dora_service_in_di(
             name=self.service_name,
             status=ServiceStatus.PUBLISHED,
             categories="cat1",
@@ -602,7 +630,7 @@ class ServiceSavedSearchNotificationTestCase(APITestCase):
             publication_date=timezone.now() - timedelta(days=20),
             diffusion_zone_details=SAVE_SEARCH_ARGS.get("city_code"),
         )
-        make_service(
+        self.setup_dora_service_in_di(
             name="service_2",
             status=ServiceStatus.PUBLISHED,
             categories="cat1",
@@ -645,7 +673,7 @@ class ServiceSavedSearchNotificationTestCase(APITestCase):
         savedSearch.fees.set([fee1])
 
         # ET un service mis à jour à J-20 lié à la même catégorie, sous-catégories, types de service et frais à charge
-        make_service(
+        self.setup_dora_service_in_di(
             name=self.service_name,
             status=ServiceStatus.PUBLISHED,
             categories="cat1",
@@ -668,7 +696,9 @@ class ServiceSavedSearchNotificationTestCase(APITestCase):
         # et deux sous-catégories et deux types de services et un frais à charge
         user = baker.make("users.User", is_valid=True)
         category = baker.make("ServiceCategory", value="cat1", label="cat1")
+        baker.make("ServiceSubCategory", value="cat1--sub1", label="cat1--sub1")
         baker.make("ServiceCategory", value="cat2", label="cat2")
+        baker.make("ServiceSubCategory", value="cat2--sub1", label="cat2--sub1")
 
         baker.make(
             "SavedSearch",
@@ -681,7 +711,7 @@ class ServiceSavedSearchNotificationTestCase(APITestCase):
         )
 
         # ET un service mis à jour à J-20 lié à la même catégorie, sous-catégories, types de service et frais à charge
-        make_service(
+        self.setup_dora_service_in_di(
             name=self.service_name,
             status=ServiceStatus.PUBLISHED,
             categories="cat2",
@@ -720,7 +750,7 @@ class ServiceSavedSearchNotificationTestCase(APITestCase):
         savedSearch.subcategories.set([sub_category_1])
 
         # ET un service mis à jour à J-20 lié à la même catégorie, sous-catégories, types de service et frais à charge
-        make_service(
+        self.setup_dora_service_in_di(
             name=self.service_name,
             status=ServiceStatus.PUBLISHED,
             categories="cat1",

--- a/back/dora/services/utils.py
+++ b/back/dora/services/utils.py
@@ -14,7 +14,6 @@ from dora.decoupage_administratif.models import (
     Department,
     Region,
 )
-from dora.decoupage_administratif.utils import arrdt_to_main_insee_code
 from dora.services.enums import ServiceStatus
 
 SYNC_FIELDS = [
@@ -142,33 +141,6 @@ def update_sync_checksum(service):
 
     result = md5.hexdigest()
     return result
-
-
-def filter_services_by_city_code(services, city_code):
-    # Si la requete entrante contient un code insee d'arrondissement,
-    # on le convertit pour récupérer le code de la commune entière.
-    city_code = arrdt_to_main_insee_code(city_code)
-    city = get_object_or_404(City, pk=city_code)
-
-    return services.filter(
-        Q(diffusion_zone_type=AdminDivisionType.COUNTRY)
-        | (
-            Q(diffusion_zone_type=AdminDivisionType.CITY)
-            & Q(diffusion_zone_details=city.code)
-        )
-        | (
-            Q(diffusion_zone_type=AdminDivisionType.EPCI)
-            & Q(diffusion_zone_details=city.epci)
-        )
-        | (
-            Q(diffusion_zone_type=AdminDivisionType.DEPARTMENT)
-            & Q(diffusion_zone_details=city.department)
-        )
-        | (
-            Q(diffusion_zone_type=AdminDivisionType.REGION)
-            & Q(diffusion_zone_details=city.region)
-        )
-    )
 
 
 def filter_services_by_department(services, dept_code):

--- a/back/dora/services/views.py
+++ b/back/dora/services/views.py
@@ -918,7 +918,6 @@ def search_services_view(request):
     kinds = request.GET.get("kinds")
     fees = request.GET.get("fees")
     locs = request.GET.get("locs")
-    funding = request.GET.get("funding")
     lat = request.GET.get("lat")
     lon = request.GET.get("lon")
 
@@ -927,7 +926,6 @@ def search_services_view(request):
     kinds_list = kinds.split(",") if kinds is not None else None
     fees_list = fees.split(",") if fees is not None else None
     locs_list = locs.split(",") if locs is not None else None
-    funding_labels_list = funding.split(",") if funding is not None else None
     lat = float(lat) if lat else None
     lon = float(lon) if lon else None
 
@@ -942,13 +940,11 @@ def search_services_view(request):
         request=request,
         di_client=di_client,
         city_code=city_code,
-        city=city,
         categories=categories_list,
         subcategories=subcategories_list,
         kinds=kinds_list,
         fees=fees_list,
         location_kinds=locs_list,
-        funding_labels=funding_labels_list,
         lat=lat,
         lon=lon,
     )


### PR DESCRIPTION
Lorsque d·i n’est pas disponible, mieux vaut l’indiquer plutôt que de retourner un sous-ensemble des résultats, qui risque d’induire l’utilisateur en erreur.

Les arguments `city` et `funding_labels` de `services.search.search_services` ne sont pas disponibles dans la recherche d·i et n’étaient utiles que pour la recherche DORA.
Comme les recherches sauvegardées (alertes) ne peuvent plus filtrer sur ces éléments, leur code a pu être légèrement simplifié.

La suite `ServiceSearchTestCase` a été retirée, car elle testait la recherche de services DORA uniquement.

La plupart des tests restants étaient construits pour la recherche de services DORA. Afin de les préserver, des réponses type d·i ont été créées à partir des services DORA.

Enfin, `ServiceSavedSearchNotificationTestCase::test_get_create_notification_with_invalid_category` a été légèrement modifié pour ajouter des sous-catégories, car une catégorie seule ne peut pas correspondre à une thématique d·i.
