### PR TITLE
feat(services): fusion algorithmique des descriptions de service

### DIFF
--- a/back/dora/services/management/commands/merge_service_descriptions.py
+++ b/back/dora/services/management/commands/merge_service_descriptions.py
@@ -1,32 +1,24 @@
 """Réintégration du résumé des services dans leur description, le temps de la migration.
 
-`Service.short_desc` disparaît au profit d'une description unique, dont les premières lignes
-tiendront lieu de résumé. Les deux champs ayant coexisté par dépit, ils ont été employés de
-deux façons opposées : certains résumés complètent la description — à conserver, en tête — et
-d'autres n'en sont qu'une recopie ou une paraphrase — à jeter.
+`Service.short_desc` disparaît au profit d'une description unique. Certains résumés complètent
+la description — à conserver, en tête — et d'autres n'en sont qu'une recopie ou une paraphrase
+— à jeter.
 
-Ce sont les deux mesures ci-dessous qui tranchent. Aucun texte n'est jamais réécrit : la
-description ressort intacte, précédée du résumé, ou remplacée par lui dans le seul cas où
-elle ne porte aucun mot. La normalisation ne sert qu'à comparer, jamais à produire, ce qui
-met la typographie du texte de référence — espaces insécables et fines, apostrophes courbes,
-guillemets français — hors d'atteinte.
-
-`--report` écrit le détail des décisions dans un CSV, les plus incertaines en tête : c'est
-la seule prise qu'on ait sur les cas limites tant que `short_desc` existe encore en base.
+Aucun texte n'est jamais réécrit : `normalize` ne sert qu'à comparer, jamais à produire, ce qui
+met la typographie du texte de référence hors d'atteinte.
 """
 
-import csv
 import difflib
 import math
 import re
 import unicodedata
 from collections import Counter
+from functools import lru_cache
 from typing import Callable, Iterable
 
 from itoutils.django.commands import AtomicHandleMixin, dry_runnable
 
 from dora.core.commands import BaseCommand
