### PR TITLE
chore(deps): Mise à jour majeure de maplibe-gl de 5.24.0 à 6.1.0

### DIFF
--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -42,7 +42,7 @@
         "insane": "^2.6.2",
         "js-cookie": "^3.0.8",
         "lint-staged": "^17.2.0",
-        "maplibre-gl": "^5.24.0",
+        "maplibre-gl": "^6.1.0",
         "opening_hours": "^3.14.0",
         "prettier": "^3.9.6",
         "prettier-plugin-svelte": "^4.1.1",
@@ -733,12 +733,13 @@
       }
     },
     "node_modules/@mapbox/jsonlint-lines-primitives": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@mapbox/jsonlint-lines-primitives/-/jsonlint-lines-primitives-2.0.2.tgz",
-      "integrity": "sha512-rY0o9A5ECsTQRVhv7tL/OyDpGAoUB4tTvLiW1DSzQGq4bvTPhNw1VpSNjDJc5GFZ2XuyOtSWSVN05qOtcD71qQ==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@mapbox/jsonlint-lines-primitives/-/jsonlint-lines-primitives-2.0.3.tgz",
+      "integrity": "sha512-0SElaV0uMxEnxzBhhX9WTuPyUeMsAN/SS0i16tjuba4/mio63MG9khjC1a0JAiPGXAwvwm4UfHJURCN7nyudQg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
-        "node": ">= 0.6"
+        "node": ">= 22"
       }
     },
     "node_modules/@mapbox/point-geometry": {
@@ -749,61 +750,53 @@
       "license": "ISC"
     },
     "node_modules/@mapbox/tiny-sdf": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@mapbox/tiny-sdf/-/tiny-sdf-2.1.0.tgz",
-      "integrity": "sha512-uFJhNh36BR4OCuWIEiWaEix9CA2WzT6CAIcqVjWYpnx8+QDtS+oC4QehRrx5cX4mgWs37MmKnwUejeHxVymzNg==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@mapbox/tiny-sdf/-/tiny-sdf-2.2.0.tgz",
+      "integrity": "sha512-LVL4wgI9YAum5V+LNVQO6QgFBPw7/MIIY4XJPNsPDMrjEwcE+JfKk1LuIl8GnF197ejVdC9QdPaxrx5gfgdGXg==",
       "dev": true,
       "license": "BSD-2-Clause"
     },
     "node_modules/@mapbox/unitbezier": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/@mapbox/unitbezier/-/unitbezier-0.0.1.tgz",
-      "integrity": "sha512-nMkuDXFv60aBr9soUG5q+GvZYL+2KZHVvsqFCzqnkGEf46U2fvmytHaEVc1/YZbiLn8X+eR3QzX1+dwDO1lxlw==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@mapbox/unitbezier/-/unitbezier-1.0.0.tgz",
+      "integrity": "sha512-fqd515fjBmANKGGsQ286E2Wvj/XvDFpGzwJxq4CI6jMQue6Oy04uCKp+JWKF00xRTmk6cEu1jPJ9p3xqH8YWqQ==",
       "dev": true,
       "license": "BSD-2-Clause"
     },
     "node_modules/@mapbox/vector-tile": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@mapbox/vector-tile/-/vector-tile-2.0.4.tgz",
-      "integrity": "sha512-AkOLcbgGTdXScosBWwmmD7cDlvOjkg/DetGva26pIRiZPdeJYjYKarIlb4uxVzi6bwHO6EWH82eZ5Nuv4T5DUg==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@mapbox/vector-tile/-/vector-tile-3.0.0.tgz",
+      "integrity": "sha512-Qf10S1uIHMk20ri/IVBnpS+esUEkVaR5Hftmz88jTInrpmWgPGJfPe3LVjjlE77trLx8tH6qjTG7uWH9hIq/0Q==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "@mapbox/point-geometry": "~1.1.0",
         "@types/geojson": "^7946.0.16",
-        "pbf": "^4.0.1"
-      }
-    },
-    "node_modules/@mapbox/whoots-js": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@mapbox/whoots-js/-/whoots-js-3.1.0.tgz",
-      "integrity": "sha512-Es6WcD0nO5l+2BOQS4uLfNPYQaNDfbot3X1XUoloz+x0mPDS3eeORZJl06HXjwBG1fOGwCRnzK88LMdxKRrd6Q==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=6.0.0"
+        "pbf": "^5.0.0"
       }
     },
     "node_modules/@maplibre/geojson-vt": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/@maplibre/geojson-vt/-/geojson-vt-5.0.4.tgz",
