### PR TITLE
refactor(services): suppression de la M2M `kinds` et du modèle `ServiceKind`

### DIFF
--- a/back/dora/data_inclusion/mappings.py
+++ b/back/dora/data_inclusion/mappings.py
@@ -5,6 +5,7 @@ from data_inclusion.schema.v1 import (
     ModeMobilisation,
     PersonneMobilisatrice,
     Public,
+    TypeService,
 )
 from django.conf import settings
 from django.utils import dateparse, timezone
@@ -21,7 +22,6 @@ from dora.services.models import (
     CoachOrientationMode,
     LocationKind,
     ServiceCategory,
-    ServiceKind,
     ServiceSubCategory,
     UpdateFrequency,
     get_update_needed,
@@ -158,7 +158,8 @@ def map_service(service_data: dict, is_authenticated: bool) -> dict:
             value__in=service_data["modes_accueil"]
         )
 
-    kind = ServiceKind.objects.filter(value=service_data["type"]).first()
+    # un type absent du référentiel (valeur historique) est traité comme un type manquant
+    kind = next((t for t in TypeService if t == service_data["type"]), None)
 
     department = None
     if service_data["code_insee"] is not None:

--- a/back/dora/services/admin.py
+++ b/back/dora/services/admin.py
@@ -26,7 +26,6 @@ from .models import (
     SavedSearch,
     Service,
     ServiceCategory,
-    ServiceKind,
     ServiceModel,
     ServiceModificationHistoryItem,
     ServiceSource,
@@ -550,7 +549,6 @@ admin.site.register(BeneficiaryAccessMode, EnumAdmin)
 admin.site.register(CoachOrientationMode, EnumAdmin)
 admin.site.register(LocationKind, EnumAdmin)
 admin.site.register(ServiceCategory, ServiceCategoryAdmin)
-admin.site.register(ServiceKind, EnumAdmin)
 admin.site.register(ServiceSubCategory, ServiceSubCategoryAdmin)
 admin.site.register(ServiceSource, EnumAdmin)
 admin.site.register(FundingLabel, EnumAdmin)

--- a/back/dora/services/migration_utils.py
+++ b/back/dora/services/migration_utils.py
@@ -250,7 +250,3 @@ def delete_category(ServiceCategory, value):
             f"Suppression impossible: la thématique '{value}' n'existe pas"
         )
     category.delete()
-
-
-def create_service_kind(ServiceKind, value, label):
-    return ServiceKind.objects.create(value=value, label=label)

--- a/back/dora/services/migrations/0009_remove_service_kinds.py
+++ b/back/dora/services/migrations/0009_remove_service_kinds.py
@@ -1,0 +1,67 @@
+from data_inclusion.schema.v1 import TypeService
+from django.db import migrations
+
+ARCHIVE_TABLE = "services_service_kinds_archive"
+
+
+def archive_kinds(apps, schema_editor):
+    """Archive la M2M avant sa suppression.
+
+    Le passage à un type unique fait perdre les types secondaires d'environ 58 % des
+    services : ils sont conservés quelques mois dans une table hors ORM, autonome (elle
+    stocke la valeur du type et non l'identifiant de `ServiceKind`, qui disparaît ici).
+    """
+    with schema_editor.connection.cursor() as cursor:
+        cursor.execute(
+            f"""
+            CREATE TABLE {ARCHIVE_TABLE} AS
+            SELECT liaison.service_id, kind.value AS kind
+            FROM services_service_kinds AS liaison
+            JOIN services_servicekind AS kind ON kind.id = liaison.servicekind_id
+            """
+        )
+
+
+def restore_kinds(apps, schema_editor):
+    """Repeuple `ServiceKind` et la M2M depuis l'archive, puis la supprime."""
+    ServiceKind = apps.get_model("services", "ServiceKind")
+    Service = apps.get_model("services", "Service")
+
+    ServiceKind.objects.bulk_create(
+        [ServiceKind(value=t.value, label=t.label) for t in TypeService],
+        ignore_conflicts=True,
+    )
+    kind_ids = dict(ServiceKind.objects.values_list("value", "id"))
+    through = Service.kinds.through
+
+    with schema_editor.connection.cursor() as cursor:
+        cursor.execute(f"SELECT service_id, kind FROM {ARCHIVE_TABLE}")
+        through.objects.bulk_create(
+            [
+                through(service_id=service_id, servicekind_id=kind_ids[value])
+                for service_id, value in cursor.fetchall()
+                if value in kind_ids
+            ],
+            batch_size=1000,
+        )
+        cursor.execute(f"DROP TABLE {ARCHIVE_TABLE}")
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("services", "0008_recompute_sync_checksums"),
+        # dernière migration à référencer `ServiceKind` : sur une base neuve, elle doit
+        # s'appliquer avant que le modèle ne disparaisse de l'état
+        ("stats", "0005_searchview_kinds_array"),
+    ]
+
+    operations = [
+        migrations.RunPython(archive_kinds, restore_kinds),
+        migrations.RemoveField(
+            model_name="service",
+            name="kinds",
+        ),
+        migrations.DeleteModel(
+            name="ServiceKind",
+        ),
+    ]

