### PR TITLE
feat: ajouter la colonne Identifiant FT à l'export des orientations reçues

### DIFF
--- a/back/dora/orientations/serializers.py
+++ b/back/dora/orientations/serializers.py
@@ -292,6 +292,7 @@ class ReceivedOrientationExportSerializer(SentOrientationExportSerializer):
             "prescriber_structure_name",
             "detail_page_url",
             "source",
+            "beneficiary_france_travail_number",
         ]
 
     @staticmethod

--- a/back/dora/orientations/serializers.py
+++ b/back/dora/orientations/serializers.py
@@ -280,6 +280,7 @@ class SentOrientationExportSerializer(serializers.ModelSerializer):
 class ReceivedOrientationExportSerializer(SentOrientationExportSerializer):
     prescriber_structure_name = serializers.SerializerMethodField()
     detail_page_url = serializers.SerializerMethodField()
+    beneficiary_france_travail_number = serializers.SerializerMethodField()
 
     class Meta:
         model = Orientation
@@ -302,6 +303,12 @@ class ReceivedOrientationExportSerializer(SentOrientationExportSerializer):
     @staticmethod
     def get_detail_page_url(obj: Orientation) -> str:
         return obj.get_magic_link()
+
+    @staticmethod
+    def get_beneficiary_france_travail_number(obj: Orientation) -> str:
+        if obj.status == OrientationStatus.ACCEPTED:
+            return obj.beneficiary_france_travail_number
+        return ""
 
 
 class OrientationBeneficiaryInfoInputSerializer(serializers.Serializer):

--- a/back/dora/orientations/tests/test_orientation_endpoints.py
+++ b/back/dora/orientations/tests/test_orientation_endpoints.py
@@ -654,6 +654,7 @@ class OrientationsExportTestCase(APITestCase):
             status=OrientationStatus.ACCEPTED,
             prescriber_structure=self.structure,
             prescriber=prescriber,
+            beneficiary_france_travail_number="12345678901",
         )
 
         orientation_2 = baker.make(
@@ -703,6 +704,7 @@ class OrientationsExportTestCase(APITestCase):
                     "service_name": orientation_1.get_service_name(),
                     "detail_page_url": orientation_1.get_magic_link(),
                     "source": "DORA",
+                    "beneficiary_france_travail_number": "12345678901",
                 },
                 {
                     "creation_date": orientation_2.creation_date.strftime("%Y-%m-%d"),
@@ -713,6 +715,7 @@ class OrientationsExportTestCase(APITestCase):
                     "service_name": orientation_2.get_service_name(),
                     "detail_page_url": orientation_2.get_magic_link(),
                     "source": "DORA",
+                    "beneficiary_france_travail_number": "",
                 },
             ],
         )

--- a/back/dora/orientations/tests/test_orientation_endpoints.py
+++ b/back/dora/orientations/tests/test_orientation_endpoints.py
@@ -666,6 +666,16 @@ class OrientationsExportTestCase(APITestCase):
             prescriber=None,
         )
 
+        orientation_3 = baker.make(
+            Orientation,
+            creation_date=timezone.now() - relativedelta(days=3),
+            service=self.service,
+            status=OrientationStatus.PENDING,
+            prescriber_structure=self.structure,
+            prescriber=prescriber,
+            beneficiary_france_travail_number="98765432109",
+        )
+
         # Assurer que ces orientations ne sont pas incluses dans les résultats
         baker.make(
             Orientation,
@@ -691,7 +701,7 @@ class OrientationsExportTestCase(APITestCase):
 
         self.assertEqual(response.status_code, 200)
 
-        self.assertEqual(len(response.data), 2)
+        self.assertEqual(len(response.data), 3)
         self.assertEqual(
             response.data,
             [
@@ -716,6 +726,17 @@ class OrientationsExportTestCase(APITestCase):
                     "detail_page_url": orientation_2.get_magic_link(),
                     "source": "DORA",
                     "beneficiary_france_travail_number": "",
+                },
+                {
+                    "creation_date": orientation_3.creation_date.strftime("%Y-%m-%d"),
+                    "status": "Ouverte / En cours de traitement",
+                    "beneficiary_name": orientation_3.get_beneficiary_full_name(),
+                    "prescriber_name": prescriber.get_full_name(),
+                    "prescriber_structure_name": orientation_3.prescriber_structure.name,
+                    "service_name": orientation_3.get_service_name(),
+                    "detail_page_url": orientation_3.get_magic_link(),
+                    "source": "DORA",
+                    "beneficiary_france_travail_number": "",  # Identifiant FT non publié pour les orientations non validées
                 },
             ],
         )

--- a/front/src/routes/orientations/suivi/orientation-export.ts
+++ b/front/src/routes/orientations/suivi/orientation-export.ts
@@ -24,6 +24,7 @@ interface ReceivedOrientationExportData extends Pick<
   prescriberStructureName: string;
   detailPageUrl: string;
   source: string;
+  beneficiaryFranceTravailNumber: string;
 }
 
 async function fetchOrientationExportData(structureSlug: string) {
@@ -57,6 +58,7 @@ function formatReceivedOrientationExportData(
     "Reçue le": orientation.creationDate,
     Statut: orientation.status,
     Bénéficiaire: orientation.beneficiaryName,
+    "Identifiant FT": orientation.beneficiaryFranceTravailNumber,
     "Service concerné": orientation.serviceName,
     "Structure émettrice": orientation.prescriberStructureName,
     "Contact émetteur": orientation.prescriberName,


### PR DESCRIPTION
Rajouter l’identifiant FT dans le fichier Excel des orientations reçues.

Quand la valeur de `beneficiary_france_travail_number` n'est pas fourni, j'ai mis `N/A` pour que la cellule soit pas vide.

<img width="991" height="235" alt="Screenshot 2026-08-21 at 15 52 49" src="https://github.com/user-attachments/assets/d02b2068-3915-4b83-b67d-52e51fa75583" />
