### PR TITLE
feat(structures): Ajout d'une commande de suppression des anciennes structures orphelines

### DIFF
--- a/back/dora/structures/management/commands/delete_orphan_structures.py
+++ b/back/dora/structures/management/commands/delete_orphan_structures.py
@@ -1,0 +1,58 @@
+from datetime import datetime
+from zoneinfo import ZoneInfo
+
+from itoutils.django.commands import AtomicHandleMixin, dry_runnable
+
+from dora.core.commands import BaseCommand
+from dora.structures.models import Structure
+
+CREATED_BEFORE = datetime(2026, 2, 1, tzinfo=ZoneInfo("Europe/Paris"))
+
+
+def get_orphan_structures():
+    # structures créées avant la date limite, sans aucun utilisateur (ni membre,
+    # ni membre potentiel), sans service (les modèles de service sont des
+    # `Service` en base) et dont l'administrateur n'a jamais été invité.
+    # Deux garde-fous supplémentaires :
+    # - les structures mères sont exclues, leur suppression entrainerait en
+    #   cascade celle de leurs antennes, qui peuvent, elles, être actives ;
+    # - les structures possédant des choix personnalisés (`accesscondition`,
+    #   `public`, `requirement`, `credential`) sont exclues, ces derniers pouvant
+    #   être utilisés par les services d'autres structures.
+    return Structure.objects.filter(
+        creation_date__lt=CREATED_BEFORE,
+        membership=None,
+        putative_membership=None,
+        services=None,
+        branches=None,
+        admin_already_invited=False,
+        accesscondition=None,
+        public=None,
+        requirement=None,
+        credential=None,
+    )
+
+
+class Command(AtomicHandleMixin, BaseCommand):
+    help = (
+        "Supprime les structures orphelines, sans service, jamais activées, "
+        f"créées avant le {CREATED_BEFORE:%d/%m/%Y}"
+    )
+    ATOMIC_HANDLE = True
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--wet-run",
+            action="store_true",
+            help="Exécute réellement les suppressions (sans ce flag, rollback automatique).",
+        )
+
+    @dry_runnable
+    def handle(self, *args, **options):
+        # suppression via le queryset de `Structure` : la synchronisation Nexus
+        # est déclenchée sur le commit, donc ignorée en cas de dry run
+        total, per_model = get_orphan_structures().delete()
+
+        self.logger.info("%d objets supprimés :", total)
+        for label, count in sorted(per_model.items()):
+            self.logger.info("  %s : %d", label, count)

