### PR TITLE
fix: afficher les services tous-publics peu importe le public sélectionné dans le filtre

### DIFF
--- a/back/dora/api/serializers.py
+++ b/back/dora/api/serializers.py
@@ -1,10 +1,10 @@
 # from django.core.files.storage import default_storage
+from data_inclusion.schema.v1.publics import Public as DiPublic
 from rest_framework import serializers
 
 from dora.services.models import (
     Service,
 )
-from dora.services.utils import display_di_publics
 from dora.structures.models import Structure
 
 ############
@@ -295,7 +295,13 @@ class ServiceSerializer(serializers.ModelSerializer):
         return obj.fee_details or None
 
     def get_publics(self, obj):
-        return display_di_publics(obj.publics_di)
+        # Export data·inclusion uniquement : une liste vide (aucune restriction) ou la
+        # totalité du référentiel se traduisent en « tous-publics ». Seul endroit où Dora
+        # réintroduit `tous-publics` ; partout ailleurs l'absence de restriction reste [].
+        specific_publics = {p.value for p in DiPublic} - {DiPublic.TOUS_PUBLICS.value}
+        if not obj.publics_di or set(obj.publics_di) >= specific_publics:
+            return [DiPublic.TOUS_PUBLICS.value]
+        return obj.publics_di
 
     def get_publics_precisions(self, obj):
         return obj.publics_precisions

--- a/back/dora/data_inclusion/mappings.py
+++ b/back/dora/data_inclusion/mappings.py
@@ -91,7 +91,11 @@ def map_search_result(result: dict) -> dict:
         #
         # ServiceSerializer
         #
-        "di_publics": service_data["publics"] or [],
+        # DI -> Dora : `tous-publics` (absence de restriction) devient une liste vide,
+        # que les lecteurs Dora réinterprètent comme « tous publics ».
+        "di_publics": [
+            p for p in (service_data["publics"] or []) if p != Public.TOUS_PUBLICS.value
+        ],
         "location_kinds": location_kinds,
         "kind": service_data["type"],
         "kinds": [service_data["type"]],
@@ -239,9 +243,12 @@ def map_service(service_data: dict, is_authenticated: bool) -> dict:
 
     publics = None
     if service_data["publics"] is not None:
+        # `tous-publics` (absence de restriction) n'est pas conservé côté Dora :
+        # une liste vide sera affichée « Tous publics ».
         publics = [
             Public(p)
             for p in (set(service_data["publics"]) & {p.value for p in Public})
+            if p != Public.TOUS_PUBLICS.value
         ]
 
     diffusion_zone_info = get_diffusion_zone_info(service_data["zone_eligibilite"])

--- a/back/dora/services/serializers.py
+++ b/back/dora/services/serializers.py
@@ -23,7 +23,7 @@ import dora.data_inclusion.client
 from dora.core.utils import code_insee_to_code_dept
 from dora.decoupage_administratif.models import AdminDivisionType
 from dora.services.enums import ServiceStatus