--- a/back/dora/services/models.py
+++ b/back/dora/services/models.py
@@ -162,12 +162,6 @@ class ServiceSubCategory(EnumModel):
         verbose_name = "Sous-catégorie"
 
 
-class ServiceKind(EnumModel):
-    class Meta:
-        verbose_name = "Type de service"
-        verbose_name_plural = "Types de service"
-
-
 class FundingLabel(EnumModel):
     class Meta:
         verbose_name = "Label de financement"
@@ -349,14 +343,6 @@ class Service(ModerationMixin, models.Model):
 
     ##########
     # Typology
-
-    # Remplacée par `kind`, qui est désormais le seul champ lu et écrit. La M2M est gelée
-    # en l'état : conservée le temps de vérifier la bascule, elle sera supprimée ensuite.
-    kinds = models.ManyToManyField(
-        ServiceKind,
-        verbose_name="Types de service (déprécié)",
-        blank=True,
-    )
 
     # `null` (et non chaîne vide) pour les services sans type : l'absence de type est une
     # information à part entière, à ne pas confondre avec une valeur non renseignée.

--- a/back/dora/services/serializers.py
+++ b/back/dora/services/serializers.py
@@ -25,7 +25,6 @@ from dora.decoupage_administratif.models import AdminDivisionType
 from dora.services.enums import ServiceStatus
 from dora.services.utils import (
     get_kinds_labels,
-    reduce_service_kinds,
 )
 from dora.structures.models import Structure, StructureMember
 
@@ -165,15 +164,6 @@ class ServiceSerializer(serializers.ModelSerializer):
         allow_blank=True,
     )
     kind_display = serializers.SerializerMethodField()
