### PR TITLE
fix(front): éviter le double report des erreurs inattendues à Sentry

### DIFF
--- a/front/src/hooks.client.ts
+++ b/front/src/hooks.client.ts
@@ -6,6 +6,7 @@ import { setupFetchInterceptor } from "$lib/utils/fetch-interceptor";
 import {
   STALE_CHUNK_ERROR_MESSAGES,
   STALE_CHUNK_RELOAD_MESSAGE,
+  UNEXPECTED_ERROR_MESSAGE,
 } from "$lib/consts";
 
 setupFetchInterceptor();
@@ -38,7 +39,7 @@ export const handleError: HandleClientError = Sentry.handleErrorWithSentry(
     const message =
       ENVIRONMENT === "local" && error instanceof Error
         ? error.message
-        : "Erreur inattendue";
+        : UNEXPECTED_ERROR_MESSAGE;
 
     return {
       message,

--- a/front/src/hooks.server.ts
+++ b/front/src/hooks.server.ts
@@ -7,6 +7,7 @@ import * as Sentry from "@sentry/sveltekit";
 import { RetryAfterRateLimiter } from "sveltekit-rate-limiter/server";
 
 import { ENVIRONMENT, SENTRY_DSN } from "$lib/env";
+import { UNEXPECTED_ERROR_MESSAGE } from "$lib/consts";
 import { handleInboundNexusAutoLogin } from "$lib/utils/nexus";
 
 import { MAX_REQUESTS_PER_MINUTE } from "$env/static/private";
@@ -30,7 +31,7 @@ export const handleError: HandleServerError = Sentry.handleErrorWithSentry(
     const message =
       ENVIRONMENT === "local" && err instanceof Error
         ? err.message
-        : "Erreur inattendue";
+        : UNEXPECTED_ERROR_MESSAGE;
 
     return {
       message,

--- a/front/src/lib/consts.ts
+++ b/front/src/lib/consts.ts
@@ -53,3 +53,8 @@ export const STALE_CHUNK_ERROR_MESSAGES = [
 // Marqueur retourné par le handleError client lors du rechargement automatique
 // après un déploiement, pour que la page d'erreur ne le remonte pas à Sentry
 export const STALE_CHUNK_RELOAD_MESSAGE = "stale-chunk-reload";
+
+// Message générique retourné par les handleError (client et serveur) en prod, en
+// remplacement du message réel. L'erreur d'origine est déjà rapportée à Sentry par
+// handleErrorWithSentry ; ce marqueur permet à la page d'erreur de ne pas la re-logger.
+export const UNEXPECTED_ERROR_MESSAGE = "Erreur inattendue";

--- a/front/src/routes/+error.svelte
+++ b/front/src/routes/+error.svelte
@@ -1,30 +1,11 @@
 <script lang="ts">
   import { page } from "$app/stores";
   import CenteredGrid from "$lib/components/display/centered-grid.svelte";
-  import {
-    RATE_LIMIT_MESSAGE,
-    STALE_CHUNK_RELOAD_MESSAGE,
-    UNEXPECTED_ERROR_MESSAGE,
-  } from "$lib/consts";
-  import { logException } from "$lib/utils/logger";
-  import { onMount } from "svelte";
+  import { RATE_LIMIT_MESSAGE } from "$lib/consts";
 
   const notFound = $page.status === 404;
   const forbidden = $page.status === 403;
   const rateLimit = $page.status === 429;
-  // La page va être rechargée automatiquement (voir hooks.client.ts),
-  // inutile de remonter l'erreur à Sentry
-  const staleChunkReload = $page.error?.message === STALE_CHUNK_RELOAD_MESSAGE;
-  // Les erreurs inattendues sont déjà rapportées à Sentry par handleErrorWithSentry
-  // (hooks.client/server.ts), qui masque leur message par UNEXPECTED_ERROR_MESSAGE.
-  // Les re-logger ici créerait un doublon regroupé dans un unique bucket de bruit.
-  const alreadyReported = $page.error?.message === UNEXPECTED_ERROR_MESSAGE;
-
-  onMount(() => {
-    if (!notFound && !staleChunkReload && !alreadyReported) {
-      logException(new Error($page.error?.message ?? String($page.status)));
-    }
-  });
 </script>
 
 <svelte:head>

--- a/front/src/routes/+error.svelte
+++ b/front/src/routes/+error.svelte
@@ -1,7 +1,11 @@
 <script lang="ts">
   import { page } from "$app/stores";
   import CenteredGrid from "$lib/components/display/centered-grid.svelte";
-  import { RATE_LIMIT_MESSAGE, STALE_CHUNK_RELOAD_MESSAGE } from "$lib/consts";
+  import {
+    RATE_LIMIT_MESSAGE,
+    STALE_CHUNK_RELOAD_MESSAGE,
+    UNEXPECTED_ERROR_MESSAGE,
+  } from "$lib/consts";
   import { logException } from "$lib/utils/logger";
   import { onMount } from "svelte";
 
@@ -11,9 +15,13 @@
   // La page va être rechargée automatiquement (voir hooks.client.ts),
   // inutile de remonter l'erreur à Sentry
   const staleChunkReload = $page.error?.message === STALE_CHUNK_RELOAD_MESSAGE;
+  // Les erreurs inattendues sont déjà rapportées à Sentry par handleErrorWithSentry
+  // (hooks.client/server.ts), qui masque leur message par UNEXPECTED_ERROR_MESSAGE.
+  // Les re-logger ici créerait un doublon regroupé dans un unique bucket de bruit.
+  const alreadyReported = $page.error?.message === UNEXPECTED_ERROR_MESSAGE;
 
   onMount(() => {
-    if (!notFound && !staleChunkReload) {
+    if (!notFound && !staleChunkReload && !alreadyReported) {
       logException(new Error($page.error?.message ?? String($page.status)));
     }
   });


### PR DESCRIPTION
`+error.svelte` reporte à Sentry les erreurs inattendues déjà reportées par `handleErrorWithSentry`. Suppression de ce doublon.

https://inclusion.sentry.io/issues/112661553/?project=4509599011045456&query=is%3Aunresolved&referrer=issue-stream