### PR TITLE
fix(front): Déclenche la recherche lors de l'appui sur la touche Entrée

### DIFF
--- a/front/src/lib/components/inputs/geo/city-search.svelte
+++ b/front/src/lib/components/inputs/geo/city-search.svelte
@@ -111,6 +111,7 @@
   {#snippet prepend()}
     <div class="px-s8 pt-s8">
       <button
+        type="button"
         class="border-gray-02 px-s8 py-s12 text-f14 text-gray-text flex w-full"
         onclick={handleClickSearchCityFromLocation}
       >

--- a/front/src/lib/components/inputs/obsolete/select-field.svelte
+++ b/front/src/lib/components/inputs/obsolete/select-field.svelte
@@ -260,6 +260,7 @@
       <div class="h-s24 w-s24 text-gray-text-alt">
         {#if (isMultiple ? value.length > 0 : !!value) && withClearButton}
           <button
+            type="button"
             class="h-s24 w-s24 fill-current"
             onclick={clearAll}
             {disabled}

--- a/front/src/lib/components/inputs/select/simple-autocomplete.svelte
+++ b/front/src/lib/components/inputs/select/simple-autocomplete.svelte
@@ -795,7 +795,8 @@
       aria-describedby={formatErrors(name, errorMessages)}
     />
     {#if clearable && text?.length}
-      <button onclick={clear} class="autocomplete-clear-button">&#10006;</button
+      <button type="button" onclick={clear} class="autocomplete-clear-button"
+        >&#10006;</button
       >
     {/if}
   </div>
@@ -821,6 +822,7 @@
                   ? value.includes(listItem.value)
                   : listItem.value === value)}
               <button
+                type="button"
                 class="autocomplete-list-item px-s20 py-s6 flex w-full flex-row items-baseline text-left {i ===
                 highlightIndex
                   ? 'selected'
@@ -896,6 +898,7 @@
 
         {#if !disabled && !readonly && !isFixedItem(tagItem)}
           <button
+            type="button"
             class="tag-delete"
             onclick={(event) => {
               event.preventDefault();

--- a/front/src/lib/components/specialized/service-search.svelte
+++ b/front/src/lib/components/specialized/service-search.svelte
@@ -212,6 +212,7 @@
             >
               {#if cityCode}
                 <button
+                  type="button"
                   class="h-s24 w-s24 inline-block"
                   onclick={() => {
                     handleAddressChange(null);


### PR DESCRIPTION
Les boutons qui ne sont pas le bouton de soumission de formulaire doivent avoir explicitement le type `button`, sinon ils ont le type `submit` par défaut.

Quand on appuie sur la touche _Entrée_, le premier bouton de type `submit` trouvé dans l'ordre du DOM est activé. Donc il faut que le seul bouton de type `submit` du formulaire soit le véritable bouton de soumission du formulaire.