-from dora.services.utils import display_di_publics, get_kinds_labels
+from dora.services.utils import get_kinds_labels
 from dora.structures.models import Structure, StructureMember
 
 from .models import (
@@ -950,7 +950,10 @@ class SearchResultSerializer(ServiceListSerializer):
             return (obj.geom.x, obj.geom.y)
 
     def get_di_publics(self, obj):
-        return display_di_publics(obj.publics_di)
+        # Côté application/front, publics = restrictions ; une liste vide signifie
+        # « aucune restriction » (tous publics). On n'inflate pas en `tous-publics`
+        # (ça reste réservé à l'interface DI, cf. api/serializers.py).
+        return obj.publics_di
 
     def get_location_kinds(self, obj):
         """

--- a/back/dora/services/tests/test_serializers.py
+++ b/back/dora/services/tests/test_serializers.py
@@ -24,26 +24,24 @@ def test_service_bookmark_serialization(service_with_source):
     assert data["service"]["source"] == service_with_source.source.label
 
 
-def test_search_di_publics_empty_maps_to_tous():
-    # Aucun public -> publics_di == [] -> réinterprété « tous-publics » à l'affichage.
+def test_search_di_publics_empty_returns_empty():
+    # Aucun public -> publics_di == [] : « aucune restriction ». La lecture applicative
+    # n'inflate plus en `tous-publics` (réservé à l'interface DI) ; le front affiche
+    # « Tous publics » sur la liste vide.
     service = make_service()
     service.refresh_from_db()
-    assert SearchResultSerializer().get_di_publics(service) == [TOUS_PUBLICS]
+    assert SearchResultSerializer().get_di_publics(service) == []
 
 
-def test_search_di_publics_all_referential_maps_to_tous():
-    # Tout le référentiel sélectionné se présente comme « tous-publics » (collapse à l'affichage,
-    # la colonne reste fidèle).
+def test_search_di_publics_all_referential_returned_as_is():
+    # Le collapse « tout le référentiel -> tous-publics » n'a plus lieu en lecture
+    # applicative : la colonne est renvoyée fidèlement.
+    expected = sorted(p.value for p in DiPublic if p.value != TOUS_PUBLICS)
     service = make_service()
-    for public in DiPublic:
-        if public.value != TOUS_PUBLICS:
-            service.publics.add(
-                baker.make(
-                    Public, name=public.value, corresponding_di_publics=[public.value]
-                )
-            )
+    service.publics_di = expected
+    service.save()
     service.refresh_from_db()
-    assert SearchResultSerializer().get_di_publics(service) == [TOUS_PUBLICS]
+    assert SearchResultSerializer().get_di_publics(service) == expected
 
 
 def test_search_di_publics_returns_specific_publics():

--- a/back/dora/services/utils.py
+++ b/back/dora/services/utils.py
@@ -90,15 +90,6 @@ def compute_service_kind(service):
     return next((k.value for k in SERVICE_KIND_PRIORITY if k.value in values), None)
 
 
-def display_di_publics(publics_di):
-    """Représentation d'affichage de `publics_di` : [] (aucun public) ou la totalité du
-    référentiel se présentent comme « tous-publics ». La colonne reste fidèle à la
-    sélection (on ne collapse jamais en base)."""
-    if not publics_di or set(publics_di) >= (VALID_DI_PUBLICS - {TOUS_PUBLICS}):
-        return [TOUS_PUBLICS]
-    return publics_di
-
-
 def _duplicate_customizable_choices(field, choices, structure):
     for choice in choices:
         if choice.structure:

--- a/front/src/routes/recherche/+page.svelte
+++ b/front/src/routes/recherche/+page.svelte
@@ -116,11 +116,17 @@
     }
   });
 
+  // Un service sans restriction de public (liste vide) est ouvert à tous :
+  // il correspond à n'importe quel filtre de public sélectionné.
+  const servesAllPublics = (service: { diPublics: string[] }) =>
+    service.diPublics.length === 0;
+
   // Filtre les services en fonctions des filtres sélectionnés
   let filteredServices = $derived(
     data.services.filter((service) => {
       const diPublicsMatch =
         filters.diPublics.length === 0 ||
+        servesAllPublics(service) ||
         filters.diPublics.some((value) => service.diPublics.includes(value));
       const kindsMatch =
         filters.kinds.length === 0 ||


### PR DESCRIPTION
Avec ou sans l'AB test, la valeur de `diPublics` des services` peut contenir `tous-publics` si c'est le public concerné. Cette PR permet de les voir quand n'importe lequel public est sélectionné dans le filtre. Dans Dora, on renvoie toujours une liste vide si le service s'applique a`tous-publics`. on va plus inclure cette valeur dans la liste.

avec recherche textuelle (AB test on)
https://github.com/user-attachments/assets/b3226c02-6eca-4fd1-973c-5b5cedf638b8

sans recherche textuelle (AB test off)
https://github.com/user-attachments/assets/16f2e03f-01f4-4ee1-b5cb-044e4e4304c1

