### PR TITLE
feat(services): Exclusion de sources data·inclusion du formulaire Dora

### DIFF
--- a/back/config/settings/__init__.py
+++ b/back/config/settings/__init__.py
@@ -2,6 +2,8 @@ import os
 import random
 from pathlib import Path
 
+import environ
+
 random.seed()
 
 # Racine du projet Django
@@ -12,7 +14,7 @@ BASE_DIR = Path(__file__).resolve().parent.parent.parent
 # de configuration contenus dans le répertoire 'envs'.
 # Dans ce cas, l'environnement est nécessairement local
 if os.path.isdir(BASE_DIR / "envs"):
-    import environ
-
     environ.Env.read_env(os.path.join(BASE_DIR / "envs", "dev.env"))
     environ.Env.read_env(os.path.join(BASE_DIR / "envs", "secrets.env"))
+
+env = environ.Env()

--- a/back/config/settings/base.py
+++ b/back/config/settings/base.py
@@ -18,7 +18,7 @@ from botocore.config import Config
 from corsheaders.defaults import default_headers
 from django.utils.csp import CSP
 
-from . import BASE_DIR
+from . import BASE_DIR, env
 
 APPS_DIR = os.path.join(BASE_DIR, "dora")
 # Paramètres Django
@@ -528,6 +528,11 @@ ORIENTATION_ANONYMIZATION_PERIOD_DAYS = int(
 )
 ORIENTATION_ATTACHMENTS_EXPIRATION_PERIOD_MONTHS = int(
     os.getenv("ORIENTATION_ATTACHMENTS_EXPIRATION_PERIOD_MONTHS", 6)
+)
+# sources data·inclusion pour lesquelles le formulaire d'orientation Dora
+# n'est pas proposé (sources séparées par des ",")
+NON_ORIENTABLE_DI_SOURCES = frozenset(
+    env.list("NON_ORIENTABLE_DI_SOURCES", cast=str.strip, default=[])
 )
 ORIENTATION_SIRENE_BLACKLIST = [
     # CAF

--- a/back/dora/data_inclusion/mappings.py
+++ b/back/dora/data_inclusion/mappings.py
@@ -121,6 +121,7 @@ def is_orientable(service_data: dict) -> bool:
         else None
     )
     blacklisted = siren in settings.ORIENTATION_SIRENE_BLACKLIST
+    blacklisted |= service_data["source"] in settings.NON_ORIENTABLE_DI_SOURCES
     blacklisted |= not service_data["courriel"]
 
     if blacklisted:

--- a/back/dora/data_inclusion/tests.py
+++ b/back/dora/data_inclusion/tests.py
@@ -1,6 +1,6 @@
 from data_inclusion.schema.v1 import ModeMobilisation, PersonneMobilisatrice
 
