### PR TITLE
feat(orientations): Ajout d'une commande d'export des orientations Les Emplois

### DIFF
--- a/back/dora/orientations/management/commands/export_emplois_orientations.py
+++ b/back/dora/orientations/management/commands/export_emplois_orientations.py
@@ -1,0 +1,104 @@
+import json
+
+from django.utils import timezone
+
+from dora.core.commands import BaseCommand
+from dora.orientations.models import Orientation
+
+
+def _isoformat(value):
+    return value.isoformat() if value else None
+
+
+def _service_id(orientation: Orientation) -> str:
+    # On reconstruit l'identifiant de service tel que Les Emplois l'avait fourni :
+    # un service DORA (converti en FK à la création) redevient « dora--<uuid> »,
+    # sinon on conserve le `di_service_id` d'origine.
+    # Même logique que `OrientationViewSet.perform_create` et
+    # `EmploisOrientationCreateSerializer.to_representation`.
+    if orientation.service_id:
+        return f"dora--{orientation.service_id}"
+    return orientation.di_service_id
+
+
+class Command(BaseCommand):
+    help = (
+        "Exporte au format JSON toutes les orientations émises par Les Emplois "
+        "afin qu'elles puissent être réimportées dans Les Emplois."
+    )
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--output",
+            type=str,
+            help="Chemin du fichier JSON de sortie (par défaut : généré automatiquement)",
+        )
+
+    def _serialize_orientation(self, orientation: Orientation) -> dict:
+        emplois_data = orientation.emplois_orientation_data
+        return {
+            # Identifiants Les Emplois transmis à la création de l'orientation et
+            # stockés tels quels : ils permettent à Les Emplois de rattacher
+            # l'orientation à ses propres objets lors du réimport.
+            "emplois_sync_uid": str(emplois_data.emplois_sync_uid),
+            "beneficiary_id": str(emplois_data.beneficiary_id),
+            "prescriber_id": str(emplois_data.prescriber_id)
+            if emplois_data.prescriber_id
+            else None,
+            "structure_id": str(emplois_data.structure_id),
+            "service_id": _service_id(orientation),
+            # Cycle de vie
+            "status": orientation.status,
+            "creation_date": _isoformat(orientation.creation_date),
+            "processing_date": _isoformat(orientation.processing_date),
+            # Bénéficiaire
+            "beneficiary_contact_preferences": orientation.beneficiary_contact_preferences,
+            "beneficiary_other_contact_method": orientation.beneficiary_other_contact_method,
+            "beneficiary_availability": _isoformat(
+                orientation.beneficiary_availability
+            ),
+            "beneficiary_attachments": orientation.beneficiary_attachments,
+            # Référent
+            "referent_last_name": orientation.referent_last_name,
+            "referent_first_name": orientation.referent_first_name,
+            "referent_email": orientation.referent_email,
+            "referent_phone": orientation.referent_phone,
+            # Demande
+            "requirements": orientation.requirements,
+            "situation": orientation.situation,
+            "situation_other": orientation.situation_other,
+            "orientation_reasons": orientation.orientation_reasons,
+            "duration_weekly_hours": orientation.duration_weekly_hours,
+            "duration_weeks": orientation.duration_weeks,
+            "data_protection_commitment": orientation.data_protection_commitment,
+        }
+
+    def handle(self, *args, **options):
+        orientations = (
+            Orientation.objects.emplois()
+            .select_related("emplois_orientation_data", "service")
+            .order_by("pk")
+        )
+
+        data = [
+            self._serialize_orientation(orientation) for orientation in orientations
+        ]
+
+        output_file = (
+            options["output"]
+            or f"emplois_orientations_export_{timezone.now().strftime('%Y%m%d_%H%M%S')}.json"
+        )
+
+        with open(output_file, "w", encoding="utf-8") as json_file:
+            json.dump(data, json_file, ensure_ascii=False, indent=2)
+
+        self.logger.info(
+            "%s orientation(s) Les Emplois exportée(s) dans %s.",
+            len(data),
+            output_file,
+        )
+        self.stdout.write(
+            self.style.SUCCESS(
+                f"{len(data)} orientation(s) Les Emplois exportée(s) dans : {output_file}"
+            )
+        )

--- a/back/dora/orientations/management/commands/export_emplois_orientations.py
+++ b/back/dora/orientations/management/commands/export_emplois_orientations.py
@@ -82,11 +82,6 @@ class Command(BaseCommand):
                 data, json_file, cls=DjangoJSONEncoder, ensure_ascii=False, indent=2
             )
 