-from dora.core.utils import strip_markdown
 from dora.services.models import Service
 from dora.services.utils import (
     SYNC_CUSTOM_M2M_FIELDS,
@@ -36,20 +28,10 @@ from dora.services.utils import (
 
 BATCH = 500
 
-# Colonnes du rapport : les mesures et le verdict d'abord, les deux textes ensuite — l'ordre
-# dans lequel on relit une décision, et non celui dans lequel on la calcule.
-REPORT_FIELDNAMES = [
-    "marge",
-    "verdict",
-    "recouvrement_ordonne",
-    "recouvrement_desordonne",
-    "nb_services",
-    "resume",
-    "description",
-]
-
-# Au-delà de l'un ou l'autre, le résumé n'apporte rien à la description. Deux seuils parce que
-# les deux mesures attrapent des redondances de nature différente, cf. plus bas.
+# Deux mesures, parce qu'elles attrapent des redondances de nature différente et se rattrapent
+# l'une l'autre : l'ordonnée tranche la recopie fautive, que la pondération par rareté prend
+# au contraire pour un apport — une faute de frappe fabrique un mot rare ; la désordonnée
+# tranche la paraphrase, qui réordonne les mots, et absorbe les flexions que l'ordonnée rate.
 SEQUENCE_THRESHOLD = 0.90
 BAG_THRESHOLD = 0.90
 
@@ -57,15 +39,9 @@ BAG_THRESHOLD = 0.90
 # pour le même mot, sans embarquer de lemmatiseur.
 STEM_LENGTH = 5
 
-# Mots-outils écartés de la comparaison désordonnée : trop fréquents pour distinguer quoi que
-# ce soit, ils ne feraient que rapprocher mécaniquement tous les textes. Les mots d'une ou
-# deux lettres n'y figurent pas : `stems` les écarte déjà tous.
-#
-# L'appartenance est testée sur le mot entier, avant troncature, et non sur sa racine : « et
-# cetera » y gagnerait quelques formes fléchies — « permettant » passe là où « permet » est
-# écarté — mais « entre » emporterait « entreprise », « entretien » et « entreprendre »,
-# « comme » emporterait « commerce », et « avant » « avantage ». Le vocabulaire de ce corpus
-# ne survit pas à ce raccourci.
+# Mots-outils écartés de la comparaison désordonnée. L'appartenance est testée sur le mot
+# entier, avant troncature : « entre » emporterait « entreprise », « entretien » et
+# « entreprendre ». Les mots d'une ou deux lettres n'y figurent pas, `stems` les écarte déjà.
 STOPWORDS = set(
     """
     les une des aux mais donc car que qui quoi dont
@@ -86,37 +62,25 @@ NON_ALPHANUMERIC = re.compile(r"[^a-z0-9]+")
 
 
 def normalize(text: str) -> list[str]:
-    """Découpe en mots comparables : casse, accents et ponctuation effacés.
+    """Mots comparables : casse, accents, ponctuation et balisage effacés.
 
-    Volontairement destructeur — c'est ce qui permet de reconnaître « l'Accueil » dans
-    « L’accueil ». Le résultat ne sert qu'à mesurer et ne ressort jamais en base.
+    Volontairement destructeur — c'est ce qui reconnaît « l'Accueil » dans « L’accueil ».
     """
     text = unicodedata.normalize("NFKD", text.lower())
     text = "".join(char for char in text if not unicodedata.combining(char))
     return NON_ALPHANUMERIC.sub(" ", APOSTROPHES.sub(" ", text)).split()
 
 
-def fold(text: str) -> list[str]:
-    """Mots comparables d'un texte balisé, le markdown en moins."""
-    return normalize(strip_markdown(text))
-
-
 def is_blank(text: str) -> bool:
-    """Le texte se réduit-il à de la ponctuation ou du balisage — « --- », « *** », « ... » ?
-
-    Mesuré sur le texte brut, et non sur `fold` : `strip_markdown` ne voit pas le HTML, dont
-    une poignée de descriptions sont entièrement faites. Les prendre pour vides reviendrait
-    à jeter le texte de référence, ce que rien n'autorise.
-    """
+    """Le texte se réduit-il à de la ponctuation ou du balisage — « --- », « *** », « ... » ?"""
     return not normalize(text)
 
 
 def stems(words: Iterable[str]) -> set[str]:
     """Racines porteuses de sens d'une suite de mots.
 
-    Les nombres sont retenus quelle que soit leur longueur, là où les mots de moins de trois
-    lettres sont écartés : « 16 », « 25 », « 2 » portent l'âge, la durée ou le nombre de
-    places — précisément ce qu'un résumé ajoute à une description qui n'en dit rien.
+    Les nombres comptent quelle que soit leur longueur : un âge ou un nombre de places est
+    souvent tout ce qu'un résumé ajoute à une description qui n'en dit rien.
     """
     return {
         word[:STEM_LENGTH]
@@ -133,63 +97,52 @@ def uniform_weight(stem: str) -> float:
 def build_idf(descriptions: Iterable[str]) -> Callable[[str], float]:
     """Poids de rareté d'une racine, tiré du corpus des descriptions.
 
-    Sans cette pondération, le vocabulaire omniprésent du secteur — « accompagnement »,
-    « emploi », « insertion » — suffirait à faire passer pour une paraphrase un résumé qui
-    apporte pourtant du neuf.
+    Sans elle, le vocabulaire omniprésent du secteur — « accompagnement », « insertion » —
+    ferait passer pour une paraphrase un résumé qui apporte du neuf.
     """
     document_frequency = Counter()
     total = 0
     for description in descriptions:
         total += 1
-        document_frequency.update(stems(fold(description)))
+        document_frequency.update(stems(normalize(description)))
 
     if not total:
         return uniform_weight
 
     def weight(stem: str) -> float:
-        # `1 + N / (1 + df)` reste strictement positif, y compris pour une racine présente
-        # dans toutes les descriptions, là où le `N / (1 + df)` habituel passerait sous zéro
-        # et rendrait le ratio de couverture ininterprétable.
+        # `1 + N / (1 + df)` reste strictement positif même pour une racine présente partout,
+        # là où le `N / (1 + df)` habituel passerait sous zéro.
         return math.log(1 + total / (1 + document_frequency[stem]))
 
     return weight
 
 
 def sequence_coverage(short_desc: str, description: str) -> float:
-    """Part du résumé retrouvée *dans l'ordre* dans la description.
-
-    Attrape la recopie et la quasi-recopie — de loin la redondance la plus fréquente — que ni
-    une majuscule, ni une incise, ni une coquille ne suffisent à masquer.
-    """
-    words = fold(short_desc)
-    if not words:
-        return 1.0
-
-    matcher = difflib.SequenceMatcher(a=words, b=fold(description), autojunk=False)
-    matched = sum(block.size for block in matcher.get_matching_blocks())
+    """Part du résumé retrouvée *dans l'ordre* dans la description : la recopie."""
+    words = normalize(short_desc)
+    matcher = difflib.SequenceMatcher(a=words, b=normalize(description), autojunk=False)
+    # Les blocs d'un seul mot ne sont que des mots-outils tombés au bon endroit : dans une
+    # description longue, ils suffiraient à faire passer n'importe quel résumé pour une recopie.
+    matched = sum(
+        block.size for block in matcher.get_matching_blocks() if block.size >= 2
+    )
     return matched / len(words)
 
 
 def bag_coverage(
     short_desc: str, description: str, weight: Callable[[str], float]
 ) -> float:
-    """Part du résumé retrouvée *sans égard à l'ordre*, pondérée par la rareté des mots.
-
-    Attrape la paraphrase, qui reformule et réordonne mais conserve le vocabulaire propre au
-    sujet. La pondération est ce qui distingue « redit la même chose » de « parle du même
-    domaine ».
-    """
-    summary = stems(fold(short_desc))
+    """Part du résumé retrouvée *sans égard à l'ordre*, pondérée par la rareté : la paraphrase."""
+    summary = stems(normalize(short_desc))
+    # Un résumé qui ne serait fait que de mots-outils n'apporte rien non plus.
     if not summary:
         return 1.0
 
-    shared = summary & stems(fold(description))
-    total = sum(weight(stem) for stem in summary)
-    if not total:
-        return len(shared) / len(summary)
-    return sum(weight(stem) for stem in shared) / total
+    shared = summary & stems(normalize(description))
+    return sum(weight(stem) for stem in shared) / sum(weight(stem) for stem in summary)
 
 
+@lru_cache(maxsize=10_000)
 def merge_description(
     short_desc: str,
     description: str,
@@ -197,22 +150,14 @@ def merge_description(
 ) -> str | None:
     """Description finale d'un couple, ou None si le résumé n'apporte rien.
 
-    La description est reproduite telle quelle, au caractère près : on ne fait que la précéder
-    du résumé, ou la laisser intacte. Elle ne cède la place qu'en ne disant rien du tout.
+    Pure, donc mémoïsable : un modèle et ses copies reçoivent le même texte sans recalcul.
     """
     short_desc = short_desc.strip()
-    # Sans mot, rien à apporter : quelques résumés ne contiennent que du bruit markdown
-    # (« --- », « **** »), qui ferait un filet horizontal ou une coquille en tête de fiche.
-    if not fold(short_desc):
+    if is_blank(short_desc):
         return None
-    # Le même bruit se rencontre côté description, où il se retrouverait en queue de fiche.
     if is_blank(description):
         return short_desc
 
-    # Le recouvrement désordonné tranche seul près de la moitié des couples, et s'obtient par
-    # deux intersections d'ensembles là où l'ordonné aligne deux suites de mots. D'où cet
-    # ordre, que la pureté des deux mesures rend indifférent au résultat — l'essentiel du
-    # temps se passant de toute façon dans `fold`, il ne fait gagner que quelques pour cent.
     redundant = (
         bag_coverage(short_desc, description, weight) >= BAG_THRESHOLD
         or sequence_coverage(short_desc, description) >= SEQUENCE_THRESHOLD
@@ -229,14 +174,6 @@ class Command(AtomicHandleMixin, BaseCommand):
 
     def add_arguments(self, parser):
         parser.add_argument("--wet-run", action="store_true")
-        parser.add_argument(
-            "--report",
-            metavar="FICHIER",
-            help=(
-                "Écrit le détail des décisions dans ce fichier CSV, les plus incertaines en "
-                "tête. Produit même en dry-run, et hors transaction : il survit au rollback."
-            ),
-        )
 
     @dry_runnable
     def handle(self, *args, **options):
@@ -247,14 +184,8 @@ class Command(AtomicHandleMixin, BaseCommand):
         )
 
         updated, touched_models = [], set()
-        # La fusion étant une fonction pure du couple, la mémoriser suffit à garantir qu'un
-        # modèle et toutes ses copies reçoivent le même texte — et évite de recalculer les
-        # mesures pour chacune.
-        merges: dict[tuple[str, str], str | None] = {}
-        occurrences: Counter[tuple[str, str]] = Counter()
         copied = dropped = inserted = 0
 
-        # `_base_manager` pour inclure les modèles
         services = (
             Service._base_manager.only("pk", "is_model", "short_desc", "description")
             .order_by("pk")
@@ -264,12 +195,7 @@ class Command(AtomicHandleMixin, BaseCommand):
             if not service.short_desc.strip():
                 continue
 
-            key = (service.short_desc, service.description)
-            if key not in merges:
-                merges[key] = merge_description(*key, weight)
-            merged = merges[key]
-            occurrences[key] += 1
-
+            merged = merge_description(service.short_desc, service.description, weight)
             if merged is None:
                 dropped += 1
                 continue
@@ -298,57 +224,10 @@ class Command(AtomicHandleMixin, BaseCommand):
         self.stdout.write(
             f"{self._recompute_sync_checksums(touched_models):>7} empreintes recalculées"
         )
-        if options["report"]:
-            written = self._write_report(options["report"], merges, occurrences, weight)
-            self.stdout.write(
-                f"{written:>7} décisions détaillées dans {options['report']}"
-            )
         if not options["wet_run"]:
             self.stdout.write(
                 self.style.WARNING("Dry-run : aucune modification enregistrée")
             )
-
-    def _write_report(self, path, merges, occurrences, weight) -> int:
-        """Détail des décisions, les plus incertaines en tête.
-
-        La marge dit de combien la mesure la plus haute a dépassé son seuil : négative quand
-        le résumé est conservé, positive quand il est abandonné, et d'autant plus proche de
-        zéro que la décision s'est jouée à peu de chose. Trier dessus met en tête les seuls
-        couples qu'une relecture humaine a intérêt à reprendre.
-        """
-        rows = []
-        for (short_desc, description), merged in merges.items():
-            sequence = sequence_coverage(short_desc, description)
-            bag = bag_coverage(short_desc, description, weight)
-            if merged is None:
-                verdict = "abandonné"
-            elif is_blank(description):
-                verdict = "recopié"
-            else:
-                verdict = "inséré en tête"
-            rows.append(
-                {
-                    "marge": round(
-                        max(sequence - SEQUENCE_THRESHOLD, bag - BAG_THRESHOLD), 3
-                    ),
-                    "verdict": verdict,
-                    "recouvrement_ordonne": round(sequence, 3),
-                    "recouvrement_desordonne": round(bag, 3),
-                    "nb_services": occurrences[(short_desc, description)],
-                    "resume": short_desc,
-                    "description": description,
-                }
-            )
-
-        rows.sort(key=lambda row: abs(row["marge"]))
-        # `utf-8-sig` : le rapport se relit dans un tableur, qui sans la marque d'ordre des
-        # octets prendrait les accents pour du latin-1.
-        with open(path, "w", newline="", encoding="utf-8-sig") as report:
-            writer = csv.DictWriter(report, fieldnames=REPORT_FIELDNAMES)
-            writer.writeheader()
-            writer.writerows(rows)
-
-        return len(rows)
 
     def _recompute_sync_checksums(self, model_ids: set) -> int:
         recomputed = 0
@@ -364,6 +243,8 @@ class Command(AtomicHandleMixin, BaseCommand):
             if model.sync_checksum == previous:
                 continue
 
+            # `last_sync_checksum=previous` : seules les copies restées en phase avec leur
+            # modèle suivent, celles que leur structure a personnalisées gardent leur écart.
             Service._base_manager.filter(
                 model_id=model.pk, last_sync_checksum=previous
             ).update(last_sync_checksum=model.sync_checksum)

--- a/back/dora/services/management/commands/merge_service_descriptions.py
+++ b/back/dora/services/management/commands/merge_service_descriptions.py
@@ -1,13 +1,27 @@
 """Réintégration du résumé des services dans leur description, le temps de la migration.
 
-Sans `--from-csv`, applique les cas évidents et exporte les couples restants, à fusionner par
-un LLM (`--show-prompt`) ; avec, applique les fusions obtenues. Les services modifiés entre
-les deux passages repartent dans l'export plutôt que d'être écrasés par une fusion périmée.
+`Service.short_desc` disparaît au profit d'une description unique, dont les premières lignes
+tiendront lieu de résumé. Les deux champs ayant coexisté par dépit, ils ont été employés de
+deux façons opposées : certains résumés complètent la description — à conserver, en tête — et
+d'autres n'en sont qu'une recopie ou une paraphrase — à jeter.
+
+Ce sont les deux mesures ci-dessous qui tranchent. Aucun texte n'est jamais réécrit : la
+description ressort intacte, précédée du résumé, ou remplacée par lui dans le seul cas où
+elle ne porte aucun mot. La normalisation ne sert qu'à comparer, jamais à produire, ce qui
+met la typographie du texte de référence — espaces insécables et fines, apostrophes courbes,
+guillemets français — hors d'atteinte.
+
+`--report` écrit le détail des décisions dans un CSV, les plus incertaines en tête : c'est
+la seule prise qu'on ait sur les cas limites tant que `short_desc` existe encore en base.
 """
 
 import csv
-import hashlib
-from datetime import datetime
+import difflib
+import math
+import re
+import unicodedata
+from collections import Counter
+from typing import Callable, Iterable
 
 from itoutils.django.commands import AtomicHandleMixin, dry_runnable
 
@@ -22,78 +36,223 @@ from dora.services.utils import (
 
 BATCH = 500
 
-FIELDNAMES = ["pair_hash", "nb_services", "short_desc", "description"]
+# Colonnes du rapport : les mesures et le verdict d'abord, les deux textes ensuite — l'ordre
+# dans lequel on relit une décision, et non celui dans lequel on la calcule.
+REPORT_FIELDNAMES = [
+    "marge",
+    "verdict",
+    "recouvrement_ordonne",
+    "recouvrement_desordonne",
+    "nb_services",
+    "resume",
+    "description",
+]
 
-PROMPT = """\
-Fusionne deux champs d'une fiche de service d'insertion : un résumé court et une
-description. Le résultat remplacera les deux.
+# Au-delà de l'un ou l'autre, le résumé n'apporte rien à la description. Deux seuils parce que
+# les deux mesures attrapent des redondances de nature différente, cf. plus bas.
+SEQUENCE_THRESHOLD = 0.90
+BAG_THRESHOLD = 0.90
 
-Règles :
-- La description est le texte de référence : reproduis-la à l'identique. Pas de reformulation,
-  pas de correction de style ou d'orthographe, pas de réorganisation, pas de titre ajouté.
-- Si le résumé n'apporte aucune information absente de la description, renvoie la description
-  telle quelle, sans rien y changer.
-- S'il apporte une information absente, insère-la — en tête par défaut, ou à l'endroit
-  pertinent — en une phrase courte, dans le ton du texte existant.
-- N'invente rien, ne complète pas, ne développe pas.
-- Réponds par la description seule, en Markdown, sans préambule ni commentaire.
-"""
+# Racines tronquées à cette longueur : « accompagnement » et « accompagnons » doivent compter
+# pour le même mot, sans embarquer de lemmatiseur.
+STEM_LENGTH = 5
 
-
-def needs_merge(short_desc: str, description: str) -> bool:
-    """Le résumé apporte-t-il quelque chose que la description ne dit pas déjà ?"""
-    # `strip_markdown` ramène le texte sur une seule ligne, ce qui rend comparables un résumé
-    # saisi en texte brut et un descriptif mis en forme.
-    short_desc = strip_markdown(short_desc).strip().lower()
-    return bool(short_desc) and short_desc not in strip_markdown(description).lower()
-
-
-def pair_hash(short_desc: str, description: str) -> str:
-    """Empreinte d'un couple de valeurs brutes, clé de correspondance des deux CSV.
-
-    C'est l'égalité stricte qui garantit qu'un modèle et ses copies reçoivent la même fusion.
+# Mots-outils écartés de la comparaison désordonnée : trop fréquents pour distinguer quoi que
+# ce soit, ils ne feraient que rapprocher mécaniquement tous les textes. Les mots d'une ou
+# deux lettres n'y figurent pas : `stems` les écarte déjà tous.
+#
+# L'appartenance est testée sur le mot entier, avant troncature, et non sur sa racine : « et
+# cetera » y gagnerait quelques formes fléchies — « permettant » passe là où « permet » est
+# écarté — mais « entre » emporterait « entreprise », « entretien » et « entreprendre »,
+# « comme » emporterait « commerce », et « avant » « avantage ». Le vocabulaire de ce corpus
+# ne survit pas à ce raccourci.
+STOPWORDS = set(
     """
-    digest = hashlib.sha256(
-        repr((short_desc, description)).encode(), usedforsecurity=False
+    les une des aux mais donc car que qui quoi dont
+    cet cette ces son ses leur leurs notre nos votre vos mon mes ton tes
+    elle nous vous ils elles
+    est sont etre suis sommes etes ete etait etaient sera seront soit
+    avoir avons avez ont avait avaient
+    pour par sur sous dans avec sans vers chez entre depuis pendant afin ainsi aussi
+    plus moins tres tout tous toute toutes meme autre autres chaque
+    pas non oui comme lors alors apres avant
+    peut peuvent pouvez pouvons permet permettre fait faire faites
+    cela ceux celle celles etc
+    """.split()
+)
+
+APOSTROPHES = re.compile(r"['‘’ʼ`]")
+NON_ALPHANUMERIC = re.compile(r"[^a-z0-9]+")
+
+
+def normalize(text: str) -> list[str]:
+    """Découpe en mots comparables : casse, accents et ponctuation effacés.
+
+    Volontairement destructeur — c'est ce qui permet de reconnaître « l'Accueil » dans
+    « L’accueil ». Le résultat ne sert qu'à mesurer et ne ressort jamais en base.
+    """
+    text = unicodedata.normalize("NFKD", text.lower())
+    text = "".join(char for char in text if not unicodedata.combining(char))
+    return NON_ALPHANUMERIC.sub(" ", APOSTROPHES.sub(" ", text)).split()
+
+
+def fold(text: str) -> list[str]:
+    """Mots comparables d'un texte balisé, le markdown en moins."""
+    return normalize(strip_markdown(text))
+
+
+def is_blank(text: str) -> bool:
+    """Le texte se réduit-il à de la ponctuation ou du balisage — « --- », « *** », « ... » ?
+
+    Mesuré sur le texte brut, et non sur `fold` : `strip_markdown` ne voit pas le HTML, dont
+    une poignée de descriptions sont entièrement faites. Les prendre pour vides reviendrait
+    à jeter le texte de référence, ce que rien n'autorise.
+    """
+    return not normalize(text)
+
+
+def stems(words: Iterable[str]) -> set[str]:
+    """Racines porteuses de sens d'une suite de mots.
+
+    Les nombres sont retenus quelle que soit leur longueur, là où les mots de moins de trois
+    lettres sont écartés : « 16 », « 25 », « 2 » portent l'âge, la durée ou le nombre de
+    places — précisément ce qu'un résumé ajoute à une description qui n'en dit rien.
+    """
+    return {
+        word[:STEM_LENGTH]
+        for word in words
+        if (word.isdigit() or len(word) > 2) and word not in STOPWORDS
+    }
+
+
+def uniform_weight(stem: str) -> float:
+    """Pondération neutre, quand aucun corpus n'est disponible pour en tirer une."""
+    return 1.0
+
+
+def build_idf(descriptions: Iterable[str]) -> Callable[[str], float]:
+    """Poids de rareté d'une racine, tiré du corpus des descriptions.
+
+    Sans cette pondération, le vocabulaire omniprésent du secteur — « accompagnement »,
+    « emploi », « insertion » — suffirait à faire passer pour une paraphrase un résumé qui
+    apporte pourtant du neuf.
+    """
+    document_frequency = Counter()
+    total = 0
+    for description in descriptions:
+        total += 1
+        document_frequency.update(stems(fold(description)))
+
+    if not total:
+        return uniform_weight
+
+    def weight(stem: str) -> float:
+        # `1 + N / (1 + df)` reste strictement positif, y compris pour une racine présente
+        # dans toutes les descriptions, là où le `N / (1 + df)` habituel passerait sous zéro
+        # et rendrait le ratio de couverture ininterprétable.
+        return math.log(1 + total / (1 + document_frequency[stem]))
+
+    return weight
+
+
+def sequence_coverage(short_desc: str, description: str) -> float:
+    """Part du résumé retrouvée *dans l'ordre* dans la description.
+
+    Attrape la recopie et la quasi-recopie — de loin la redondance la plus fréquente — que ni
+    une majuscule, ni une incise, ni une coquille ne suffisent à masquer.
+    """
+    words = fold(short_desc)
+    if not words:
+        return 1.0
+
+    matcher = difflib.SequenceMatcher(a=words, b=fold(description), autojunk=False)
+    matched = sum(block.size for block in matcher.get_matching_blocks())
+    return matched / len(words)
+
+
+def bag_coverage(
+    short_desc: str, description: str, weight: Callable[[str], float]
+) -> float:
+    """Part du résumé retrouvée *sans égard à l'ordre*, pondérée par la rareté des mots.
+
+    Attrape la paraphrase, qui reformule et réordonne mais conserve le vocabulaire propre au
+    sujet. La pondération est ce qui distingue « redit la même chose » de « parle du même
+    domaine ».
+    """
+    summary = stems(fold(short_desc))
+    if not summary:
+        return 1.0
+
+    shared = summary & stems(fold(description))
+    total = sum(weight(stem) for stem in summary)
+    if not total:
+        return len(shared) / len(summary)
+    return sum(weight(stem) for stem in shared) / total
+
+
+def merge_description(
+    short_desc: str,
+    description: str,
+    weight: Callable[[str], float] = uniform_weight,
+) -> str | None:
+    """Description finale d'un couple, ou None si le résumé n'apporte rien.
+
+    La description est reproduite telle quelle, au caractère près : on ne fait que la précéder
+    du résumé, ou la laisser intacte. Elle ne cède la place qu'en ne disant rien du tout.
+    """
+    short_desc = short_desc.strip()
+    # Sans mot, rien à apporter : quelques résumés ne contiennent que du bruit markdown
+    # (« --- », « **** »), qui ferait un filet horizontal ou une coquille en tête de fiche.
+    if not fold(short_desc):
+        return None
+    # Le même bruit se rencontre côté description, où il se retrouverait en queue de fiche.
+    if is_blank(description):
+        return short_desc
+
+    # Le recouvrement désordonné tranche seul près de la moitié des couples, et s'obtient par
+    # deux intersections d'ensembles là où l'ordonné aligne deux suites de mots. D'où cet
+    # ordre, que la pureté des deux mesures rend indifférent au résultat — l'essentiel du
+    # temps se passant de toute façon dans `fold`, il ne fait gagner que quelques pour cent.
+    redundant = (
+        bag_coverage(short_desc, description, weight) >= BAG_THRESHOLD
+        or sequence_coverage(short_desc, description) >= SEQUENCE_THRESHOLD
     )
-    return digest.hexdigest()[:16]
+    return None if redundant else f"{short_desc}\n\n{description}"
 
 
 class Command(AtomicHandleMixin, BaseCommand):
     ATOMIC_HANDLE = True
     help = (
-        "Réintègre le résumé des services dans leur description : copie directe quand la "
-        "description est vide, fusions calculées par un LLM avec --from-csv. Les couples "
-        "restant à fusionner sont exportés en CSV."
+        "Réintègre le résumé des services dans leur description : en tête quand il la "
+        "complète, abandonné quand il ne fait que la redire."
     )
 
     def add_arguments(self, parser):
         parser.add_argument("--wet-run", action="store_true")
         parser.add_argument(
-            "--from-csv",
-            type=str,
-            help="CSV de fusions (colonnes `pair_hash` et `description`)",
-        )
-        parser.add_argument(
-            "--output",
-            type=str,
-            help="CSV des couples restant à fusionner (par défaut : nom horodaté)",
-        )
-        parser.add_argument(
-            "--show-prompt",
-            action="store_true",
-            help="Affiche la consigne de fusion à donner au LLM, et sort",
+            "--report",
+            metavar="FICHIER",
+            help=(
+                "Écrit le détail des décisions dans ce fichier CSV, les plus incertaines en "
+                "tête. Produit même en dry-run, et hors transaction : il survit au rollback."
+            ),
         )
 
     @dry_runnable
     def handle(self, *args, **options):
-        if options["show_prompt"]:
-            self.stdout.write(PROMPT)
-            return
+        weight = build_idf(
+            Service._base_manager.exclude(description="")
+            .values_list("description", flat=True)
+            .iterator(chunk_size=BATCH)
+        )
 
-        merges = self._load_merges(options["from_csv"]) if options["from_csv"] else {}
-        updated, touched_models, pending = [], set(), {}
-        copied = applied = 0
+        updated, touched_models = [], set()
+        # La fusion étant une fonction pure du couple, la mémoriser suffit à garantir qu'un
+        # modèle et toutes ses copies reçoivent le même texte — et évite de recalculer les
+        # mesures pour chacune.
+        merges: dict[tuple[str, str], str | None] = {}
+        occurrences: Counter[tuple[str, str]] = Counter()
+        copied = dropped = inserted = 0
 
         # `_base_manager` pour inclure les modèles
         services = (
@@ -102,30 +261,25 @@ class Command(AtomicHandleMixin, BaseCommand):
             .iterator(chunk_size=BATCH)
         )
         for service in services:
-            short_desc, description = service.short_desc.strip(), service.description
-            if not short_desc or not needs_merge(short_desc, description):
+            if not service.short_desc.strip():
                 continue
 
-            if not description.strip():
-                service.description = short_desc
+            key = (service.short_desc, service.description)
+            if key not in merges:
+                merges[key] = merge_description(*key, weight)
+            merged = merges[key]
+            occurrences[key] += 1
+
+            if merged is None:
+                dropped += 1
+                continue
+
+            if is_blank(service.description):
                 copied += 1
             else:
-                key = pair_hash(service.short_desc, description)
-                if key not in merges:
-                    pending.setdefault(
-                        key,
-                        {
-                            "pair_hash": key,
-                            "nb_services": 0,
-                            "short_desc": service.short_desc,
-                            "description": description,
-                        },
-                    )["nb_services"] += 1
-                    continue
+                inserted += 1
 
-                service.description = merges[key]
-                applied += 1
-
+            service.description = merged
             if service.is_model:
                 touched_models.add(service.pk)
             updated.append(service)
@@ -137,34 +291,64 @@ class Command(AtomicHandleMixin, BaseCommand):
             Service._base_manager.bulk_update(updated, ["description"])
 
         self.stdout.write(f"{copied:>7} descriptions reprises du résumé")
-        self.stdout.write(f"{applied:>7} descriptions fusionnées depuis le CSV")
-        self.stdout.write(f"{len(pending):>7} couples restant à fusionner")
-        if pending:
-            self._write_pending(pending, options["output"])
-
+        self.stdout.write(f"{inserted:>7} résumés insérés en tête de la description")
+        self.stdout.write(
+            f"{dropped:>7} résumés abandonnés, déjà dits par la description"
+        )
         self.stdout.write(
             f"{self._recompute_sync_checksums(touched_models):>7} empreintes recalculées"
         )
+        if options["report"]:
+            written = self._write_report(options["report"], merges, occurrences, weight)
+            self.stdout.write(
+                f"{written:>7} décisions détaillées dans {options['report']}"
+            )
         if not options["wet_run"]:
             self.stdout.write(
                 self.style.WARNING("Dry-run : aucune modification enregistrée")
             )
 
-    def _load_merges(self, path: str) -> dict[str, str]:
-        with open(path, encoding="utf-8", newline="") as csv_file:
-            return {
-                row["pair_hash"]: row["description"].strip()
-                for row in csv.DictReader(csv_file)
-                if row["description"].strip()
-            }
+    def _write_report(self, path, merges, occurrences, weight) -> int:
+        """Détail des décisions, les plus incertaines en tête.
 
-    def _write_pending(self, pending: dict[str, dict], path: str | None):
-        path = path or f"descriptions_{datetime.now():%Y%m%d_%H%M%S}.csv"
-        with open(path, "w", encoding="utf-8", newline="") as csv_file:
-            writer = csv.DictWriter(csv_file, fieldnames=FIELDNAMES)
+        La marge dit de combien la mesure la plus haute a dépassé son seuil : négative quand
+        le résumé est conservé, positive quand il est abandonné, et d'autant plus proche de
+        zéro que la décision s'est jouée à peu de chose. Trier dessus met en tête les seuls
+        couples qu'une relecture humaine a intérêt à reprendre.
+        """
+        rows = []
+        for (short_desc, description), merged in merges.items():
+            sequence = sequence_coverage(short_desc, description)
+            bag = bag_coverage(short_desc, description, weight)
+            if merged is None:
+                verdict = "abandonné"
+            elif is_blank(description):
+                verdict = "recopié"
+            else:
+                verdict = "inséré en tête"
+            rows.append(
+                {
+                    "marge": round(
+                        max(sequence - SEQUENCE_THRESHOLD, bag - BAG_THRESHOLD), 3
+                    ),
+                    "verdict": verdict,
+                    "recouvrement_ordonne": round(sequence, 3),
+                    "recouvrement_desordonne": round(bag, 3),
+                    "nb_services": occurrences[(short_desc, description)],
+                    "resume": short_desc,
+                    "description": description,
+                }
+            )
+
+        rows.sort(key=lambda row: abs(row["marge"]))
+        # `utf-8-sig` : le rapport se relit dans un tableur, qui sans la marque d'ordre des
+        # octets prendrait les accents pour du latin-1.
+        with open(path, "w", newline="", encoding="utf-8-sig") as report:
+            writer = csv.DictWriter(report, fieldnames=REPORT_FIELDNAMES)
             writer.writeheader()
-            writer.writerows(pending.values())
-        self.stdout.write(self.style.NOTICE(f"Couples à fusionner écrits dans {path}"))
+            writer.writerows(rows)
+
+        return len(rows)
 
     def _recompute_sync_checksums(self, model_ids: set) -> int:
         recomputed = 0

--- a/back/dora/services/tests/test_service_descriptions.py
+++ b/back/dora/services/tests/test_service_descriptions.py
@@ -1,5 +1,3 @@
-import csv
-
 import pytest
 from django.core.management import call_command
 from model_bakery import baker
@@ -127,15 +125,6 @@ def test_merge_description_replaces_a_description_reduced_to_markup():
     # le pendant du résumé sans mot : « --- » ferait un filet horizontal en queue de fiche
     assert merge_description("Un résumé", "---") == "Un résumé"
     assert merge_description("Un résumé", "  ***  ") == "Un résumé"
-
-
-@pytest.mark.no_django_db
-def test_merge_description_keeps_a_description_written_in_html():
-    # `strip_markdown` ne voit pas le HTML brut et rend ces descriptions pour vides. Les
-    # prendre au mot reviendrait à jeter le texte de référence de quelques fiches.
-    description = "<h2>Notre offre</h2><p>Location de véhicules à tarif solidaire.</p>"
-
-    assert merge_description("Permanence le jeudi.", description).endswith(description)
 
 
 @pytest.mark.no_django_db
@@ -289,54 +278,3 @@ def test_merge_keeps_copies_in_sync():
     assert synced.last_sync_checksum == model.sync_checksum
     # … et celles qui l'étaient déjà le restent
     assert customized.last_sync_checksum == "périmé"
-
-
-def read_report(path):
-    # `utf-8-sig` des deux côtés : la marque d'ordre des octets est là pour le tableur
-    return list(csv.DictReader(path.read_text(encoding="utf-8-sig").splitlines()))
-
-
-def test_merge_reports_its_decisions_even_in_dry_run(tmp_path):
-    make_service(short_desc="Un résumé", description="Un tout autre descriptif")
-    make_service(short_desc="Un résumé", description="**Un résumé** mis en forme")
-    copied = make_service(short_desc="Un résumé", description="")
-    report = tmp_path / "fusion.csv"
-
-    call_command("merge_service_descriptions", "--report", str(report))
-
-    copied.refresh_from_db()
-    # le rapport s'écrit hors transaction : il survit au rollback du dry-run, sinon il n'y
-    # aurait aucun moyen de relire les décisions avant de les appliquer
-    assert copied.description == ""
-    rows = read_report(report)
-    assert {row["resume"] for row in rows} == {"Un résumé"}
-    assert {row["description"]: row["verdict"] for row in rows} == {
-        "Un tout autre descriptif": "inséré en tête",
-        "**Un résumé** mis en forme": "abandonné",
-        "": "recopié",
-    }
-
-
-def test_report_lists_one_line_per_pair_closest_decisions_first(tmp_path):
-    structure = make_structure(baker.make("users.User", is_valid=True))
-    # deux services partageant le même couple : une seule décision, deux services concernés
-    make_service(
-        structure=structure,
-        short_desc="Un résumé",
-        description="Un tout autre descriptif",
-    )
-    make_service(
-        structure=structure,
-        short_desc="Un résumé",
-        description="Un tout autre descriptif",
-    )
-    make_service(structure=structure, short_desc="Un résumé", description="Un résumé")
-    report = tmp_path / "fusion.csv"
-
-    call_command("merge_service_descriptions", "--report", str(report))
-
-    rows = read_report(report)
-    assert len(rows) == 2
-    assert {row["nb_services"] for row in rows} == {"2", "1"}
-    margins = [abs(float(row["marge"])) for row in rows]
-    assert margins == sorted(margins)

--- a/back/dora/services/tests/test_service_descriptions.py
+++ b/back/dora/services/tests/test_service_descriptions.py
@@ -11,26 +11,181 @@ from dora.core.test_utils import (
     make_structure,
 )
 from dora.services.management.commands.merge_service_descriptions import (
-    needs_merge,
-    pair_hash,
+    build_idf,
+    merge_description,
 )
 from dora.services.models import Service
 from dora.services.utils import instantiate_service_from_model, update_sync_checksum
 
+DESCRIPTION = (
+    "## Notre offre\n\nNous proposons :\n\n- la **location** de véhicules\n"
+    "- un accompagnement au permis\n\nContactez-nous."
+)
+
+# La typographie fait partie du texte de l'utilisateur, au même titre que les mots. Écrite
+# en échappements : ces caractères sont invisibles à la relecture et un éditeur pourrait les
+# normaliser sans qu'on s'en aperçoive, ce qui viderait le test de son objet.
+NARROW_NBSP, NBSP, APOSTROPHE = "\u202f", "\u00a0", "\u2019"
+TYPOGRAPHY = (
+    f"L{APOSTROPHE}accueil{NARROW_NBSP}? Au c\u0153ur du quartier, "
+    f"le mardi{NBSP}: «{NBSP}sur rendez-vous{NBSP}»."
+)
+
 
 @pytest.mark.no_django_db
 @pytest.mark.parametrize(
-    "short_desc,description,expected",
+    "short_desc,description",
     [
-        ("Un résumé", "Un résumé", False),
+        ("Un résumé", "Un résumé"),
         # le résumé est saisi en texte brut, le descriptif en markdown
-        ("Un résumé", "**Un résumé** mis en forme", False),
-        ("Un résumé", "un   RÉSUMÉ\n\nsuivi d'un développement", False),
-        ("Un résumé", "Un tout autre descriptif", True),
+        ("Un résumé", "**Un résumé** mis en forme"),
+        ("Un résumé", "un   RÉSUMÉ\n\nsuivi d'un développement"),
+        # recopie à une coquille et une incise près : le cas le plus fréquent en base
+        (
+            "Nous proposons la location de véhicules et un accompagnement au permis.",
+            "Nous proposons, sous conditions, la location de véhicules et un "
+            "accompagnement au permis.",
+        ),
+        # paraphrase : les mots changent et se réordonnent, le sujet non
+        (
+            "Accompagnement à la création ou au développement d'une entreprise",
+            "BGE Picardie est une structure spécialisée dans l'accompagnement à la "
+            "création et au développement des entreprises.",
+        ),
+        ("", DESCRIPTION),
+        ("   ", DESCRIPTION),
+        # des résumés réduits à du bruit markdown : « --- » ferait un filet horizontal en
+        # tête de fiche, et servirait de chapô dans les résultats de recherche
+        ("---", DESCRIPTION),
+        ("****", ""),
+        ("-", ""),
     ],
 )
-def test_needs_merge(short_desc, description, expected):
-    assert needs_merge(short_desc, description) is expected
+def test_merge_description_drops_a_summary_that_adds_nothing(short_desc, description):
+    assert merge_description(short_desc, description) is None
+
+
+@pytest.mark.no_django_db
+@pytest.mark.parametrize(
+    "short_desc,description",
+    [
+        ("Un résumé", "Un tout autre descriptif"),
+        # un même domaine ne suffit pas : le résumé nomme un service que la description tait
+        (
+            "Location de scooters et de vélos électriques.",
+            "Nos conseillers vous accompagnent dans vos démarches de mobilité.",
+        ),
+    ],
+)
+def test_merge_description_keeps_a_summary_that_completes_the_description(
+    short_desc, description
+):
+    assert (
+        merge_description(short_desc, description) == f"{short_desc}\n\n{description}"
+    )
+
+
+@pytest.mark.no_django_db
+def test_merge_description_copies_the_summary_when_there_is_no_description():
+    assert merge_description("Un résumé", "") == "Un résumé"
+    assert merge_description("Un résumé", "   \n ") == "Un résumé"
+
+
+@pytest.mark.no_django_db
+def test_merge_description_reproduces_the_description_character_for_character():
+    # Le point qui a fait renoncer à une fusion par LLM : la description est le texte de
+    # référence, et sa typographie en fait partie.
+    merged = merge_description("Permanence numérique le jeudi.", TYPOGRAPHY)
+
+    assert merged is not None
+    assert merged.endswith(TYPOGRAPHY)
+    assert all(char in merged for char in (NARROW_NBSP, NBSP, APOSTROPHE))
+
+
+@pytest.mark.no_django_db
+@pytest.mark.parametrize(
+    "short_desc,description",
+    [
+        # un nombre de deux caractères tient en un mot-outil pour qui compte les lettres :
+        # sans lui, le résumé se réduit au vocabulaire de la description et disparaît
+        (
+            "2 logements meublés à votre disposition",
+            "L'association met un logement meublé à disposition.",
+        ),
+        (
+            "Accompagnement des jeunes de 16 à 25 ans",
+            "Nous accompagnons les jeunes dans leur parcours.",
+        ),
+    ],
+)
+def test_merge_description_counts_the_numbers_a_summary_adds(short_desc, description):
+    assert merge_description(short_desc, description) is not None
+
+
+@pytest.mark.no_django_db
+def test_merge_description_replaces_a_description_reduced_to_markup():
+    # le pendant du résumé sans mot : « --- » ferait un filet horizontal en queue de fiche
+    assert merge_description("Un résumé", "---") == "Un résumé"
+    assert merge_description("Un résumé", "  ***  ") == "Un résumé"
+
+
+@pytest.mark.no_django_db
+def test_merge_description_keeps_a_description_written_in_html():
+    # `strip_markdown` ne voit pas le HTML brut et rend ces descriptions pour vides. Les
+    # prendre au mot reviendrait à jeter le texte de référence de quelques fiches.
+    description = "<h2>Notre offre</h2><p>Location de véhicules à tarif solidaire.</p>"
+
+    assert merge_description("Permanence le jeudi.", description).endswith(description)
+
+
+@pytest.mark.no_django_db
+def test_merge_description_accepts_a_result_beyond_the_field_length():
+    # `max_length` ne vaut que pour les formulaires : mieux vaut une description trop longue
+    # qu'un résumé perdu.
+    description = "Un développement singulier. " * 400
+    merged = merge_description("Ouvert à tous, sans rendez-vous.", description)
+
+    assert len(merged) > 10_000
+    assert merged.endswith(description)
+
+
+@pytest.mark.no_django_db
+def test_idf_weighting_separates_a_shared_topic_from_a_repeated_one():
+    # Le vocabulaire du secteur est partout : sans pondération, il rapprocherait n'importe
+    # quels deux textes du champ de l'insertion.
+    corpus = [
+        "Accompagnement vers l'emploi et l'insertion professionnelle."
+        for _ in range(50)
+    ] + ["Location de scooters à tarif solidaire."]
+    weight = build_idf(corpus)
+
+    assert weight("locat") > weight("emplo")
+
+
+@pytest.mark.no_django_db
+def test_idf_saves_a_summary_whose_only_addition_is_a_rare_name():
+    # Cas relevé en base : le résumé ne se distingue que par le sigle de la structure, que
+    # la description ne reprend pas. Sous pondération neutre il pèse autant qu'« insertion »
+    # et le résumé passe pour une paraphrase ; l'IDF lui rend son poids.
+    short_desc = (
+        "PROTIS - PROGRAMME ORIENTATION INSERTION SOCIALE propose des services : "
+        "réaliser des démarches administratives avec un accompagnement"
+    )
+    description = (
+        "Programme d'Insertion et d'Orientation Sociale propose des services : numérique, "
+        "réaliser des démarches administratives avec un accompagnement."
+    )
+    weight = build_idf(
+        [
+            f"Structure numéro {n} : programme d'insertion et d'orientation sociale, "
+            "propose des services de réalisation de démarches administratives avec un "
+            "accompagnement."
+            for n in range(40)
+        ]
+    )
+
+    assert merge_description(short_desc, description) is None
+    assert merge_description(short_desc, description, weight) is not None
 
 
 def test_service_exposes_description_and_its_alias(api_client):
@@ -65,29 +220,11 @@ def test_alias_takes_precedence_over_description(api_client):
     assert service.description == "Après"
 
 
-def _merge(tmp_path, *args):
-    call_command(
-        "merge_service_descriptions",
-        *args,
-        "--output",
-        str(tmp_path / "restants.csv"),
-    )
-    path = tmp_path / "restants.csv"
-    return list(csv.DictReader(path.open(encoding="utf-8"))) if path.exists() else []
-
-
-def _write_merges(path, merges):
-    with path.open("w", encoding="utf-8", newline="") as csv_file:
-        writer = csv.DictWriter(csv_file, fieldnames=["pair_hash", "description"])
-        writer.writeheader()
-        writer.writerows(merges)
-
-
-def test_merge_copies_short_desc_when_description_is_empty(tmp_path):
+def test_merge_copies_short_desc_when_description_is_empty():
     service = make_service(short_desc="Un résumé", description="")
     modification_date = service.modification_date
 
-    _merge(tmp_path, "--wet-run")
+    call_command("merge_service_descriptions", "--wet-run")
 
     service.refresh_from_db()
     assert service.description == "Un résumé"
@@ -95,107 +232,111 @@ def test_merge_copies_short_desc_when_description_is_empty(tmp_path):
     assert service.modification_date == modification_date
 
 
-def test_merge_dry_run_writes_nothing(tmp_path):
+def test_merge_dry_run_writes_nothing():
     service = make_service(short_desc="Un résumé", description="")
 
-    _merge(tmp_path)
+    call_command("merge_service_descriptions")
 
     service.refresh_from_db()
     assert service.description == ""
 
 
-def test_merge_exports_one_pair_per_distinct_values(tmp_path):
-    structure = make_structure()
-    for _ in range(2):
-        make_service(
-            structure=structure, short_desc="Un résumé", description="Un descriptif"
-        )
-    make_service(
-        structure=structure,
-        short_desc="Autre résumé",
-        description="Un tout autre texte",
-    )
-    # déjà couverts par leur description, à ne pas exporter
-    make_service(structure=structure, short_desc="Seul", description="")
-    make_service(
-        structure=structure, short_desc="Repris", description="Repris tel quel"
+def test_merge_inserts_the_summary_ahead_of_the_description():
+    service = make_service(
+        short_desc="Un résumé", description="Un tout autre descriptif"
     )
 
-    rows = _merge(tmp_path, "--wet-run")
-
-    assert {row["short_desc"]: int(row["nb_services"]) for row in rows} == {
-        "Un résumé": 2,
-        "Autre résumé": 1,
-    }
-
-
-def test_merge_applies_merges_from_csv(tmp_path):
-    service = make_service(short_desc="Un résumé", description="Un descriptif")
-    merges = tmp_path / "fusions.csv"
-    _write_merges(
-        merges,
-        [
-            {
-                "pair_hash": pair_hash("Un résumé", "Un descriptif"),
-                "description": "Un résumé fusionné au descriptif",
-            }
-        ],
-    )
-
-    _merge(tmp_path, "--from-csv", str(merges), "--wet-run")
+    call_command("merge_service_descriptions", "--wet-run")
 
     service.refresh_from_db()
-    assert service.description == "Un résumé fusionné au descriptif"
+    assert service.description == "Un résumé\n\nUn tout autre descriptif"
 
 
-def test_merge_skips_services_changed_since_export(tmp_path):
-    service = make_service(short_desc="Un résumé", description="Descriptif réécrit")
-    merges = tmp_path / "fusions.csv"
-    _write_merges(
-        merges,
-        [
-            {
-                "pair_hash": pair_hash("Un résumé", "Descriptif d'origine"),
-                "description": "Fusion périmée",
-            }
-        ],
+def test_merge_leaves_a_description_that_already_says_it():
+    service = make_service(
+        short_desc="Un résumé", description="**Un résumé** mis en forme"
     )
 
-    rows = _merge(tmp_path, "--from-csv", str(merges), "--wet-run")
+    call_command("merge_service_descriptions", "--wet-run")
 
     service.refresh_from_db()
-    assert service.description == "Descriptif réécrit"
-    assert [row["description"] for row in rows] == ["Descriptif réécrit"]
+    assert service.description == "**Un résumé** mis en forme"
 
 
-def test_merge_keeps_copies_in_sync(tmp_path):
+def test_merge_keeps_copies_in_sync():
     structure = make_structure(baker.make("users.User", is_valid=True))
     model = make_model(
-        structure=structure, short_desc="Un résumé", description="Un descriptif"
+        structure=structure,
+        short_desc="Un résumé",
+        description="Un tout autre descriptif",
     )
     synced = instantiate_service_from_model(model, structure, structure.creator)
     customized = instantiate_service_from_model(model, structure, structure.creator)
     Service._base_manager.filter(pk=customized.pk).update(last_sync_checksum="périmé")
 
-    merges = tmp_path / "fusions.csv"
-    _write_merges(
-        merges,
-        [
-            {
-                "pair_hash": pair_hash("Un résumé", "Un descriptif"),
-                "description": "Un descriptif, résumé compris",
-            }
-        ],
-    )
-
-    _merge(tmp_path, "--from-csv", str(merges), "--wet-run")
+    call_command("merge_service_descriptions", "--wet-run")
 
     model.refresh_from_db()
     synced.refresh_from_db()
     customized.refresh_from_db()
     # même fusion pour le modèle et ses copies : aucune ne doit passer en « modifié »…
-    assert synced.description == model.description == "Un descriptif, résumé compris"
+    assert (
+        synced.description
+        == model.description
+        == "Un résumé\n\nUn tout autre descriptif"
+    )
     assert model.sync_checksum == update_sync_checksum(model)
     assert synced.last_sync_checksum == model.sync_checksum
     # … et celles qui l'étaient déjà le restent
     assert customized.last_sync_checksum == "périmé"
+
+
+def read_report(path):
+    # `utf-8-sig` des deux côtés : la marque d'ordre des octets est là pour le tableur
+    return list(csv.DictReader(path.read_text(encoding="utf-8-sig").splitlines()))
+
+
+def test_merge_reports_its_decisions_even_in_dry_run(tmp_path):
+    make_service(short_desc="Un résumé", description="Un tout autre descriptif")
+    make_service(short_desc="Un résumé", description="**Un résumé** mis en forme")
+    copied = make_service(short_desc="Un résumé", description="")
+    report = tmp_path / "fusion.csv"
+
+    call_command("merge_service_descriptions", "--report", str(report))
+
+    copied.refresh_from_db()
+    # le rapport s'écrit hors transaction : il survit au rollback du dry-run, sinon il n'y
+    # aurait aucun moyen de relire les décisions avant de les appliquer
+    assert copied.description == ""
+    rows = read_report(report)
+    assert {row["resume"] for row in rows} == {"Un résumé"}
+    assert {row["description"]: row["verdict"] for row in rows} == {
+        "Un tout autre descriptif": "inséré en tête",
+        "**Un résumé** mis en forme": "abandonné",
+        "": "recopié",
+    }
+
+
+def test_report_lists_one_line_per_pair_closest_decisions_first(tmp_path):
+    structure = make_structure(baker.make("users.User", is_valid=True))
+    # deux services partageant le même couple : une seule décision, deux services concernés
+    make_service(
+        structure=structure,
+        short_desc="Un résumé",
+        description="Un tout autre descriptif",
+    )
+    make_service(
+        structure=structure,
+        short_desc="Un résumé",
+        description="Un tout autre descriptif",
+    )
+    make_service(structure=structure, short_desc="Un résumé", description="Un résumé")
+    report = tmp_path / "fusion.csv"
+
+    call_command("merge_service_descriptions", "--report", str(report))
+
+    rows = read_report(report)
+    assert len(rows) == 2
+    assert {row["nb_services"] for row in rows} == {"2", "1"}
+    margins = [abs(float(row["marge"])) for row in rows]
+    assert margins == sorted(margins)


### PR DESCRIPTION
La commande `merge_service_descriptions` avait initialement été écrite pour exporter les données en vue d'un traitement par LLM. Elle a été réécrite pour effectuer une fusion algorithmique. Le diff n'est donc pas pertinent il faut lire le code de la commande entièrement.