-from .mappings import map_service
+from .mappings import is_orientable, map_service
 from .test_utils import make_di_service_data
 
 ALL_DI_ORIENTATION_MODES = [
@@ -126,6 +126,13 @@ def test_map_service_coach_orientation_modes_mapping_without_form_mode_without_e
     assert sorted(service["coach_orientation_modes"]) == sorted(
         expected_dora_coach_orientation_modes
     )
+
+
+def test_is_orientable_when_source_is_blacklisted(settings):
+    settings.NON_ORIENTABLE_DI_SOURCES = frozenset({"blacklisted-source"})
+
+    assert is_orientable(make_di_service_data(source="blacklisted-source")) is False
+    assert is_orientable(make_di_service_data(source="another-source")) is True
 
 
 def test_map_service_address_line():

--- a/back/envs-example/dev.env
+++ b/back/envs-example/dev.env
@@ -24,6 +24,7 @@ FT_CLIENT_ID=
 BREVO_ACTIVE=
 
 DATA_INCLUSION_URL=https://api-staging.data.inclusion.beta.gouv.fr/api/v1/
+NON_ORIENTABLE_DI_SOURCES="soliguide,monenfant,ma-boussole-aidants,fredo"
 
 SENTRY_DSN=
 SENTRY_TRACES_SAMPLE_RATE=

--- a/back/requirements/base.in
+++ b/back/requirements/base.in
@@ -2,6 +2,7 @@ data-inclusion-schema
 dj-database-url
 Django
 django-cors-headers
+django-environ
 django-otp[segno]
 django-filter
 django-storages[s3]

--- a/back/requirements/base.txt
+++ b/back/requirements/base.txt
@@ -457,6 +457,10 @@ django-datadog-logger==0.9.1 \
     # via
     #   -r requirements/base.in
     #   itoutils
+django-environ==0.14.0 \
+    --hash=sha256:8dbe8a57f0a540ab8abd6f54f230de5e99e3a2c9d797cb9caecb037bca3d47d8 \
+    --hash=sha256:b6c48d93b9d2ff8a3ea14099e90c35aa4f101c1b4d5f262dfee0d27b06742ed7
+    # via -r requirements/base.in
 django-filter==25.2 \
     --hash=sha256:760e984a931f4468d096f5541787efb8998c61217b73006163bf2f9523fe8f23 \
     --hash=sha256:9c0f8609057309bba611062fe1b720b4a873652541192d232dd28970383633e3

--- a/back/requirements/dev.txt
+++ b/back/requirements/dev.txt
@@ -473,7 +473,7 @@ django-datadog-logger==0.9.1 \
 django-environ==0.14.0 \
     --hash=sha256:8dbe8a57f0a540ab8abd6f54f230de5e99e3a2c9d797cb9caecb037bca3d47d8 \
     --hash=sha256:b6c48d93b9d2ff8a3ea14099e90c35aa4f101c1b4d5f262dfee0d27b06742ed7
-    # via -r requirements/test.in
+    # via -r requirements/base.in
 django-extensions==4.1 \
     --hash=sha256:0699a7af28f2523bf8db309a80278519362cd4b6e1fd0a8cd4bf063e1e023336 \
     --hash=sha256:7b70a4d28e9b840f44694e3f7feb54f55d495f8b3fa6c5c0e5e12bcb2aa3cdeb

--- a/back/requirements/prod.txt
+++ b/back/requirements/prod.txt
@@ -455,6 +455,10 @@ django-datadog-logger==0.9.1 \
     # via
     #   -r requirements/base.in
     #   itoutils
+django-environ==0.14.0 \
+    --hash=sha256:8dbe8a57f0a540ab8abd6f54f230de5e99e3a2c9d797cb9caecb037bca3d47d8 \
+    --hash=sha256:b6c48d93b9d2ff8a3ea14099e90c35aa4f101c1b4d5f262dfee0d27b06742ed7
+    # via -r requirements/base.in
 django-filter==25.2 \
     --hash=sha256:760e984a931f4468d096f5541787efb8998c61217b73006163bf2f9523fe8f23 \
     --hash=sha256:9c0f8609057309bba611062fe1b720b4a873652541192d232dd28970383633e3

--- a/back/requirements/test.in
+++ b/back/requirements/test.in
@@ -1,6 +1,5 @@
 -r base.in
 
-django-environ
 django-querycount
 djhtml
 freezegun

--- a/back/requirements/test.txt
+++ b/back/requirements/test.txt
@@ -459,7 +459,7 @@ django-datadog-logger==0.9.1 \
 django-environ==0.14.0 \
     --hash=sha256:8dbe8a57f0a540ab8abd6f54f230de5e99e3a2c9d797cb9caecb037bca3d47d8 \
     --hash=sha256:b6c48d93b9d2ff8a3ea14099e90c35aa4f101c1b4d5f262dfee0d27b06742ed7
-    # via -r requirements/test.in
+    # via -r requirements/base.in
 django-filter==25.2 \
     --hash=sha256:760e984a931f4468d096f5541787efb8998c61217b73006163bf2f9523fe8f23 \
     --hash=sha256:9c0f8609057309bba611062fe1b720b4a873652541192d232dd28970383633e3


### PR DESCRIPTION
On veut pouvoir désactiver le formulaire Dora pour certaines sources DI spécifiées par variable d'environnement.

Variable d'environnement créée sur les apps de staging et prod :

```
NON_ORIENTABLE_DI_SOURCES="soliguide,monenfant,ma-boussole-aidants,fredo"
```