-      "integrity": "sha512-KGg9sma45S+stfH9vPCJk1J0lSDLWZgCT9Y8u8qWZJyjFlP8MNP1WGTxIMYJZjDvVT3PDn05kN1C95Sut1HpgQ==",
-      "dev": true,
-      "license": "ISC"
-    },
-    "node_modules/@maplibre/maplibre-gl-style-spec": {
-      "version": "24.8.1",
-      "resolved": "https://registry.npmjs.org/@maplibre/maplibre-gl-style-spec/-/maplibre-gl-style-spec-24.8.1.tgz",
-      "integrity": "sha512-zxa92qF96ZNojLxeAjnaRpjVCy+swoUNJvDhtpC90k7u5F0TMr4GmvNqMKvYrMoPB8d7gRSXbMG1hBbmgESIsw==",
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@maplibre/geojson-vt/-/geojson-vt-6.1.1.tgz",
+      "integrity": "sha512-FVMOcmSP/yqol45t7StApEyTL5/vmqBCuFhH9n+fFuINenhaX+YgHHIt1yJ86S8kln3uJLcMvmEU2cfn6E2eCQ==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
-        "@mapbox/jsonlint-lines-primitives": "~2.0.2",
-        "@mapbox/unitbezier": "^0.0.1",
+        "kdbush": "^4.1.0"
+      }
+    },
+    "node_modules/@maplibre/maplibre-gl-style-spec": {
+      "version": "26.2.1",
+      "resolved": "https://registry.npmjs.org/@maplibre/maplibre-gl-style-spec/-/maplibre-gl-style-spec-26.2.1.tgz",
+      "integrity": "sha512-QFKCXkOeSzOr8jF75jm6kySOg+dUvOehPhRi68gcOYPHb7U5JloUq0dJW0Y5/fZV8ygfT0Vp2RWodvq+fyxFWA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@mapbox/jsonlint-lines-primitives": "^2.0.3",
+        "@mapbox/unitbezier": "^1.0.0",
         "json-stringify-pretty-compact": "^4.0.0",
         "minimist": "^1.2.8",
         "quickselect": "^3.0.0",
-        "rw": "^1.3.3",
         "tinyqueue": "^3.0.0"
       },
       "bin": {
@@ -813,9 +806,9 @@
       }
     },
     "node_modules/@maplibre/mlt": {
-      "version": "1.1.8",
-      "resolved": "https://registry.npmjs.org/@maplibre/mlt/-/mlt-1.1.8.tgz",
-      "integrity": "sha512-8vtfYGidr1rNkv5IwIoU2lfe3Oy+Wa8HluzQYcQi9cveU9K3pweAal/poQj4GJ0K/EW4bTQp2wVAs09g2yDRZg==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/@maplibre/mlt/-/mlt-1.1.12.tgz",
+      "integrity": "sha512-ZeK5w2TTeHOajcLaEQs1KZXw2V9wIKo1PmThlxlsHoXsQsYlBqLJzPOd6tJHRtGTChUY3DPPmjXRArYVvAbmZw==",
       "dev": true,
       "license": "(MIT OR Apache-2.0)",
       "dependencies": {
@@ -823,19 +816,15 @@
       }
     },
     "node_modules/@maplibre/vt-pbf": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@maplibre/vt-pbf/-/vt-pbf-4.3.0.tgz",
-      "integrity": "sha512-jIvp8F5hQCcreqOOpEt42TJMUlsrEcpf/kI1T2v85YrQRV6PPXUcEXUg5karKtH6oh47XJZ4kHu56pUkOuqA7w==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@maplibre/vt-pbf/-/vt-pbf-4.3.2.tgz",
+      "integrity": "sha512-j6p0AdjvAR19Z3XaCysle7A4ZSo08tYOzxD0Y9NQylwPAkwJJeYub5b2eVucdeDh7erhv69DahoLOevDRERRUw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@mapbox/point-geometry": "^1.1.0",
-        "@mapbox/vector-tile": "^2.0.4",
-        "@maplibre/geojson-vt": "^5.0.4",
         "@types/geojson": "^7946.0.16",
