### PR TITLE
perf: paralléliser les appels pour alimenter la page d'édition d'un service et d'un modèle

### DIFF
--- a/front/src/routes/(modeles-services)/modeles/[slug]/editer/+page.ts
+++ b/front/src/routes/(modeles-services)/modeles/[slug]/editer/+page.ts
@@ -10,20 +10,21 @@ export const load: PageLoad = async ({ fetch, params, parent }) => {
 
   const model = await getModel(params.slug, fetch);
 
-  const servicesOptions = await getServicesOptions(fetch);
-
   if (!model) {
     error(404, "Page Not Found");
   }
 
-  const structure = await getStructure(model.structure, fetch);
+  const [structure, servicesOptions] = await Promise.all([
+    getStructure(model.structure, fetch),
+    getServicesOptions(fetch),
+  ]);
 
   return {
-    title: `Éditer | ${model.name} | ${structure.name} | DORA`,
+    title: `Éditer | ${model.name}${structure ? ` | ${structure.name}` : ""} | DORA`,
     noIndex: true,
     model,
     servicesOptions,
-    structures: [structure],
+    structures: structure ? [structure] : [],
     structure,
   };
 };

--- a/front/src/routes/(modeles-services)/modeles/[slug]/editer/+page.ts
+++ b/front/src/routes/(modeles-services)/modeles/[slug]/editer/+page.ts
@@ -19,12 +19,18 @@ export const load: PageLoad = async ({ fetch, params, parent }) => {
     getServicesOptions(fetch),
   ]);
 
+  if (!structure) {
+    throw new Error(
+      `Le fetch d'une structure liée au modèle avec le slug ${params.slug} a échoué`
+    );
+  }
+
   return {
-    title: `Éditer | ${model.name}${structure ? ` | ${structure.name}` : ""} | DORA`,
+    title: `Éditer | ${model.name} | ${structure.name} } | DORA`,
     noIndex: true,
     model,
     servicesOptions,
-    structures: structure ? [structure] : [],
+    structures: [structure],
     structure,
   };
 };

--- a/front/src/routes/(modeles-services)/services/[slug]/editer/+page.ts
+++ b/front/src/routes/(modeles-services)/services/[slug]/editer/+page.ts
@@ -28,12 +28,18 @@ export const load: PageLoad = async ({ fetch, params, parent }) => {
     service.model ? getModel(service.model, fetch) : null,
   ]);
 
+  if (!structure) {
+    throw new Error(
+      `Le fetch d'une structure liée au service avec le slug ${params.slug} a échoué`
+    );
+  }
+
   return {
-    title: `Éditer | ${service.name}${structure ? ` | ${structure.name}` : ""} | DORA`,
+    title: `Éditer | ${service.name} | ${structure.name} | DORA`,
     noIndex: true,
     service,
     servicesOptions,
-    structures: structure ? [structure] : [],
+    structures: [structure],
     structure,
     model,
   };

--- a/front/src/routes/(modeles-services)/services/[slug]/editer/+page.ts
+++ b/front/src/routes/(modeles-services)/services/[slug]/editer/+page.ts
@@ -22,16 +22,18 @@ export const load: PageLoad = async ({ fetch, params, parent }) => {
     error(404, "Page Not Found");
   }
 
-  const structure = await getStructure(service.structure, fetch);
-
-  const model = service.model ? await getModel(service.model, fetch) : null;
+  const [structure, servicesOptions, model] = await Promise.all([
+    getStructure(service.structure, fetch),
+    getServicesOptions(fetch),
+    service.model ? getModel(service.model, fetch) : null,
+  ]);
 
   return {
-    title: `Éditer | ${service.name} | ${structure.name} | DORA`,
+    title: `Éditer | ${service.name}${structure ? ` | ${structure.name}` : ""} | DORA`,
     noIndex: true,
     service,
-    servicesOptions: await getServicesOptions(fetch),
-    structures: [structure],
+    servicesOptions,
+    structures: structure ? [structure] : [],
     structure,
     model,
   };


### PR DESCRIPTION
En travaillant sur la migration des publics, j'ai remarqué une façon de diminuer le temps de chargement de ces deux pages 