### PR TITLE
feat: Limitation du nombre de résultats de recherche pour ne pas submerger les utilisateurs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@
 *.logs
 .cursor
 .claude
+mise.toml

--- a/back/config/settings/base.py
+++ b/back/config/settings/base.py
@@ -704,3 +704,9 @@ try:
     GEO_API_GOUV_TIMEOUT_SECONDS = int(os.getenv("GEO_API_GOUV_TIMEOUT_SECONDS"), 10)
 except (TypeError, ValueError):
     GEO_API_GOUV_TIMEOUT_SECONDS = None
+
+
+# Recherche par mots-clés
+# ---------------------------------------
+KEYWORD_SEARCH_PAGE_SIZE = int(os.getenv("KEYWORD_SEARCH_PAGE_SIZE", 50))
+KEYWORD_SEARCH_MAX_PAGES = int(os.getenv("KEYWORD_SEARCH_MAX_PAGES", 3))

--- a/back/dora/services/search.py
+++ b/back/dora/services/search.py
@@ -379,7 +379,9 @@ def _get_keyword_search_results(request, raw_di_results):
 def search_keyword(request, api_params):
     di_client = data_inclusion.di_client_factory()
     try:
-        raw_di_results = di_client.search(**api_params, size=50)
+        raw_di_results = di_client.search(
+            **api_params, size=settings.KEYWORD_SEARCH_PAGE_SIZE
+        )
     except requests.RequestException:
         raise ServiceUnavailable(
             "L’API data.inclusion.gouv.fr nécessaire pour la recherche "

--- a/back/dora/services/views.py
+++ b/back/dora/services/views.py
@@ -1023,11 +1023,18 @@ def search_keyword_view(request):
         if total:
             search_center = [sum_x / total, sum_y / total]
 
+    # Limitation du nombre de pages et de résultats pour ne pas submerger les utilisateurs
+    service_pages = min(metadata["services_pages"], settings.KEYWORD_SEARCH_MAX_PAGES)
+    service_total = min(
+        metadata["services_total"],
+        settings.KEYWORD_SEARCH_MAX_PAGES * settings.KEYWORD_SEARCH_PAGE_SIZE,
+    )
+
     return Response(
         {
             "search_center": search_center,
             "services": sorted_services,
-            "services_pages": metadata["services_pages"],
-            "services_total": metadata["services_total"],
+            "services_pages": service_pages,
+            "services_total": service_total,
         }
     )

--- a/front/package.json
+++ b/front/package.json
@@ -97,5 +97,8 @@
   },
   "dependencies": {
     "@sentry/sveltekit": "^10.69.0"
+  },
+  "allowScripts": {
+    "@sentry/cli@2.58.5": true
   }
 }


### PR DESCRIPTION
Ticket : https://app.notion.com/p/gip-inclusion/Limiter-le-nombre-de-r-sultats-pour-la-recherche-par-mots-cl-s-3ad5f321b60480f98397d810fc7bb422

## Fonctionnalité

- Ajout des constantes de configuration `KEYWORD_SEARCH_PAGE_SIZE` et `KEYWORD_SEARCH_MAX_PAGES` ;
- Limitation du nombre de pages de résultats affichées à `KEYWORD_SEARCH_MAX_PAGES` ;
- Limitation du nombre de résultats affichés à `KEYWORD_SEARCH_MAX_PAGES` * `KEYWORD_SEARCH_PAGE_SIZE`.

## Divers

- Autorisation de script Sentry ;
- Ajout de [`mise.toml`](https://mise.jdx.dev/) dans `.gitignore`.