-    # Tolérance transitoire : front et back se déployant séparément, une version du front
-    # envoyant encore `kinds` doit continuer à fonctionner — DRF ignorerait silencieusement
-    # la clé et le service perdrait son type. Réduit vers `kind` ; la lecture est assurée
-    # par `to_representation`, elle aussi dérivée de `kind`. À retirer avec `Service.kinds`.
-    kinds = serializers.ListField(
-        child=serializers.ChoiceField(choices=TypeService),
-        write_only=True,
-        required=False,
-    )
     categories = serializers.SlugRelatedField(
         slug_field="value",
         queryset=ServiceCategory.objects.all(),
@@ -344,7 +334,6 @@ class ServiceSerializer(serializers.ModelSerializer):
             "is_orientable",
             "kind",
             "kind_display",
-            "kinds",
             "location_kinds",
             "location_kinds_display",
             "model",
@@ -396,17 +385,6 @@ class ServiceSerializer(serializers.ModelSerializer):
     def get_kind_display(self, obj):
         return TypeService(obj.kind).label if obj.kind else None
 
-    def to_representation(self, instance):
-        # Pendant de la tolérance en écriture sur `kinds` : une version du front pas encore
-        # à jour lit encore `kinds`/`kinds_display`, et leur absence la casse (résultats de
-        # recherche vidés dès qu'un filtre de type est coché, `.filter()` sur `undefined`).
-        # Dérivés de `kind`, jamais lus depuis la M2M. À retirer avec `Service.kinds`.
-        data = super().to_representation(instance)
-        kinds = [instance.kind] if instance.kind else []
-        data["kinds"] = kinds
-        data["kinds_display"] = get_kinds_labels(kinds)
-        return data
-
     def get_is_available(self, obj):
         return True
 
@@ -450,13 +428,6 @@ class ServiceSerializer(serializers.ModelSerializer):
     def validate(self, data):
         user = self.context.get("request").user
         structure = data.get("structure") or self.instance.structure
-
-        # `kinds` n'est plus stockée : soit elle complète un `kind` absent (front pas encore
-        # à jour), soit elle est ignorée. Le retrait de la clé est nécessaire, sans quoi DRF
-        # tenterait d'écrire la M2M avec des chaînes.
-        kinds = data.pop("kinds", None)
-        if kinds is not None and "kind" not in data:
-            data["kind"] = reduce_service_kinds(kinds)
 
         # Un service sans type saisi est un service sans type : le formulaire envoie une
         # chaîne vide, la base attend un NULL.
@@ -611,7 +582,6 @@ class ServiceModelSerializer(ServiceSerializer):
             "is_model",
             "kind",
             "kind_display",
-            "kinds",
             "modification_date",
             "name",
             "num_services",

--- a/back/dora/services/tests/test_service_kind_api.py
+++ b/back/dora/services/tests/test_service_kind_api.py
@@ -21,9 +21,6 @@ def test_service_detail_exposes_the_kind(api_client):
     assert response.status_code == 200
     assert response.data["kind"] == "atelier"
     assert response.data["kind_display"] == "Atelier"
-    # la M2M a disparu
-    assert "kinds" not in response.data
-    assert "kinds_display" not in response.data
 
 
 def test_service_without_kind_exposes_null(api_client):

--- a/back/dora/services/tests/test_service_kind_api.py
+++ b/back/dora/services/tests/test_service_kind_api.py
@@ -4,7 +4,6 @@ from data_inclusion.schema.v1 import TypeService
 from django.core.cache import cache
 
 from dora.core.test_utils import make_published_service, make_structure, make_user
-from dora.services.models import ServiceKind
 
 
 def _published_service(api_client, **kwargs):
@@ -22,9 +21,9 @@ def test_service_detail_exposes_the_kind(api_client):
     assert response.status_code == 200
     assert response.data["kind"] == "atelier"
     assert response.data["kind_display"] == "Atelier"
-    # tolérance transitoire, en lecture cette fois : `kinds` reste servie, dérivée de `kind`
-    assert response.data["kinds"] == ["atelier"]
-    assert response.data["kinds_display"] == ["Atelier"]
+    # la M2M a disparu
+    assert "kinds" not in response.data
+    assert "kinds_display" not in response.data
 
 
 def test_service_without_kind_exposes_null(api_client):
@@ -34,8 +33,6 @@ def test_service_without_kind_exposes_null(api_client):
 
     assert response.data["kind"] is None
     assert response.data["kind_display"] is None
-    assert response.data["kinds"] == []
-    assert response.data["kinds_display"] == []
 
 
 def test_kind_is_writable(api_client):
@@ -69,49 +66,8 @@ def test_an_unknown_kind_is_rejected(api_client):
     assert service.kind == "information"
 
 
-def test_a_front_still_sending_kinds_keeps_the_highest_priority_one(api_client):
-    """Tolérance transitoire : front et back ne sont pas déployés au même instant."""
-    service = _published_service(api_client)
-
-    response = api_client.patch(
-        f"/services/{service.slug}/", {"kinds": ["information", "aide-financiere"]}
-    )
-
-    assert response.status_code == 200
-    assert response.data["kind"] == "aide-financiere"
-    service.refresh_from_db()
-    assert service.kind == "aide-financiere"
-
-
-def test_kind_wins_over_kinds_when_both_are_sent(api_client):
-    service = _published_service(api_client)
-
-    response = api_client.patch(
-        f"/services/{service.slug}/",
-        {"kind": "atelier", "kinds": ["aide-financiere"]},
-    )
-
-    assert response.status_code == 200
-    service.refresh_from_db()
-    assert service.kind == "atelier"
-
-
-def test_the_m2m_is_left_untouched(api_client):
-    """`kinds` est gelée jusqu'à sa suppression : elle n'est plus ni lue ni écrite."""
-    service = _published_service(api_client)
-    service.kinds.set(ServiceKind.objects.filter(value="information"))
-
-    response = api_client.patch(f"/services/{service.slug}/", {"kind": "atelier"})
-
-    assert [k.value for k in service.kinds.all()] == ["information"]
-    # y compris pour la compatibilité en lecture, qui dérive de `kind` et non de la M2M
-    assert response.data["kinds"] == ["atelier"]
-
-
 def test_option_kinds_come_from_the_di_referential(api_client):
     cache.delete("options:anon")
-    # un type résiduel en base ne doit plus apparaître dans les options
-    ServiceKind.objects.create(value="plus-utilise", label="Plus utilisé")
 
     response = api_client.get("/services-options/")
 

--- a/back/dora/services/tests/test_services.py
+++ b/back/dora/services/tests/test_services.py
@@ -31,7 +31,6 @@ from dora.services.enums import ServiceStatus
 from dora.services.migration_utils import (
     add_categories_and_subcategories_if_subcategory,
     create_category,
-    create_service_kind,
     create_subcategory,
     delete_category,
     delete_subcategory,
@@ -55,7 +54,6 @@ from ..models import (
     Service,
     ServiceCategory,
     ServiceFee,
-    ServiceKind,
     ServiceModel,
     ServiceModificationHistoryItem,
     ServiceStatusHistoryItem,
@@ -1295,9 +1293,7 @@ class DataInclusionSearchTestCase(APITestCase):
             {
                 "di": True,
                 "city": self.city2.code,
-                "kinds": ServiceKind.objects.filter(value=service_data["type"])
-                .first()
-                .value,
+                "kinds": service_data["type"],
             },
         )
         response = self.search(request)
@@ -1403,13 +1399,7 @@ class DataInclusionSearchTestCase(APITestCase):
         request = self.factory.get(f"/services-di/{service_data['id']}/")
         response = self.service_di(request, di_id=service_data["id"])
 
-        # les champs en écriture seule — la tolérance transitoire `kinds` — ne sont pas restitués
-        readable_fields = {
-            name
-            for name, field in ServiceSerializer().fields.items()
-            if not field.write_only
-        }
-        for field in readable_fields:
+        for field in ServiceSerializer().fields:
             with self.subTest(field=field):
                 assert field in response.data
 
@@ -2584,21 +2574,6 @@ class ServiceMigrationUtilsTestCase(APITestCase):
         self.assertEqual(category.count(), 1)
         self.assertEqual(category.first().value, value)
         self.assertEqual(category.first().label, label)
-
-    def test_create_service_kind(self):
-        # ÉTANT DONNÉ un type de service non existant
-        value = "new-value"
-        label = "Nouvelle valeur"
-        self.assertEqual(ServiceKind.objects.filter(value=value).count(), 0)
-
-        # QUAND je créé ce type de service
-        create_service_kind(ServiceKind, value, label)
-
-        # ALORS il existe
-        subcategory = ServiceKind.objects.filter(value=value)
-        self.assertEqual(subcategory.count(), 1)
-        self.assertEqual(subcategory.first().value, value)
-        self.assertEqual(subcategory.first().label, label)
 
     def test_create_subcategory(self):
         # ÉTANT DONNÉ un besoin non existant

--- a/back/dora/services/tests/test_services_saved_searchs.py
+++ b/back/dora/services/tests/test_services_saved_searchs.py
@@ -1,4 +1,3 @@
-import random
 from datetime import timedelta
 from io import StringIO
 from unittest import mock
@@ -28,7 +27,6 @@ from dora.services.management.commands.send_saved_searches_notifications import 
 from ..models import (
     SavedSearch,
     SavedSearchFrequency,
-    ServiceKind,
     ServiceSubCategory,
 )
 
@@ -238,8 +236,8 @@ class ServiceSavedSearchNotificationTestCase(APITestCase):
                     ).values_list("value", flat=True)
                 )
         di_kwargs["thematiques"] = thematiques