-        "@types/supercluster": "^7.1.3",
-        "pbf": "^4.0.1",
-        "supercluster": "^8.0.1"
+        "pbf": "^5.1.0"
       }
     },
     "node_modules/@napi-rs/wasm-runtime": {
@@ -3219,16 +3208,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@types/supercluster": {
-      "version": "7.1.3",
-      "resolved": "https://registry.npmjs.org/@types/supercluster/-/supercluster-7.1.3.tgz",
-      "integrity": "sha512-Z0pOY34GDFl3Q6hUFYf3HkTwKEE02e7QgtJppBt+beEAxnyOpJua+voGFvxINBHa06GwLFFym7gRPY2SiKIfIA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/geojson": "*"
-      }
-    },
     "node_modules/@types/trusted-types": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
@@ -4211,9 +4190,9 @@
       }
     },
     "node_modules/earcut": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/earcut/-/earcut-3.0.2.tgz",
-      "integrity": "sha512-X7hshQbLyMJ/3RPhyObLARM2sNxxmRALLKx1+NVFFnQ9gKzmCrxm9+uLIAdBcvc8FNLpctqlQ2V6AE92Ol9UDQ==",
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/earcut/-/earcut-3.2.3.tgz",
+      "integrity": "sha512-vnS4AVwp1KHAF13i1vp1/2D5evWy3k5u/iW/B81QVsUZtV8cv2tU0b2VNFlqvh4kYwrFMDdjPCfAmfyJW9y14Q==",
       "dev": true,
       "license": "ISC"
     },
@@ -5184,9 +5163,9 @@
       }
     },
     "node_modules/kdbush": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/kdbush/-/kdbush-4.0.2.tgz",
-      "integrity": "sha512-WbCVYJ27Sz8zi9Q7Q0xHC+05iwkm3Znipc2XTlrnJbsHMYktW4hPhXUE8Ys1engBrvffoSCqbil1JQAa7clRpA==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/kdbush/-/kdbush-4.1.0.tgz",
+      "integrity": "sha512-e9vurzrXJQrFX6ckpHP3bvj5l+9CnYzkxDNnNQ1h2QTqdWsUAJgXiKdGNcOa1EY85dU8KbQ+z/FdQdB7P+9yfQ==",
       "dev": true,
       "license": "ISC"
     },
@@ -5570,28 +5549,26 @@
       }
     },
     "node_modules/maplibre-gl": {
-      "version": "5.24.0",
-      "resolved": "https://registry.npmjs.org/maplibre-gl/-/maplibre-gl-5.24.0.tgz",
-      "integrity": "sha512-ALyFxgtd5R+65UqZ/++lOqwWcC0SNho9c27fYSyLmG7AfnAul2o46F05aDJGPbFU57wos9dgcIySHs0Xe6ia3A==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/maplibre-gl/-/maplibre-gl-6.1.0.tgz",
+      "integrity": "sha512-vLRukjvbUai4SXW2/jKo8rPsw6YMXuA/b4fKFVSulZKFVRHkOvk4ZmNlDSVZpTYPV0/7/iTqq8ltYdyr764b7w==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@mapbox/jsonlint-lines-primitives": "^2.0.2",
         "@mapbox/point-geometry": "^1.1.0",
-        "@mapbox/tiny-sdf": "^2.1.0",
-        "@mapbox/unitbezier": "^0.0.1",
-        "@mapbox/vector-tile": "^2.0.4",
-        "@mapbox/whoots-js": "^3.1.0",
-        "@maplibre/geojson-vt": "^6.1.0",
-        "@maplibre/maplibre-gl-style-spec": "^24.8.1",
-        "@maplibre/mlt": "^1.1.8",
-        "@maplibre/vt-pbf": "^4.3.0",
+        "@mapbox/tiny-sdf": "^2.2.0",
+        "@mapbox/unitbezier": "^1.0.0",
+        "@mapbox/vector-tile": "^3.0.0",
+        "@maplibre/geojson-vt": "^6.1.1",
+        "@maplibre/maplibre-gl-style-spec": "^26.2.1",
+        "@maplibre/mlt": "^1.1.12",
+        "@maplibre/vt-pbf": "^4.3.2",
         "@types/geojson": "^7946.0.16",
-        "earcut": "^3.0.2",
+        "earcut": "^3.2.3",
         "gl-matrix": "^3.4.4",
-        "kdbush": "^4.0.2",
+        "kdbush": "^4.1.0",
         "murmurhash-js": "^1.0.0",
-        "pbf": "^4.0.1",
+        "pbf": "^5.1.2",
         "potpack": "^2.1.0",
         "quickselect": "^3.0.0",
         "tinyqueue": "^3.0.0"
@@ -5602,16 +5579,6 @@
       },
       "funding": {
         "url": "https://github.com/maplibre/maplibre-gl-js?sponsor=1"
-      }
-    },
-    "node_modules/maplibre-gl/node_modules/@maplibre/geojson-vt": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@maplibre/geojson-vt/-/geojson-vt-6.1.0.tgz",
-      "integrity": "sha512-2eIY4gZxeKIVOZVNkAMb+5NgXhgsMQpOveTQAvnp53LYqHGJZDidk7Ew0Tged9PThidpbS+NFTh0g4zivhPDzQ==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "kdbush": "^4.0.2"
       }
     },
     "node_modules/mdn-data": {
@@ -5917,9 +5884,9 @@
       "license": "MIT"
     },
     "node_modules/pbf": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/pbf/-/pbf-4.0.1.tgz",
