### PR TITLE
fix: assurer que toutes les critères d'admission sont uniques

### DIFF
--- a/front/src/routes/(modeles-services)/components/service-body/service-presentation/service-key-informations/service-key-informations.svelte
+++ b/front/src/routes/(modeles-services)/components/service-body/service-presentation/service-key-informations/service-key-informations.svelte
@@ -35,9 +35,11 @@
   let hasLabelSection = $derived(isNotCumulative || hasFundingLabels);
 
   let eligibilityRequirements = $derived([
-    ...(service.accessConditionsDisplay || []),
-    ...(service.requirementsDisplay || []),
-    ...(service.qpvOrZrr ? ["Uniquement QPV ou ZFRR"] : []),
+    ...new Set([
+      ...(service.accessConditionsDisplay || []),
+      ...(service.requirementsDisplay || []),
+      ...(service.qpvOrZrr ? ["Uniquement QPV ou ZFRR"] : []),
+    ]),
   ]);
 
   let addressForMapLink = $derived(


### PR DESCRIPTION
Il y a une erreur de `each key duplicate` en production parce que ce [service](https://dora.inclusion.gouv.fr/services/assim-il-auto-ecole-associati) a deux critères d'admission identiques. 

Cette PR rend ces critères uniques pour éviter cette erreur qui fait planter la page et pour ne pas afficher la même chose deux fois