-        if kinds := kwargs.get("kinds"):
-            di_kwargs["type"] = random.choice(kinds).value
+        if kind := kwargs.get("kind"):
+            di_kwargs["type"] = kind
         if fee := kwargs.get("fee_condition"):
             di_kwargs["frais"] = fee.value
         di_service = make_di_service_data(
@@ -552,8 +550,6 @@ class ServiceSavedSearchNotificationTestCase(APITestCase):
         sub_category_2 = baker.make(
             "ServiceSubCategory", value="cat1--sub2", label="cat1--sub2"
         )
-        kind = ServiceKind.objects.get(value="formation")
-        kind_2 = ServiceKind.objects.get(value="information")
 
         savedSearch = baker.make(
             "SavedSearch",
@@ -563,7 +559,7 @@ class ServiceSavedSearchNotificationTestCase(APITestCase):
             city_label=SAVE_SEARCH_ARGS.get("city_label"),
             city_code=SAVE_SEARCH_ARGS.get("city_code"),
             last_notification_date=timezone.now() - timedelta(days=40),
-            kinds=[kind.value, kind_2.value],
+            kinds=["formation", "information"],
         )
         savedSearch.subcategories.set([sub_category, sub_category_2])
 
@@ -573,7 +569,7 @@ class ServiceSavedSearchNotificationTestCase(APITestCase):
             status=ServiceStatus.PUBLISHED,
             categories="cat1",
             subcategories="cat1--sub1,cat1--sub2",
-            kinds=[kind, kind_2],
+            kind="formation",
             diffusion_zone_type=AdminDivisionType.CITY,
             publication_date=timezone.now() - timedelta(days=20),
             diffusion_zone_details=SAVE_SEARCH_ARGS.get("city_code"),
@@ -611,8 +607,6 @@ class ServiceSavedSearchNotificationTestCase(APITestCase):
         sub_category_2 = baker.make(
             "ServiceSubCategory", value="cat1--sub2", label="cat1--sub2"
         )
-        kind = ServiceKind.objects.get(value="formation")
-        kind_2 = ServiceKind.objects.get(value="information")
         fee = baker.make("ServiceFee", value="fee", label="fee")
 
         savedSearch = baker.make(
@@ -623,7 +617,7 @@ class ServiceSavedSearchNotificationTestCase(APITestCase):
             city_label=SAVE_SEARCH_ARGS.get("city_label"),
             city_code=SAVE_SEARCH_ARGS.get("city_code"),
             last_notification_date=timezone.now() - timedelta(days=40),
-            kinds=[kind.value, kind_2.value],
+            kinds=["formation", "information"],
         )
         savedSearch.subcategories.set([sub_category, sub_category_2])
         savedSearch.fees.set([fee])
@@ -634,7 +628,7 @@ class ServiceSavedSearchNotificationTestCase(APITestCase):
             status=ServiceStatus.PUBLISHED,
             categories="cat1",
             subcategories="cat1--sub1,cat1--sub2",
-            kinds=[kind, kind_2],
+            kind="formation",
             fee_condition=fee,
             diffusion_zone_type=AdminDivisionType.CITY,
             publication_date=timezone.now() - timedelta(days=20),

--- a/back/dora/services/tests/test_utils_publics.py
+++ b/back/dora/services/tests/test_utils_publics.py
@@ -1,16 +1,9 @@
-import pytest
-from data_inclusion.schema.v1 import TypeService
 from data_inclusion.schema.v1.publics import Public as DiPublic
 from model_bakery import baker
 
 from dora.core.test_utils import make_service
 from dora.services.models import Public
-from dora.services.utils import (
-    SERVICE_KIND_PRIORITY,
-    TOUS_PUBLICS,
-    compute_publics_di,
-    reduce_service_kinds,
-)
+from dora.services.utils import TOUS_PUBLICS, compute_publics_di
 
 FAMILLES = DiPublic.FAMILLES.value
 ETUDIANTS = DiPublic.ETUDIANTS.value
@@ -79,40 +72,3 @@ def test_publics_di_is_sorted():
     )
     publics_di = compute_publics_di(service)
     assert publics_di == sorted(publics_di)
