### PR TITLE
feat(emplois): Ajout du champ `processing_date` au endpoint de synchronisation des statuts des orientations

### DIFF
--- a/back/dora/emplois/serializers.py
+++ b/back/dora/emplois/serializers.py
@@ -220,7 +220,7 @@ class EmploisOrientationStatusSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = Orientation
-        fields = ["emplois_sync_uid", "status", "updated_at"]
+        fields = ["emplois_sync_uid", "status", "processing_date", "updated_at"]
 
 
 # Valeurs constantes communes à tous les événements de mobilisation enregistrés

--- a/back/dora/emplois/tests/test_emplois_orientations.py
+++ b/back/dora/emplois/tests/test_emplois_orientations.py
@@ -506,11 +506,17 @@ def test_orientation_status_list_returns_only_emplois_orientations(
     assert len(results) == 1
 
     [item] = response.data["results"]
-    assert set(item.keys()) == {"emplois_sync_uid", "status", "updated_at"}
+    assert set(item.keys()) == {
+        "emplois_sync_uid",
+        "status",
+        "processing_date",
+        "updated_at",
+    }
     assert item["emplois_sync_uid"] == str(
         emplois_orientation.emplois_orientation_data.emplois_sync_uid
     )
     assert item["status"] == OrientationStatus.ACCEPTED
+    assert item["processing_date"] == DateTimeField().to_representation(processing_date)
     assert item["updated_at"] == DateTimeField().to_representation(processing_date)
 
 
@@ -525,6 +531,7 @@ def test_orientation_status_list_updated_at_falls_back_to_creation_date(
     assert response.status_code == 200
     assert len(response.data["results"]) == 1
     [item] = response.data["results"]
+    assert item["processing_date"] is None
     assert item["updated_at"] == DateTimeField().to_representation(
         orientation.creation_date
     )


### PR DESCRIPTION
On a besoin de synchroniser `processing_date` (qui est la date de changement de statut) en plus du champ `status`.

Note : `updated_at` est un `Coalesce("processing_date", "creation_date")` qui sert uniquement pour la synchronisation incrémentale.