-        self.logger.info(
-            "%s orientation(s) Les Emplois exportée(s) dans %s.",
-            len(data),
-            output_file,
-        )
         self.stdout.write(
             self.style.SUCCESS(
                 f"{len(data)} orientation(s) Les Emplois exportée(s) dans : {output_file}"

--- a/back/dora/orientations/management/commands/export_emplois_orientations.py
+++ b/back/dora/orientations/management/commands/export_emplois_orientations.py
@@ -42,9 +42,7 @@ class Command(BaseCommand):
             # l'orientation à ses propres objets lors du réimport.
             "emplois_sync_uid": str(emplois_data.emplois_sync_uid),
             "beneficiary_id": str(emplois_data.beneficiary_id),
-            "prescriber_id": str(emplois_data.prescriber_id)
-            if emplois_data.prescriber_id
-            else None,
+            "prescriber_id": str(emplois_data.prescriber_id),
             "structure_id": str(emplois_data.structure_id),
             "service_id": _service_id(orientation),
             # Cycle de vie

--- a/back/dora/orientations/management/commands/export_emplois_orientations.py
+++ b/back/dora/orientations/management/commands/export_emplois_orientations.py
@@ -10,12 +10,7 @@ def _isoformat(value):
     return value.isoformat() if value else None
 
 
-def _service_id(orientation: Orientation) -> str:
-    # On reconstruit l'identifiant de service tel que Les Emplois l'avait fourni :
-    # un service DORA (converti en FK à la création) redevient « dora--<uuid> »,
-    # sinon on conserve le `di_service_id` d'origine.
-    # Même logique que `OrientationViewSet.perform_create` et
-    # `EmploisOrientationCreateSerializer.to_representation`.
+def _di_service_id(orientation: Orientation) -> str:
     if orientation.service_id:
         return f"dora--{orientation.service_id}"
     return orientation.di_service_id
@@ -44,7 +39,7 @@ class Command(BaseCommand):
             "beneficiary_id": str(emplois_data.beneficiary_id),
             "prescriber_id": str(emplois_data.prescriber_id),
             "structure_id": str(emplois_data.structure_id),
-            "service_id": _service_id(orientation),
+            "service_id": _di_service_id(orientation),
             # Cycle de vie
             "status": orientation.status,
             "creation_date": _isoformat(orientation.creation_date),

--- a/back/dora/orientations/management/commands/export_emplois_orientations.py
+++ b/back/dora/orientations/management/commands/export_emplois_orientations.py
@@ -1,13 +1,10 @@
 import json
 
+from django.core.serializers.json import DjangoJSONEncoder
 from django.utils import timezone
 
 from dora.core.commands import BaseCommand
 from dora.orientations.models import Orientation
-
-
-def _isoformat(value):
-    return value.isoformat() if value else None
 
 
 def _di_service_id(orientation: Orientation) -> str:
@@ -35,21 +32,19 @@ class Command(BaseCommand):
             # Identifiants Les Emplois transmis à la création de l'orientation et
             # stockés tels quels : ils permettent à Les Emplois de rattacher
             # l'orientation à ses propres objets lors du réimport.
-            "emplois_sync_uid": str(emplois_data.emplois_sync_uid),
-            "beneficiary_id": str(emplois_data.beneficiary_id),
-            "prescriber_id": str(emplois_data.prescriber_id),
-            "structure_id": str(emplois_data.structure_id),
+            "emplois_sync_uid": emplois_data.emplois_sync_uid,
+            "beneficiary_id": emplois_data.beneficiary_id,
+            "prescriber_id": emplois_data.prescriber_id,
+            "structure_id": emplois_data.structure_id,
             "service_id": _di_service_id(orientation),
             # Cycle de vie
             "status": orientation.status,
-            "creation_date": _isoformat(orientation.creation_date),
-            "processing_date": _isoformat(orientation.processing_date),
+            "creation_date": orientation.creation_date,
+            "processing_date": orientation.processing_date,
             # Bénéficiaire
             "beneficiary_contact_preferences": orientation.beneficiary_contact_preferences,
             "beneficiary_other_contact_method": orientation.beneficiary_other_contact_method,
-            "beneficiary_availability": _isoformat(
-                orientation.beneficiary_availability
-            ),
+            "beneficiary_availability": orientation.beneficiary_availability,
             "beneficiary_attachments": orientation.beneficiary_attachments,
             # Référent
             "referent_last_name": orientation.referent_last_name,
@@ -83,7 +78,9 @@ class Command(BaseCommand):
         )
 
         with open(output_file, "w", encoding="utf-8") as json_file:
-            json.dump(data, json_file, ensure_ascii=False, indent=2)
+            json.dump(
+                data, json_file, cls=DjangoJSONEncoder, ensure_ascii=False, indent=2
+            )
 
         self.logger.info(
             "%s orientation(s) Les Emplois exportée(s) dans %s.",

--- a/back/dora/orientations/tests/test_export_emplois_orientations.py
+++ b/back/dora/orientations/tests/test_export_emplois_orientations.py
@@ -1,0 +1,87 @@
+import json
+import uuid
+
+from django.core.management import call_command
+
+from dora.core.test_utils import (
+    make_emplois_orientation,
+    make_jwt_orientation,
+    make_orientation,
+)
+
+
+def _run_export(tmp_path):
+    output = tmp_path / "export.json"
+    call_command("export_emplois_orientations", "--output", str(output))
+    with open(output, encoding="utf-8") as f:
+        return json.load(f)
+
+
+def test_exports_only_emplois_orientations(tmp_path):
+    emplois_orientation = make_emplois_orientation()
+    # Une orientation DORA classique (avec prescripteur) doit être exclue,
+    make_orientation()
+    # de même qu'une orientation JWT (données Emplois mais prescripteur DORA).
+    make_jwt_orientation()
+
+    data = _run_export(tmp_path)
+
+    assert [entry["emplois_sync_uid"] for entry in data] == [
+        str(emplois_orientation.emplois_orientation_data.emplois_sync_uid)
+    ]
+
+
+def test_linking_identifiers(tmp_path):
+    orientation = make_emplois_orientation(emplois_data={"prescriber_id": uuid.uuid4()})
+    emplois_data = orientation.emplois_orientation_data
+
+    [entry] = _run_export(tmp_path)
+
+    assert entry["emplois_sync_uid"] == str(emplois_data.emplois_sync_uid)
+    assert entry["beneficiary_id"] == str(emplois_data.beneficiary_id)
+    assert entry["prescriber_id"] == str(emplois_data.prescriber_id)
+    assert entry["structure_id"] == str(emplois_data.structure_id)
+
+
+def test_dora_service_identifier(tmp_path):
+    orientation = make_emplois_orientation()
+
+    [entry] = _run_export(tmp_path)
+
+    assert entry["service_id"] == f"dora--{orientation.service_id}"
+
+
+def test_di_service_identifier(tmp_path):
+    make_emplois_orientation(service=None, di_service_id="di--abc")
+
+    [entry] = _run_export(tmp_path)
+
+    assert entry["service_id"] == "di--abc"
+
+
+def test_includes_anonymized_orientations(tmp_path):
+    # Une orientation anonymisée (données référent vidées) reste exportable :
+    # les identifiants de réassociation ne sont pas anonymisés.
+    orientation = make_emplois_orientation(
+        is_anonymized=True,
+        referent_first_name="",
+        referent_last_name="",
+        referent_email="",
+    )
+
+    [entry] = _run_export(tmp_path)
+
+    assert entry["emplois_sync_uid"] == str(
+        orientation.emplois_orientation_data.emplois_sync_uid
+    )
+    assert entry["referent_last_name"] == ""
+
+
+def test_json_is_readable_with_consistent_count(tmp_path):
+    make_emplois_orientation()
+    make_emplois_orientation()
+
+    data = _run_export(tmp_path)
+
+    assert len(data) == 2
+    assert all(entry["emplois_sync_uid"] for entry in data)


### PR DESCRIPTION
## Contexte

Une fois que Les Emplois sauvegardera localement ses orientations, il faudra importer les anciennes orientations Les Emplois qui n'auront été sauvegardées que sur Dora.

Pour cela, 2 commandes :

- Une commande d'export côté Dora ;
- Une commande d'import côté Les Emplois. 

PR Les Emplois : https://github.com/gip-inclusion/les-emplois/pull/8479

## Solution

Ajout d'une commande `export_emplois_orientations` sur Dora pour exporter les orientations Les Emplois.

Le fichier de sortie sera importé par Les Emplois.