-
-
-@pytest.mark.no_django_db
-def test_no_kind_reduces_to_none():
-    assert reduce_service_kinds([]) is None
-
-
-@pytest.mark.no_django_db
-@pytest.mark.parametrize("kind", [t.value for t in TypeService])
-def test_single_kind_is_kept(kind):
-    assert reduce_service_kinds([kind]) == kind
-
-
-@pytest.mark.no_django_db
-@pytest.mark.parametrize(
-    "kinds,expected",
-    [
-        (["information", "aide-financiere"], "aide-financiere"),
-        (["accompagnement", "aide-materielle"], "aide-materielle"),
-        (["atelier", "formation"], "formation"),
-        (["accompagnement", "atelier"], "atelier"),
-        (["information", "accompagnement"], "accompagnement"),
-        ([t.value for t in TypeService], "aide-financiere"),
-    ],
-)
-def test_highest_priority_kind_wins(kinds, expected):
-    assert reduce_service_kinds(kinds) == expected
-
-
-@pytest.mark.no_django_db
-def test_priority_covers_the_whole_referential():
-    assert {k.value for k in SERVICE_KIND_PRIORITY} == {t.value for t in TypeService}
-
-
-@pytest.mark.no_django_db
-def test_kind_outside_the_referential_is_ignored():
-    assert reduce_service_kinds(["obsolete"]) is None

