### PR TITLE
fix(front): Affichage d'une erreur 404 pour un service inaccessible au lieu de rediriger vers la connexion

### DIFF
--- a/front/src/routes/(modeles-services)/services/[slug]/+page.ts
+++ b/front/src/routes/(modeles-services)/services/[slug]/+page.ts
@@ -5,11 +5,10 @@ import {
   getServicesOptions,
 } from "$lib/requests/services";
 import type { Service } from "$lib/types";
-import { isAuthenticated } from "$lib/utils/auth";
-import { error, redirect } from "@sveltejs/kit";
+import { error } from "@sveltejs/kit";
 import type { PageLoad } from "./$types";
 
-export const load: PageLoad = async ({ fetch, url, params, parent }) => {
+export const load: PageLoad = async ({ fetch, params, parent }) => {
   await parent();
 
   if (params.slug.startsWith("di--")) {
@@ -39,12 +38,6 @@ export const load: PageLoad = async ({ fetch, url, params, parent }) => {
       return {
         service: null,
       };
-    }
-    if (!isAuthenticated()) {
-      redirect(
-        302,
-        `/auth/connexion?next=${encodeURIComponent(url.pathname + url.search)}`
-      );
     }
     error(404, "Page Not Found");
   }


### PR DESCRIPTION
## Contexte

Lorsqu'on accède à une fiche service en brouillon en n'étant pas connecté, on fait une redirection vers la page de connexion. Cela a du sens lorsque c'est un membre de la structure qui veut y accéder, car une fois connecté, il peut réellement accéder à la fiche service en brouillon. Mais cela n'a pas de sens pour un utilisateur non membre de la structure qui arriverait sur la page via Google ou un lien stocké quelque part. Dans ce cas, il devrait voir une 404.

Le bon choix ici est d'avoir une erreur 404.