-      "integrity": "sha512-SuLdBvS42z33m8ejRbInMapQe8n0D3vN/Xd5fmWM3tufNgRQFBpaW2YVJxQZV4iPNqb0vEFvssMEo5w9c6BTIA==",
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/pbf/-/pbf-5.1.2.tgz",
+      "integrity": "sha512-mnvGdvOrIvJOBGUEdGkrVXjN8E/VkIJCkf2eS1DH2yv82ORUlLttmDt0rWY38yYZmVwciZwBUvHM20qxBZf40w==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -6585,13 +6552,6 @@
         }
       }
     },
-    "node_modules/rw": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/rw/-/rw-1.3.3.tgz",
-      "integrity": "sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ==",
-      "dev": true,
-      "license": "BSD-3-Clause"
-    },
     "node_modules/sade": {
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/sade/-/sade-1.8.1.tgz",
@@ -6791,16 +6751,6 @@
       "resolved": "https://registry.npmjs.org/suncalc/-/suncalc-2.0.1.tgz",
       "integrity": "sha512-wjujU+HpsP1TUvN3/9dFkVQQCsMZbk7PkdZsASRJR4jVPHCm9Qy0FVkFTqXfs70Ag2yheN7ZUavzCyOjhJDGxQ==",
       "dev": true
-    },
-    "node_modules/supercluster": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/supercluster/-/supercluster-8.0.1.tgz",
-      "integrity": "sha512-IiOea5kJ9iqzD2t7QJq/cREyLHTtSmUT6gQsweojg9WH2sYJqZK9SswTu6jrscO6D1G5v5vYZ9ru/eq85lXeZQ==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "kdbush": "^4.0.2"
-      }
     },
     "node_modules/supports-preserve-symlinks-flag": {
       "version": "1.0.0",

--- a/front/package.json
+++ b/front/package.json
@@ -58,7 +58,7 @@
     "insane": "^2.6.2",
     "js-cookie": "^3.0.8",
     "lint-staged": "^17.2.0",
-    "maplibre-gl": "^5.24.0",
+    "maplibre-gl": "^6.1.0",
     "opening_hours": "^3.14.0",
     "prettier": "^3.9.6",
     "prettier-plugin-svelte": "^4.1.1",

--- a/front/src/lib/components/display/map.svelte
+++ b/front/src/lib/components/display/map.svelte
@@ -3,6 +3,7 @@
 
   import * as mlgl from "maplibre-gl";
   import "maplibre-gl/dist/maplibre-gl.css";
+  import maplibreWorkerUrl from "maplibre-gl/dist/maplibre-gl-worker.mjs?worker&url";
 
   import mapStyle from "./map-style.json?raw"; // Basé sur https://openmaptiles.geo.data.gouv.fr/styles/osm-bright/style.json
 
@@ -18,6 +19,8 @@
   let mapDiv: HTMLElement;
 
   onMount(() => {
+    mlgl.setWorkerUrl(maplibreWorkerUrl);
+
     map = new mlgl.Map({
       container: mapDiv,
       style: JSON.parse(mapStyle),


### PR DESCRIPTION
Depuis maplibre-gl 6, le worker n'est plus inliné dans le bundle mais résolu via `import.meta.url`, ce qui échoue avec Vite.

Il faut donc lui fournir explicitement son URL via `setWorkerUrl()`, en `?worker&url` pour que Vite empaquette aussi sa dépendance `maplibre-gl-shared.mjs`.