### PR TITLE
refactor(`SavedSearch` et `SearchView`): Migration du champ `kinds` de M2M vers `ArrayField`

### DIFF
--- a/back/dora/rest_auth/serializers.py
+++ b/back/dora/rest_auth/serializers.py
@@ -95,7 +95,6 @@ class UserInfoSerializer(serializers.ModelSerializer):
                 .select_related("category")
                 .prefetch_related(
                     "subcategories",
-                    "kinds",
                     "fees",
                     "location_kinds",
                     "funding_labels",

--- a/back/dora/rest_auth/tests/test_auth.py
+++ b/back/dora/rest_auth/tests/test_auth.py
@@ -35,14 +35,15 @@ class AuthenticationTestCase(APITestCase):
         baker.make("Bookmark", user=user, service=service)
 
         category = baker.make("ServiceCategory")
-        saved_search = baker.make("SavedSearch", user=user, category=category)
+        saved_search = baker.make(
+            "SavedSearch", user=user, category=category, kinds=["formation"]
+        )
         saved_search.subcategories.set([baker.make("ServiceSubCategory")])
-        saved_search.kinds.set([baker.make("ServiceKind")])
         saved_search.fees.set([baker.make("ServiceFee")])
         saved_search.location_kinds.set([baker.make("LocationKind")])
         saved_search.funding_labels.set([baker.make("FundingLabel")])
 
-        with self.assertNumQueries(15):
+        with self.assertNumQueries(14):
             response = self.client.get("/auth/user-info/")
 
         self.assertEqual(response.status_code, 200)

--- a/back/dora/services/admin.py
+++ b/back/dora/services/admin.py
@@ -496,7 +496,6 @@ class SavedSearchAdmin(admin.ModelAdmin):
     raw_id_fields = ["user"]
     filter_horizontal = [
         "subcategories",
-        "kinds",
         "fees",
     ]
     readonly_fields = ["creation_date"]

--- a/back/dora/services/management/commands/send_saved_searches_notifications.py
+++ b/back/dora/services/management/commands/send_saved_searches_notifications.py
@@ -1,6 +1,6 @@
 from datetime import timedelta
 
-from data_inclusion.schema.v1 import ModeAccueil, TypeService
+from data_inclusion.schema.v1 import ModeAccueil
 from django.conf import settings
 from django.template.loader import render_to_string
 from django.utils import timezone
@@ -10,6 +10,7 @@ from dora.api.exceptions import ServiceUnavailable
 from dora.core.commands import BaseCommand
 from dora.core.emails import send_mail
 from dora.services.models import LocationKind
+from dora.services.utils import get_kinds_labels
 
 from ...models import SavedSearch, SavedSearchFrequency
 
@@ -103,7 +104,7 @@ class Command(BaseCommand):
             text += f", pour le(s) besoin(s) : {', '.join(labels)}"
 
         if saved_search.kinds:
-            labels = [TypeService(kind).label for kind in saved_search.kinds]
+            labels = get_kinds_labels(saved_search.kinds)
             text += f", pour le(s) type(s) de service : {', '.join(labels)}"
 
         if saved_search.fees.exists():

--- a/back/dora/services/management/commands/send_saved_searches_notifications.py
+++ b/back/dora/services/management/commands/send_saved_searches_notifications.py
@@ -1,6 +1,6 @@
 from datetime import timedelta
 
-from data_inclusion.schema.v1 import ModeAccueil
+from data_inclusion.schema.v1 import ModeAccueil, TypeService
 from django.conf import settings
 from django.template.loader import render_to_string
 from django.utils import timezone
@@ -102,8 +102,8 @@ class Command(BaseCommand):
             labels = saved_search.subcategories.values_list("label", flat=True)
             text += f", pour le(s) besoin(s) : {', '.join(labels)}"
 
-        if saved_search.kinds.exists():
-            labels = saved_search.kinds.values_list("label", flat=True)
+        if saved_search.kinds:
+            labels = [TypeService(kind).label for kind in saved_search.kinds]
             text += f", pour le(s) type(s) de service : {', '.join(labels)}"
 
         if saved_search.fees.exists():

--- a/back/dora/services/migrations/0005_savedsearch_kinds_array.py
+++ b/back/dora/services/migrations/0005_savedsearch_kinds_array.py
@@ -1,0 +1,75 @@
+import django.contrib.postgres.fields
+from django.db import migrations, models
+
+
+def fill_kinds(apps, schema_editor):
+    """Reprend les types de service depuis la table M2M vers `ServiceKind`."""
+    SavedSearch = apps.get_model("services", "SavedSearch")
+
+    rows = list(
+        SavedSearch.objects.filter(kinds__isnull=False)
+        .distinct()
+        .prefetch_related("kinds")
+    )
+    for row in rows:
+        row.kinds_tmp = sorted(kind.value for kind in row.kinds.all())
+
+    SavedSearch.objects.bulk_update(rows, ["kinds_tmp"], batch_size=1000)
+
+
+def restore_kinds(apps, schema_editor):
+    SavedSearch = apps.get_model("services", "SavedSearch")
+    ServiceKind = apps.get_model("services", "ServiceKind")
+
+    kind_ids = dict(ServiceKind.objects.values_list("value", "id"))
+    through = SavedSearch.kinds.through
+
+    through.objects.bulk_create(
+        [
+            through(savedsearch_id=row.pk, servicekind_id=kind_ids[value])
+            for row in SavedSearch.objects.exclude(kinds_tmp=[])
+            for value in row.kinds_tmp
+            if value in kind_ids
+        ],
+        batch_size=1000,
+    )
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("services", "0004_protect_structure_fks"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="savedsearch",
+            name="kinds_tmp",
+            field=django.contrib.postgres.fields.ArrayField(
+                base_field=models.CharField(
+                    choices=[
+                        ("accompagnement", "Accompagnement"),
+                        ("aide-financiere", "Aide financière"),
+                        ("aide-materielle", "Aide materielle"),
+                        ("atelier", "Atelier"),
+                        ("formation", "Formation"),
+                        ("information", "Information"),
+                    ],
+                    max_length=255,
+                ),
+                blank=True,
+                default=list,
+                size=None,
+                verbose_name="Types de service",
+            ),
+        ),
+        migrations.RunPython(fill_kinds, restore_kinds),
+        migrations.RemoveField(
+            model_name="savedsearch",
+            name="kinds",
+        ),
+        migrations.RenameField(
+            model_name="savedsearch",
+            old_name="kinds_tmp",
+            new_name="kinds",
+        ),
+    ]

