### PR TITLE
fix: ne pas modifier la colonne publics_precisions ni au backfill ni à la double-écriture

### DIFF
--- a/back/dora/services/management/commands/backfill_publics_di.py
+++ b/back/dora/services/management/commands/backfill_publics_di.py
@@ -9,7 +9,7 @@ BATCH = 500
 
 class Command(AtomicHandleMixin, BaseCommand):
     ATOMIC_HANDLE = True
-    help = "Réconciliation des services dont les publics ont divergé de leurs valeurs pour les colonnes publics_di et publics_precisions."
+    help = "Réconciliation des services dont les publics ont divergé de leurs valeurs pour les colonnes publics_di"
 
     def add_arguments(self, parser):
         parser.add_argument(
@@ -28,37 +28,27 @@ class Command(AtomicHandleMixin, BaseCommand):
         updated = []
         qs = (
             Service._base_manager.prefetch_related("publics")
-            .only("pk", "publics_di", "publics_precisions")
+            .only("pk", "publics_di")
             .iterator(chunk_size=BATCH)
         )
         for service in qs:
-            publics_di, publics_precisions = compute_publics_di(service)
-            if (
-                service.publics_di == publics_di
-                and service.publics_precisions == publics_precisions
-            ):
+            publics_di = compute_publics_di(service)
+            if service.publics_di == publics_di:
                 continue
 
             mismatches += 1
             self.stdout.write(
-                f"{service.pk}: "
-                f"{service.publics_di!r} -> {publics_di!r} | "
-                f"{service.publics_precisions!r} -> {publics_precisions!r}"
+                f"{service.pk}: {service.publics_di!r} -> {publics_di!r} | "
             )
 
             service.publics_di = publics_di
-            service.publics_precisions = publics_precisions
             updated.append(service)
             if len(updated) >= BATCH:
-                Service._base_manager.bulk_update(
-                    updated, ["publics_di", "publics_precisions"]
-                )
+                Service._base_manager.bulk_update(updated, ["publics_di"])
                 updated = []
 
         if updated:
-            Service._base_manager.bulk_update(
-                updated, ["publics_di", "publics_precisions"]
-            )
+            Service._base_manager.bulk_update(updated, ["publics_di"])
 
         if options["wet_run"]:
             self.stdout.write(self.style.SUCCESS(f"{mismatches} services corrigés"))

--- a/back/dora/services/signals_publics.py
+++ b/back/dora/services/signals_publics.py
@@ -1,4 +1,4 @@
-"""Double écriture : maintient `Service.publics_di` / `publics_precisions` synchronisés avec la
+"""Double écriture : maintient `Service.publics_di` synchronisés avec la
 relation M2M historique `publics` pendant leur coexistence (fenêtre de migration expand/contract).
 """
 
@@ -15,12 +15,9 @@ def _sync_instance(service):
     # `service` est l'instance de la requête (cas forward) : on écrit en base ET on met à jour
     # l'objet en mémoire, sinon un save() complet ultérieur (p. ex. send_moderation_notification)
     # réécrirait des valeurs périmées.
-    publics_di, publics_precisions = compute_publics_di(service)
-    Service._base_manager.filter(pk=service.pk).update(
-        publics_di=publics_di, publics_precisions=publics_precisions
-    )
+    publics_di = compute_publics_di(service)
+    Service._base_manager.filter(pk=service.pk).update(publics_di=publics_di)
     service.publics_di = publics_di
-    service.publics_precisions = publics_precisions
 
 
 def _sync_pks(pks):
@@ -29,11 +26,11 @@ def _sync_pks(pks):
     services = (
         Service._base_manager.filter(pk__in=pks)
         .prefetch_related("publics")
-        .only("pk", "publics_di", "publics_precisions")
+        .only("pk", "publics_di")
         .iterator(chunk_size=BATCH)
     )
     for service in services:
-        service.publics_di, service.publics_precisions = compute_publics_di(service)
+        service.publics_di = compute_publics_di(service)
         updated.append(service)
         if len(updated) >= BATCH:
             _bulk_update(updated)
@@ -43,9 +40,7 @@ def _sync_pks(pks):
 
 def _bulk_update(services):
     if services:
-        Service._base_manager.bulk_update(
-            services, ["publics_di", "publics_precisions"]
-        )
+        Service._base_manager.bulk_update(services, ["publics_di"])
 
 
 @receiver(m2m_changed, sender=Service.publics.through)

--- a/back/dora/services/tests/test_backfill_publics_di.py
+++ b/back/dora/services/tests/test_backfill_publics_di.py
@@ -23,9 +23,7 @@ def _service_with_drift():
         baker.make(Public, name="familles", corresponding_di_publics=[FAMILLES])
     )
     # Contourne le signal de double écriture pour introduire un écart.
-    Service.objects.filter(pk=service.pk).update(
-        publics_di=["stale-value"], publics_precisions="stale"
-    )
+    Service.objects.filter(pk=service.pk).update(publics_di=["stale-value"])
     return service
 
 
@@ -39,7 +37,6 @@ def test_dry_run_reports_drift_without_writing():
 
     service.refresh_from_db()
     assert service.publics_di == ["stale-value"]
-    assert service.publics_precisions == "stale"
 
 
 def test_run_fixes_drift():
@@ -50,7 +47,6 @@ def test_run_fixes_drift():
     assert "corrigés" in out
     service.refresh_from_db()
     assert service.publics_di == [FAMILLES]
-    assert service.publics_precisions == "familles"
 
 
 def test_clean_state_reports_no_drift():
@@ -84,7 +80,7 @@ def test_fixes_service_model_with_drift():
         baker.make(Public, name="familles", corresponding_di_publics=[FAMILLES])
     )
     ServiceModel.objects.filter(pk=service_model_with_drift.pk).update(
-        publics_di=["stale-value"], publics_precisions="stale"
+        publics_di=["stale-value"]
     )
 
     out = _run("--wet-run")
@@ -92,4 +88,3 @@ def test_fixes_service_model_with_drift():
     assert "corrigés" in out
     service_model_with_drift.refresh_from_db()
     assert service_model_with_drift.publics_di == [FAMILLES]
-    assert service_model_with_drift.publics_precisions == "familles"

--- a/back/dora/services/tests/test_signals_publics.py
+++ b/back/dora/services/tests/test_signals_publics.py
@@ -15,9 +15,7 @@ def test_signal_add_writes_columns():
         baker.make(Public, name="familles", corresponding_di_publics=[FAMILLES])
     )
     service.refresh_from_db()
-    assert (service.publics_di, service.publics_precisions) == compute_publics_di(
-        service
-    )
+    assert service.publics_di == compute_publics_di(service)
     assert service.publics_di == [FAMILLES]
 
 
@@ -30,9 +28,7 @@ def test_signal_set_rewrites_columns():
         [baker.make(Public, name="etudiants", corresponding_di_publics=[ETUDIANTS])]
     )
     service.refresh_from_db()
-    assert (service.publics_di, service.publics_precisions) == compute_publics_di(
-        service
-    )
+    assert service.publics_di == compute_publics_di(service)
     assert service.publics_di == [ETUDIANTS]
 
 
@@ -44,7 +40,7 @@ def test_signal_clear_returns_empty():
     )
     service.publics.clear()
     service.refresh_from_db()
-    assert (service.publics_di, service.publics_precisions) == ([], "")
+    assert service.publics_di == []
 
 
 def test_signal_public_save_applies_to_all_associated_services():
@@ -55,7 +51,7 @@ def test_signal_public_save_applies_to_all_associated_services():
     public.corresponding_di_publics = [ETUDIANTS]
     public.save()
     service.refresh_from_db()
-    assert (service.publics_di, service.publics_precisions) == ([ETUDIANTS], "familles")
+    assert service.publics_di == [ETUDIANTS]
 
 
 def test_signal_survives_later_full_save():
@@ -67,7 +63,7 @@ def test_signal_survives_later_full_save():
     )
     service.save()
     service.refresh_from_db()
-    assert (service.publics_di, service.publics_precisions) == ([FAMILLES], "familles")
+    assert service.publics_di == [FAMILLES]
 
 
 def test_signal_reverse_clear_resyncs_services():
@@ -78,7 +74,7 @@ def test_signal_reverse_clear_resyncs_services():
 
     public.service_set.clear()
     service.refresh_from_db()
-    assert (service.publics_di, service.publics_precisions) == ([], "")
+    assert service.publics_di == []
 
 
 def test_signal_public_delete_resyncs_services():
@@ -89,7 +85,7 @@ def test_signal_public_delete_resyncs_services():
 
     public.delete()
     service.refresh_from_db()
-    assert (service.publics_di, service.publics_precisions) == ([], "")
+    assert service.publics_di == []
 
 
 def test_update_service_model():
@@ -99,8 +95,5 @@ def test_update_service_model():
     )
     service_model.refresh_from_db()
 
-    assert (
-        service_model.publics_di,
-        service_model.publics_precisions,
-    ) == compute_publics_di(service_model)
+    assert service_model.publics_di == compute_publics_di(service_model)
     assert service_model.publics_di == [FAMILLES]

--- a/back/dora/services/tests/test_utils_kind.py
+++ b/back/dora/services/tests/test_utils_kind.py
@@ -3,7 +3,7 @@ from data_inclusion.schema.v1 import TypeService
 from data_inclusion.schema.v1.publics import Public as DiPublic
 from model_bakery import baker
 
-from dora.core.test_utils import make_service, make_structure
+from dora.core.test_utils import make_service
 from dora.services.models import Public, ServiceKind
 from dora.services.utils import (
     SERVICE_KIND_PRIORITY,
@@ -26,13 +26,13 @@ def _public(name, slugs, structure=None):
 def test_empty_m2m_returns_empty():
     # [] signifie « tous publics »
     service = make_service()
-    assert compute_publics_di(service) == ([], "")
+    assert compute_publics_di(service) == []
 
 
 def test_single_public():
     service = make_service()
     service.publics.add(_public("familles", [FAMILLES]))
-    assert compute_publics_di(service) == ([FAMILLES], "familles")
+    assert compute_publics_di(service) == [FAMILLES]
 
 
 def test_publics_di_contains_only_unique_values():
@@ -41,7 +41,7 @@ def test_publics_di_contains_only_unique_values():
         _public("a", [FAMILLES, ETUDIANTS]),
         _public("b", [ETUDIANTS, ACTIFS]),
     )
-    publics_di, _ = compute_publics_di(service)
+    publics_di = compute_publics_di(service)
     assert publics_di == sorted({ACTIFS, ETUDIANTS, FAMILLES})
 
 
@@ -51,14 +51,14 @@ def test_exclusivity_drops_tous_publics_if_another_public_present():
         _public("tous", [TOUS_PUBLICS]),
         _public("familles", [FAMILLES]),
     )
-    assert compute_publics_di(service) == ([FAMILLES], "familles; tous")
+    assert compute_publics_di(service) == [FAMILLES]
 
 
 def test_tous_publics_is_never_stored():
     # tous-publics est toujours retiré : un service « tous publics » stocke [].
     service = make_service()
     service.publics.add(_public("tous", [TOUS_PUBLICS]))
-    assert compute_publics_di(service) == ([], "tous")
+    assert compute_publics_di(service) == []
 
 
 def test_invalid_slug_filtered_out():
@@ -68,42 +68,7 @@ def test_invalid_slug_filtered_out():
     Public.objects.filter(pk=public.pk).update(
         corresponding_di_publics=["not-a-real-public", FAMILLES]
     )
-    assert compute_publics_di(service) == ([FAMILLES], "familles")
-
-
-def test_publics_precisions_contains_all_public_names():
-    # precisions = tous les noms de publics (globaux + personnalisés), triés, dédupliqués.
-    service = make_service()
-    structure = make_structure()
-    service.publics.add(
-        _public("Nom personnalisé", [FAMILLES], structure=structure),
-        _public("familles", [ETUDIANTS]),
-    )
-    _, precisions = compute_publics_di(service)
-    assert precisions == "Nom personnalisé; familles"
-
-
-def test_publics_precisions_are_unique():
-    service = make_service()
-    structure_a = make_structure()
-    structure_b = make_structure()
-    service.publics.add(
-        _public("Jeunes du quartier", [FAMILLES], structure=structure_a),
-        _public("Seniors isolés", [ETUDIANTS], structure=structure_a),
-        _public("Jeunes du quartier", [ACTIFS], structure=structure_b),
-    )
-    _, precisions = compute_publics_di(service)
-    assert precisions == "Jeunes du quartier; Seniors isolés"
-
-
-def test_publics_precisions_are_sorted():
-    service = make_service()
-    service.publics.add(
-        _public("Seniors isolés", [FAMILLES], structure=make_structure()),
-        _public("Jeunes du quartier", [ACTIFS], structure=make_structure()),
-    )
-    _, precisions = compute_publics_di(service)
-    assert precisions == "Jeunes du quartier; Seniors isolés"
+    assert compute_publics_di(service) == [FAMILLES]
 
 
 def test_publics_di_is_sorted():
@@ -112,7 +77,7 @@ def test_publics_di_is_sorted():
         _public("z", [FAMILLES]),
         _public("a", [ACTIFS]),
     )
-    publics_di, _ = compute_publics_di(service)
+    publics_di = compute_publics_di(service)
     assert publics_di == sorted(publics_di)
 
 

--- a/back/dora/services/utils.py
+++ b/back/dora/services/utils.py
@@ -71,15 +71,14 @@ SERVICE_KIND_PRIORITY = [
 
 
 def compute_publics_di(service):
-    slugs, names = set(), []
+    slugs = set()
     for public in service.publics.all():
         slugs.update(
             s for s in (public.corresponding_di_publics or []) if s in VALID_DI_PUBLICS
         )
-        names.append(public.name)
     # tous-publics n'est jamais stocké : un tableau vide signifie « tous publics ».
     slugs.discard(TOUS_PUBLICS)
-    return sorted(slugs), "; ".join(sorted(set(names)))
+    return sorted(slugs)
 
 
 def compute_service_kind(service):


### PR DESCRIPTION
On a décidé de ne pas modifier la colonne `publics_precisions` ni au backfill ni à la double-écriture