### PR TITLE
chore: Ajout d'une commande de normalisation des `password`

### DIFF
--- a/back/dora/users/management/commands/reset_non_staff_passwords.py
+++ b/back/dora/users/management/commands/reset_non_staff_passwords.py
@@ -1,0 +1,32 @@
+from dora.core.commands import BaseCommand
+from dora.users.models import User
+
+
+class Command(BaseCommand):
+    help = "Rend inutilisables les mots de passe des utilisateurs non-staff"
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--wet-run",
+            action="store_true",
+            default=False,
+            help="effectue les modifications demandées (pour de vrai)",
+        )
+
+    def handle(self, *args, **options):
+        users = list(
+            User.objects.filter(is_staff=False).exclude(password__startswith="!")
+        )
+
+        self.stdout.write(f"{len(users)} comptes à normaliser")
+
+        if not options["wet_run"]:
+            self.stdout.write(self.style.NOTICE("Mode 'dry-run' : rien n'est modifié"))
+            return
+
+        for user in users:
+            user.set_unusable_password()
+
+        User.objects.bulk_update(users, ["password"], batch_size=1000)
+
+        self.stdout.write(self.style.SUCCESS("Normalisation effectuée"))

--- a/docs/passwords/README.md
+++ b/docs/passwords/README.md
@@ -1,0 +1,16 @@
+# Mots de passe
+
+Les utilisateurs se connectent exclusivement par ProConnect. Seuls les utilisateurs `is_staff` peuvent se connecter via l'authentification Django à Django Admin.
+
+En fonction de la façon dont a été créé l'utilisateur, le format du contenu du champ `password` peut varier :
+
+
+| Valeur            | Origine                                                                                                                                                    |
+| ----------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `pbkdf2_sha256$…` | `set_password()` — inscription e-mail/mdp d'avant Inclusion Connect, superusers, création via l'admin                                                      |
+| `!` + 40 car.     | `set_unusable_password()` via `create_user()` — ProConnect, invitations, import CSV. Cas nominal actuel                                                    |
+| `""`              | `User.objects.create()` dans l'ancien callback Inclusion Connect (`dora/oidc/views.py` avant `fd909a5c`, 14/11/2024) — ne passait pas par `set_password()` |
+| `!disabled`       | Chaîne d'anonymisation (`tools/datanymizer-config.yml:26`) + [data.inclusion@beta.gouv.fr](mailto:data.inclusion@beta.gouv.fr) en prod                     |
+
+
+Une normalisation de valeurs du champ `password` a été faite en août 2026 afin que tous les utilisateurs normaux (non `is_staff`) aient une valeur au format `!` + 40 car.


### PR DESCRIPTION
## Contexte

Normalisation des valeurs du champ `password` des utilisateurs.

Formats des valeurs actuelles :

| Valeur | Origine | Connexion | Comptes |
| --- | --- | --- | --- |
| `pbkdf2_sha256$…` | `set_password()` — inscription e-mail/mdp d'avant Inclusion Connect, superusers, création via l'admin | Admin uniquement, staff uniquement | 1 110 |
| `!` + 40 car. | `set_unusable_password()` via `create_user()` — ProConnect, invitations, import CSV. Cas nominal actuel | Non | 45 229 |
| `""` | `User.objects.create()` dans l'ancien callback Inclusion Connect (`dora/oidc/views.py` avant `fd909a5c`, 14/11/2024) — ne passait pas par `set_password()` | Non | 8 376 |
| `!disabled` | Chaîne d'anonymisation (`tools/datanymizer-config.yml:26`) + compte DI en prod | Non | 1 |

## Solution

Le champ `password` des utilisateurs non-staff qui ne commencent pas déjà par `!` est mis à jour au format `!` + 40 car. via `user.set_unusable_password()`.

Le `password` du compte DI sera mis à jour manuellement.

Résultat escompté : tous les utilisateurs normaux (non-staff) ont une valeur au format `!` + 40 car dans le champ `password`.