--- a/back/dora/services/utils.py
+++ b/back/dora/services/utils.py
@@ -66,15 +66,6 @@ SYNC_CUSTOM_M2M_FIELDS = [
 TOUS_PUBLICS = DiPublic.TOUS_PUBLICS.value
 VALID_DI_PUBLICS = {p.value for p in DiPublic}
 
-SERVICE_KIND_PRIORITY = [
-    TypeService.AIDE_FINANCIERE,
-    TypeService.AIDE_MATERIELLE,
-    TypeService.FORMATION,
-    TypeService.ATELIER,
-    TypeService.ACCOMPAGNEMENT,
-    TypeService.INFORMATION,
-]
-
 
 def compute_publics_di(service):
     slugs = set()
@@ -85,12 +76,6 @@ def compute_publics_di(service):
     # tous-publics n'est jamais stocké : un tableau vide signifie « tous publics ».
     slugs.discard(TOUS_PUBLICS)
     return sorted(slugs)
-
-
-def reduce_service_kinds(values):
-    """Réduit une liste de types de service au type unique retenu."""
-    values = set(values)
-    return next((k.value for k in SERVICE_KIND_PRIORITY if k.value in values), None)
 
 
 def _duplicate_customizable_choices(field, choices, structure):

--- a/back/dora/services/views.py
+++ b/back/dora/services/views.py
@@ -731,7 +731,8 @@ def options(request):
         "subcategories": ServiceSubCategorySerializer(
             ServiceSubCategory.objects.all(), many=True
         ).data,
-        # servis depuis le référentiel DI plutôt que depuis `ServiceKind`, voué à disparaître
+        # servis depuis le référentiel DI ; la liste alimente aussi les filtres de recherche,
+        # qui restent multi-valués
         "kinds": [
             {"value": t.value, "label": t.label}
             for t in sorted(TypeService, key=lambda t: t.label)


### PR DESCRIPTION
Dernière étape du passage à un type unique : la M2M gelée, son référentiel et la tolérance transitoire disparaissent. La table de la M2M est archivée pour garder la migration réversible.