--- a/back/dora/services/models.py
+++ b/back/dora/services/models.py
@@ -2,7 +2,7 @@ import logging
 import uuid
 from datetime import datetime, timedelta
 
-from data_inclusion.schema.v1 import ModeAccueil
+from data_inclusion.schema.v1 import ModeAccueil, TypeService
 from data_inclusion.schema.v1.publics import Public as DiPublic
 from dateutil.relativedelta import relativedelta
 from django.conf import settings
@@ -856,8 +856,17 @@ class SavedSearch(models.Model):
         verbose_name="Besoins",
         blank=True,
     )
-    kinds = models.ManyToManyField(
-        ServiceKind, verbose_name="Type de service", blank=True
+    kinds = ArrayField(
+        models.CharField(
+            max_length=255,
+            choices=zip(
+                [t.value for t in TypeService],
+                [t.label for t in TypeService],
+            ),
+        ),
+        verbose_name="Types de service",
+        blank=True,
+        default=list,
     )
     fees = models.ManyToManyField(ServiceFee, verbose_name="Frais à charge", blank=True)
     location_kinds = models.ManyToManyField(
@@ -895,9 +904,7 @@ class SavedSearch(models.Model):
         if self.subcategories.exists():
             subcategories = self.subcategories.values_list("value", flat=True)
 
-        kinds = None
-        if self.kinds.exists():
-            kinds = self.kinds.values_list("value", flat=True)
+        kinds = self.kinds or None
 
         fees = None
         if self.fees.exists():

--- a/back/dora/services/models.py
+++ b/back/dora/services/models.py
@@ -859,10 +859,7 @@ class SavedSearch(models.Model):
     kinds = ArrayField(
         models.CharField(
             max_length=255,
-            choices=zip(
-                [t.value for t in TypeService],
-                [t.label for t in TypeService],
-            ),
+            choices=[(t.value, t.label) for t in TypeService],
         ),
         verbose_name="Types de service",
         blank=True,

--- a/back/dora/services/serializers.py
+++ b/back/dora/services/serializers.py
@@ -710,15 +710,11 @@ class SavedSearchSerializer(serializers.ModelSerializer):
         source="subcategories", slug_field="label", many=True, read_only=True
     )
 
-    kinds = serializers.SlugRelatedField(
-        slug_field="value",
-        queryset=ServiceKind.objects.all(),
-        many=True,
+    kinds = serializers.ListField(
+        child=serializers.ChoiceField(choices=TypeService),
         required=False,
     )
-    kinds_display = serializers.SlugRelatedField(
-        source="kinds", slug_field="label", many=True, read_only=True
-    )
+    kinds_display = serializers.SerializerMethodField()
 
     fees = serializers.SlugRelatedField(
         slug_field="value",
@@ -772,6 +768,9 @@ class SavedSearchSerializer(serializers.ModelSerializer):
             "funding_labels_display",
             "new_services_count",
         ]
+
+    def get_kinds_display(self, obj):
+        return [TypeService(kind).label for kind in obj.kinds]
 
     def get_new_services_count(self, obj):
         return len(

--- a/back/dora/services/serializers.py
+++ b/back/dora/services/serializers.py
@@ -23,6 +23,7 @@ import dora.data_inclusion.client
 from dora.core.utils import code_insee_to_code_dept
 from dora.decoupage_administratif.models import AdminDivisionType
 from dora.services.enums import ServiceStatus
+from dora.services.utils import get_kinds_labels
 from dora.structures.models import Structure, StructureMember
 
 from .models import (
@@ -770,7 +771,7 @@ class SavedSearchSerializer(serializers.ModelSerializer):
         ]
 
     def get_kinds_display(self, obj):
-        return [TypeService(kind).label for kind in obj.kinds]
+        return get_kinds_labels(obj.kinds)
 
     def get_new_services_count(self, obj):
         return len(

--- a/back/dora/services/tests/test_services_saved_searchs.py
+++ b/back/dora/services/tests/test_services_saved_searchs.py
@@ -25,7 +25,12 @@ from dora.services.management.commands.send_saved_searches_notifications import 
     get_saved_search_notifications_to_send,
 )
 
-from ..models import SavedSearch, SavedSearchFrequency, ServiceSubCategory
+from ..models import (
+    SavedSearch,
+    SavedSearchFrequency,
+    ServiceKind,
+    ServiceSubCategory,
+)
 
 SAVE_SEARCH_ARGS = {
     "category": "choisir-un-metier",
@@ -80,9 +85,23 @@ class ServiceSavedSearchTestCase(APITestCase):
             sorted(SAVE_SEARCH_ARGS.get("subcategories")),
         )
         self.assertEqual(
+            sorted(saved_search.kinds), sorted(SAVE_SEARCH_ARGS.get("kinds"))
+        )
+        self.assertEqual(
             sorted(list(saved_search.funding_labels.values_list("value", flat=True))),
             sorted(SAVE_SEARCH_ARGS.get("funding_labels")),
         )
+
+    def test_create_search_with_unknown_kind(self):
+        user = baker.make("users.User", is_valid=True)
+        self.client.force_authenticate(user=user)
+
+        args = SAVE_SEARCH_ARGS.copy()
+        args["kinds"] = ["type-inexistant"]
+        response = self.client.post("/saved-searches/", args)
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(SavedSearch.objects.all().count(), 0)
 
     def test_delete_search(self):
         user = baker.make("users.User", is_valid=True)
@@ -533,8 +552,8 @@ class ServiceSavedSearchNotificationTestCase(APITestCase):
         sub_category_2 = baker.make(
             "ServiceSubCategory", value="cat1--sub2", label="cat1--sub2"
         )
-        kind = baker.make("ServiceKind", value="kind1", label="kind1")
-        kind_2 = baker.make("ServiceKind", value="kind2", label="kind2")
+        kind = ServiceKind.objects.get(value="formation")
+        kind_2 = ServiceKind.objects.get(value="information")
 
         savedSearch = baker.make(
             "SavedSearch",
@@ -544,9 +563,9 @@ class ServiceSavedSearchNotificationTestCase(APITestCase):
             city_label=SAVE_SEARCH_ARGS.get("city_label"),
             city_code=SAVE_SEARCH_ARGS.get("city_code"),
             last_notification_date=timezone.now() - timedelta(days=40),
+            kinds=[kind.value, kind_2.value],
         )
         savedSearch.subcategories.set([sub_category, sub_category_2])
-        savedSearch.kinds.set([kind, kind_2])
 
         # ET un service mis à jour à J-20 lié à la même catégorie, sous-catégories et types de service
         self.setup_dora_service_in_di(
@@ -574,7 +593,8 @@ class ServiceSavedSearchNotificationTestCase(APITestCase):
             "pour le(s) besoin(s) : cat1--sub1, cat1--sub2", mail.outbox[0].body
         )
         self.assertIn(
-            "pour le(s) type(s) de service : kind1, kind2", mail.outbox[0].body
+            "pour le(s) type(s) de service : Formation, Information",
+            mail.outbox[0].body,
         )
         self.assertIn(f"<strong>{self.service_name}</strong>", mail.outbox[0].body)
 
@@ -591,8 +611,8 @@ class ServiceSavedSearchNotificationTestCase(APITestCase):
         sub_category_2 = baker.make(
             "ServiceSubCategory", value="cat1--sub2", label="cat1--sub2"
         )
-        kind = baker.make("ServiceKind", value="kind1", label="kind1")
-        kind_2 = baker.make("ServiceKind", value="kind2", label="kind2")
+        kind = ServiceKind.objects.get(value="formation")
+        kind_2 = ServiceKind.objects.get(value="information")
         fee = baker.make("ServiceFee", value="fee", label="fee")
 
         savedSearch = baker.make(
@@ -603,9 +623,9 @@ class ServiceSavedSearchNotificationTestCase(APITestCase):
             city_label=SAVE_SEARCH_ARGS.get("city_label"),
             city_code=SAVE_SEARCH_ARGS.get("city_code"),
             last_notification_date=timezone.now() - timedelta(days=40),
+            kinds=[kind.value, kind_2.value],
         )
         savedSearch.subcategories.set([sub_category, sub_category_2])
-        savedSearch.kinds.set([kind, kind_2])
         savedSearch.fees.set([fee])
 
         # ET un service mis à jour à J-20 lié à la même catégorie, sous-catégories, types de service et frais à charge
@@ -635,7 +655,8 @@ class ServiceSavedSearchNotificationTestCase(APITestCase):
             "pour le(s) besoin(s) : cat1--sub1, cat1--sub2", mail.outbox[0].body
         )
         self.assertIn(
-            "pour le(s) type(s) de service : kind1, kind2", mail.outbox[0].body
+            "pour le(s) type(s) de service : Formation, Information",
+            mail.outbox[0].body,
         )
         self.assertIn("avec comme frais à charge : fee", mail.outbox[0].body)
         self.assertIn(f"<strong>{self.service_name}</strong>", mail.outbox[0].body)

--- a/back/dora/services/utils.py
+++ b/back/dora/services/utils.py
@@ -1,5 +1,6 @@
 import hashlib
 
+from data_inclusion.schema.v1 import TypeService
 from django.contrib.gis.geos import Point
 from django.db.models import Q
 from django.shortcuts import get_object_or_404
@@ -199,3 +200,7 @@ def filter_services_by_region(services, region_code):
             & Q(diffusion_zone_details=region.code)
         )
     )
+
+
+def get_kinds_labels(kinds):
+    return [TypeService(kind).label for kind in kinds]

--- a/back/dora/stats/migrations/0005_searchview_kinds_array.py
+++ b/back/dora/stats/migrations/0005_searchview_kinds_array.py
@@ -1,0 +1,75 @@
+import django.contrib.postgres.fields
+from django.db import migrations, models
+
+
+def fill_kinds(apps, schema_editor):
+    """Reprend les types de service depuis la table M2M vers `ServiceKind`."""
+    SearchView = apps.get_model("stats", "SearchView")
+
+    rows = list(
+        SearchView.objects.filter(kinds__isnull=False)
+        .distinct()
+        .prefetch_related("kinds")
+    )
+    for row in rows:
+        row.kinds_tmp = sorted(kind.value for kind in row.kinds.all())
+
+    SearchView.objects.bulk_update(rows, ["kinds_tmp"], batch_size=1000)
+
+
+def restore_kinds(apps, schema_editor):
+    SearchView = apps.get_model("stats", "SearchView")
+    ServiceKind = apps.get_model("services", "ServiceKind")
+
+    kind_ids = dict(ServiceKind.objects.values_list("value", "id"))
+    through = SearchView.kinds.through
+
+    through.objects.bulk_create(
+        [
+            through(searchview_id=row.pk, servicekind_id=kind_ids[value])
+            for row in SearchView.objects.exclude(kinds_tmp=[])
+            for value in row.kinds_tmp
+            if value in kind_ids
+        ],
+        batch_size=1000,
+    )
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("stats", "0004_searchview_region"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="searchview",
+            name="kinds_tmp",
+            field=django.contrib.postgres.fields.ArrayField(
+                base_field=models.CharField(
+                    choices=[
+                        ("accompagnement", "Accompagnement"),
+                        ("aide-financiere", "Aide financière"),
+                        ("aide-materielle", "Aide materielle"),
+                        ("atelier", "Atelier"),
+                        ("formation", "Formation"),
+                        ("information", "Information"),
+                    ],
+                    max_length=255,
+                ),
+                blank=True,
+                default=list,
+                size=None,
+                verbose_name="Types de service",
+            ),
+        ),
+        migrations.RunPython(fill_kinds, restore_kinds),
+        migrations.RemoveField(
+            model_name="searchview",
+            name="kinds",
+        ),
+        migrations.RenameField(
+            model_name="searchview",
+            old_name="kinds_tmp",
+            new_name="kinds",
+        ),
+    ]