--- a/back/dora/structures/tests/test_delete_orphan_structures.py
+++ b/back/dora/structures/tests/test_delete_orphan_structures.py
@@ -1,0 +1,145 @@
+from datetime import timedelta
+
+import pytest
+from data_inclusion.schema.v1.publics import Public as DiPublic
+from django.core.management import call_command
+from model_bakery import baker
+
+from dora.core.models import LogItem
+from dora.core.test_utils import (
+    make_service,
+    make_structure,
+    make_structure_member,
+    make_user,
+)
+from dora.structures.management.commands.delete_orphan_structures import CREATED_BEFORE
+from dora.structures.models import (
+    Structure,
+    StructureNationalLabel,
+    StructurePutativeMember,
+)
+
+
+def make_orphan_structure(created_at=CREATED_BEFORE - timedelta(days=1), **kwargs):
+    # `creation_date` est en `auto_now_add`, on ne peut la fixer qu'après coup
+    structure = make_structure(**kwargs)
+    Structure.objects.filter(pk=structure.pk).update(creation_date=created_at)
+    return structure
+
+
+def test_deletes_orphan_structures():
+    structure = make_orphan_structure()
+
+    call_command("delete_orphan_structures", "--wet-run")
+
+    assert not Structure.objects.filter(pk=structure.pk).exists()
+
+
+def test_dry_run_deletes_nothing():
+    structure = make_orphan_structure()
+
+    call_command("delete_orphan_structures")
+
+    assert Structure.objects.filter(pk=structure.pk).exists()
+
+
+@pytest.mark.parametrize(
+    "prepare",
+    [
+        pytest.param(
+            lambda structure: make_structure_member(
+                user=make_user(), structure=structure
+            ),
+            id="member",
+        ),
+        pytest.param(
+            lambda structure: StructurePutativeMember(
+                user=make_user(), structure=structure
+            ).save(),
+            id="putative-member",
+        ),
+        pytest.param(
+            lambda structure: make_service(structure=structure),
+            id="service",
+        ),
+        pytest.param(
+            lambda structure: Structure.objects.filter(pk=structure.pk).update(
+                admin_already_invited=True
+            ),
+            id="admin-already-invited",
+        ),
+        pytest.param(
+            lambda structure: make_structure(parent=structure, siret=None),
+            id="parent-structure",
+        ),
+        pytest.param(
+            lambda structure: baker.make(
+                "services.AccessCondition", structure=structure
+            ),
+            id="custom-access-condition",
+        ),
+        pytest.param(
+            lambda structure: baker.make(
+                "services.Public",
+                structure=structure,
+                corresponding_di_publics=[DiPublic.FAMILLES],
+            ),
+            id="custom-public",
+        ),
+        pytest.param(
+            lambda structure: baker.make("services.Requirement", structure=structure),
+            id="custom-requirement",
+        ),
+        pytest.param(
+            lambda structure: baker.make("services.Credential", structure=structure),
+            id="custom-credential",
+        ),
+    ],
+)
+def test_preserves_structures(prepare):
+    structure = make_orphan_structure()
+    prepare(structure)
+
+    call_command("delete_orphan_structures", "--wet-run")
+
+    assert Structure.objects.filter(pk=structure.pk).exists()
+
+
+def test_preserves_recent_structure():
+    structure = make_orphan_structure(created_at=CREATED_BEFORE + timedelta(days=1))
+
+    call_command("delete_orphan_structures", "--wet-run")
+
+    assert Structure.objects.filter(pk=structure.pk).exists()
+
+
+def test_deletes_related_objects():
+    structure = make_orphan_structure()
+    kept_structure = make_structure(user=make_user())
+
+    label = baker.make("structures.StructureNationalLabel")
+    structure.national_labels.add(label)
+
+    log_item = baker.make("core.LogItem", structure=structure)
+    kept_log_item = baker.make("core.LogItem", structure=kept_structure)
+
+    call_command("delete_orphan_structures", "--wet-run")
+
+    assert not LogItem.objects.filter(pk=log_item.pk).exists()
+    assert LogItem.objects.filter(pk=kept_log_item.pk).exists()
+
+    # seule l'association au label national disparait, pas le label lui-même
+    assert not Structure.national_labels.through.objects.filter(
+        structure_id=structure.pk
+    ).exists()
+    assert StructureNationalLabel.objects.filter(pk=label.pk).exists()
+
+
+def test_deletes_orphan_branch():
+    structure = make_structure(user=make_user())
+    branch = make_orphan_structure(parent=structure, siret=None)
+
+    call_command("delete_orphan_structures", "--wet-run")
+
+    assert not Structure.objects.filter(pk=branch.pk).exists()
+    assert Structure.objects.filter(pk=structure.pk).exists()


### PR DESCRIPTION
## Contexte

On a beaucoup de structures orphelines inutilisées en base. Elles polluent la base de données et surtout le TDB gestionnaire.

On veut supprimer les structures orphelines créées avant le 1er févier 2026.

## Changements

Création d'une commande `delete_orphan_structures` supprimant les structures respectant les conditions suivantes :
- créées avant le 1er févier 2026 ;
- sans membre ;
- sans membre potentiel ;
- sans service ;
- sans antenne ;
- dont `admin_already_invited` est à `False` (champ introduit en février 2026, donc aucun effet) ;
- sans `AccessCondition` custom ;
- sans `Public` custom ;
- sans `Requirement` custom ;
- sans `Credential` custom.

Les 4 types d'objets custom peuvent être utilisés par des services d'autres structures. La suppression de la structure propriétaire les supprimerait en cascade. Pour éviter cela, on ne supprime pas ces structures. Cela représente très peu de cas.

De même, on se supprime pas les structures ayant des antennes car ça les supprimerait en cascade.