--- a/back/dora/stats/models.py
+++ b/back/dora/stats/models.py
@@ -218,10 +218,7 @@ class AbstractSearchEvent(AbstractAnalyticsEvent):
     kinds = ArrayField(
         models.CharField(
             max_length=255,
-            choices=zip(
-                [t.value for t in TypeService],
-                [t.label for t in TypeService],
-            ),
+            choices=[(t.value, t.label) for t in TypeService],
         ),
         verbose_name="Types de service",
         blank=True,

--- a/back/dora/stats/models.py
+++ b/back/dora/stats/models.py
@@ -1,3 +1,4 @@
+from data_inclusion.schema.v1 import TypeService
 from django.conf import settings
 from django.contrib.postgres.fields import ArrayField
 from django.db import models
@@ -9,7 +10,6 @@ from dora.services.models import (
     Service,
     ServiceCategory,
     ServiceFee,
-    ServiceKind,
     ServiceSubCategory,
 )
 from dora.structures.models import Structure
@@ -215,10 +215,17 @@ class AbstractSearchEvent(AbstractAnalyticsEvent):
 
     results_slugs_top10 = ArrayField(models.CharField(blank=True), default=list)
 
-    kinds = models.ManyToManyField(
-        ServiceKind,
-        verbose_name="Type de service",
+    kinds = ArrayField(
+        models.CharField(
+            max_length=255,
+            choices=zip(
+                [t.value for t in TypeService],
+                [t.label for t in TypeService],
+            ),
+        ),
+        verbose_name="Types de service",
         blank=True,
+        default=list,
     )
 
     fee_conditions = models.ManyToManyField(

--- a/back/dora/stats/tests/test_search_event.py
+++ b/back/dora/stats/tests/test_search_event.py
@@ -91,3 +91,21 @@ def test_thematic_search_derives_department(
     assert event.city_code == city_code
     assert event.department == expected_department
     assert event.region == ""
+
+
+def test_search_stores_kinds(api_client, base_payload):
+    event = post_search_view(
+        api_client,
+        {**base_payload, "kinds": ["formation", "information"]},
+    )
+
+    assert event.kinds == ["formation", "information"]
+
+
+def test_search_ignores_unknown_kinds(api_client, base_payload):
+    event = post_search_view(
+        api_client,
+        {**base_payload, "kinds": ["formation", "type-inexistant"]},
+    )
+
+    assert event.kinds == ["formation"]

--- a/back/dora/stats/views.py
+++ b/back/dora/stats/views.py
@@ -1,3 +1,4 @@
+from data_inclusion.schema.v1 import TypeService
 from django.db.models import Q
 from rest_framework import permissions
 from rest_framework.decorators import api_view, permission_classes
@@ -14,7 +15,6 @@ from dora.services.models import (
     Service,
     ServiceCategory,
     ServiceFee,
-    ServiceKind,
     ServiceSubCategory,
 )
 from dora.stats.models import (
@@ -155,7 +155,10 @@ def log_event(request):
             num_results = int(request.data.get("search_num_results", "0"))
             num_di_results = int(request.data.get("num_di_results", "0"))
             num_di_results_top10 = int(request.data.get("num_di_results_top10", "0"))
-            kinds = request.data.get("kinds", [])
+            # Les valeurs proviennent du front : on ne conserve que celles du référentiel
+            kinds = [
+                kind for kind in request.data.get("kinds") or [] if kind in TypeService
+            ]
             fee_conditions = request.data.get("fee_conditions")
             location_kinds = request.data.get("location_kinds")
             results_slugs_top10 = request.data.get("results_slugs_top10", [])
@@ -170,13 +173,13 @@ def log_event(request):
                 num_di_results=num_di_results,
                 num_di_results_top10=num_di_results_top10,
                 results_slugs_top10=results_slugs_top10,
+                kinds=kinds,
             )
             cats_values = request.data.get("category_ids", [])
             subcats_values = request.data.get("sub_category_ids", [])
             categories, subcategories = get_categories(cats_values, subcats_values)
             event.categories.set(categories)
             event.subcategories.set(subcategories)
-            event.kinds.set(ServiceKind.objects.filter(value__in=kinds))
             event.fee_conditions.set(
                 ServiceFee.objects.filter(value__in=fee_conditions)
             )


### PR DESCRIPTION
Étape 1 de la migration du champ `kinds` M2M vers un champ `kind` mono-valué : remplacement des M2M kinds de `SavedSearch` et `SearchView` par un `ArrayField`.